### PR TITLE
Fix for systems without file locking

### DIFF
--- a/Shoko.Server/Commands/Import/CommandRequest_HashFile.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_HashFile.cs
@@ -88,6 +88,27 @@ namespace Shoko.Server.Commands
             }
         }
 
+        //Used to check if file has been modified within the last X seconds.
+        private bool FileModified(string FileName, int Seconds)
+        {
+            try
+            {
+                if (System.IO.File.GetLastWriteTime(FileName).AddSeconds(Seconds) >= DateTime.Now)
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex);
+                return false;
+            }
+        }
+
         private void ProcessFile_LocalInfo()
         {
             // hash and read media info for file
@@ -132,6 +153,13 @@ namespace Shoko.Server.Commands
                 {
                     logger.Error("Could not access file: " + FileName);
                     return;
+                }
+
+                //For systems with no locking
+                while (FileModified(FileName, 3))
+                {
+                    Thread.Sleep(1000);
+                    logger.Error($@"An external process is modifying the file, {FileName}");
                 }
             }
 


### PR DESCRIPTION
I've been running shoko server on docker for some time with a single import folder being watched that is also shared out via samba from my NAS. Every time I copied a file into the folder I would have to pause the hashing queue so it would not half hash the file before it finished the copy.

This code is to fix that issue by checking the last write time on the file. I thought of including the check in the existing while loop with something like:

`while ((filesize = CanAccessFile(FileName)) == 0 || FileModified(FileName,3) && (numAttempts < 60))`

But given that a file may take more than 60 seconds to copy I thought it best to separate it out.

Tested and it seems to work with 2 seconds but to be safe I went with 3. Ran some tests and it does not impact anything when running on Windows as this gets caught in the existing file access check.

This is my first time contributing to a project so any feedback/suggestions are welcome.