### PR TITLE
Updating Docker File

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,5 +41,4 @@ HEALTHCHECK --start-period=5m CMD curl -H "Content-Type: application/json" -H 'A
 
 EXPOSE 8111
 
-ENTRYPOINT /bin/bash /dockerentry.sh 
-
+ENTRYPOINT /bin/bash /dockerentry.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ENV PUID=1000 \
     PGID=100  \ 
     TargetFrameworkDirectory=/usr/lib/mono/
 
-RUN apt-get install apt
 RUN apt-get update && apt-get install -y gnupg curl wget
 
 RUN curl https://bintray.com/user/downloadSubjectPublicKey?username=bintray | apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM mono:5.20
+FROM mono:6.0
+
 
 #MAINTAINER Cayde Dixon <me@cazzar.net>
 ENV PUID=1000 \
-    PGID=100
+    PGID=100  \ 
+    FrameworkPathOverride=/usr/lib/mono/
 
 RUN apt-get update && apt-get install -y --force-yes gnupg curl
 
@@ -19,7 +21,7 @@ RUN mv /usr/src/app/source/dockerentry.sh /dockerentry.sh
 
 ADD https://github.com/NuGet/Home/releases/download/3.3/NuGet.exe .
 RUN mono NuGet.exe restore
-RUN xbuild /property:Configuration=CLI /property:OutDir=/usr/src/app/build/
+RUN msbuild /property:Configuration=CLI /property:OutDir=/usr/src/app/build/
 RUN rm -rf /usr/src/app/source
 RUN rm /usr/src/app/build/System.Net.Http.dll
 


### PR DESCRIPTION
After days of effort Shoko can now finally compile on Linux again.

Changes:
-Mono 6.0
-Managed to cram NetCore in there. May need a better method. I went the easy route.
-Updated xbiuld to msbuild.
-Likewise updated nuget to a native package rather than the old Mono 3.3 Nuget.