### PR TITLE
Make the AniDB image server url dynamic from the login call.

### DIFF
--- a/Shoko.CLI/Shoko.CLI.csproj
+++ b/Shoko.CLI/Shoko.CLI.csproj
@@ -24,7 +24,6 @@
     <ProjectReference Include="..\Shoko.Commons\Shoko.Commons.csproj" />
     <ProjectReference Include="..\Shoko.Commons\Shoko.Models\Shoko.Models.csproj" />
     <ProjectReference Include="..\Shoko.Server\Shoko.Server.csproj" />
-    <ProjectReference Include="..\MediaInfoWrapper\MediaInfoWrapper.csproj" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />

--- a/Shoko.Server/AniDB_API/Commands/AniDBCommand_Login.cs
+++ b/Shoko.Server/AniDB_API/Commands/AniDBCommand_Login.cs
@@ -8,6 +8,8 @@ namespace AniDBAPI.Commands
     {
         public string SessionID = string.Empty;
 
+        public string ImageServerUrl;
+
         public virtual AniDBUDPResponseCode GetStartEventType()
         {
             return AniDBUDPResponseCode.LoggingIn;
@@ -36,7 +38,7 @@ namespace AniDBAPI.Commands
             string sMsgType = socketResponse.Substring(0, 3);
             //BaseConfig.MyAnimeLog.Write("AniDBCommand_Login.Process: Response: {0}", socketResponse);
 
-            // 200 {str session_key} LOGIN ACCEPTED
+            // 200 {str session_key} LOGIN ACCEPTED\n{imgserver url}
             // 203 LOGGED OUT
             // 500 LOGIN FAILED
             if (sMsgType.Equals("500"))
@@ -50,7 +52,7 @@ namespace AniDBAPI.Commands
             SessionID = sMessage.Trim();
             int i = sMessage.IndexOf("LOGIN");
             SessionID = sMessage.Substring(0, i - 1).Trim();
-
+            ImageServerUrl = sMessage.Substring(sMessage.IndexOf('\n')).Trim();
             return AniDBUDPResponseCode.LoggedIn;
         }
 
@@ -67,7 +69,7 @@ namespace AniDBAPI.Commands
             commandText += "&protover=3";
             commandText += "&client=ommserver";
             //commandText += "&client=vmcanidb";
-            commandText += "&clientver=2&comp=1";
+            commandText += "&clientver=2&comp=1&imgserver=1";
             //BaseConfig.MyAnimeLog.Write("commandText: {0}", commandText);
         }
     }

--- a/Shoko.Server/Commands/Import/CommandRequest_DownloadAniDBImages.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_DownloadAniDBImages.cs
@@ -17,6 +17,7 @@ using Shoko.Server.AniDB_API;
 using Shoko.Server.Extensions;
 using Shoko.Server.ImageDownload;
 using Shoko.Server.Models;
+using Shoko.Server.Providers.AniDB;
 using Shoko.Server.Repositories;
 using Shoko.Server.Settings;
 
@@ -89,7 +90,7 @@ namespace Shoko.Server.Commands
                                 return;
                             }
 
-                            downloadURLs.Add(string.Format(Constants.URLS.AniDB_Images, anime.Picname));
+                            downloadURLs.Add(string.Format(ShokoService.AnidbProcessor.ImageServerUrl, anime.Picname));
                             fileNames.Add(anime.PosterPath);
                             break;
 
@@ -109,7 +110,7 @@ namespace Shoko.Server.Commands
 
                             foreach (var chr in chrs)
                             {
-                                downloadURLs.Add(string.Format(Constants.URLS.AniDB_Images, chr.PicName));
+                                downloadURLs.Add(string.Format(ShokoService.AnidbProcessor.ImageServerUrl, chr.PicName));
                                 fileNames.Add(chr.GetPosterPath());
                             }
 
@@ -134,7 +135,7 @@ namespace Shoko.Server.Commands
 
                             foreach (var creator in creators)
                             {
-                                downloadURLs.Add(string.Format(Constants.URLS.AniDB_Images, creator.PicName));
+                                downloadURLs.Add(string.Format(ShokoService.AnidbProcessor.ImageServerUrl, creator.PicName));
                                 fileNames.Add(creator.GetPosterPath());
                             }
 

--- a/Shoko.Server/Commands/Import/CommandRequest_DownloadImage.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_DownloadImage.cs
@@ -15,6 +15,7 @@ using Shoko.Server.AniDB_API;
 using Shoko.Server.Extensions;
 using Shoko.Server.ImageDownload;
 using Shoko.Server.Models;
+using Shoko.Server.Providers.AniDB;
 using Shoko.Server.Repositories;
 using Shoko.Server.Settings;
 
@@ -403,15 +404,15 @@ namespace Shoko.Server.Commands
 
                 case ImageEntityType.AniDB_Cover:
                     SVR_AniDB_Anime anime = req.ImageData as SVR_AniDB_Anime;
-                    return string.Format(Constants.URLS.AniDB_Images, anime.Picname);
+                    return string.Format(ShokoService.AnidbProcessor.ImageServerUrl, anime.Picname);
 
                 case ImageEntityType.AniDB_Character:
                     AniDB_Character chr = req.ImageData as AniDB_Character;
-                    return string.Format(Constants.URLS.AniDB_Images, chr.PicName);
+                    return string.Format(ShokoService.AnidbProcessor.ImageServerUrl, chr.PicName);
 
                 case ImageEntityType.AniDB_Creator:
                     AniDB_Seiyuu creator = req.ImageData as AniDB_Seiyuu;
-                    return string.Format(Constants.URLS.AniDB_Images, creator.PicName);
+                    return string.Format(ShokoService.AnidbProcessor.ImageServerUrl, creator.PicName);
 
                 default:
                     return string.Empty;

--- a/Shoko.Server/Constants.cs
+++ b/Shoko.Server/Constants.cs
@@ -157,7 +157,10 @@ namespace Shoko.Server
             public static readonly string AniDB_ReleaseGroup =
                 @"https://anidb.net/perl-bin/animedb.pl?show=group&gid={0}";
 
-            public static readonly string AniDB_Images = @"https://img7.anidb.net/pics/anime/{0}";
+            public static readonly string AniDB_Images = @"https://{0}/images/main/{{0}}";
+
+            // This is the fallback if the API response does not work.
+            public static readonly string AniDB_Images_Domain = @"cdn.anidb.net";
 
             public static readonly string TvDB_Series = @"https://thetvdb.com/?tab=series&id={0}";
 

--- a/Shoko.Server/Extensions/ModelProviders.cs
+++ b/Shoko.Server/Extensions/ModelProviders.cs
@@ -651,14 +651,14 @@ namespace Shoko.Server.Extensions
                 CharKanjiName = character.CharKanjiName,
                 CharDescription = character.CharDescription,
                 CharType = charRel.CharType,
-                CharImageURL = string.Format(Constants.URLS.AniDB_Images, character.PicName)
+                CharImageURL = string.Format(ShokoService.AnidbProcessor.ImageServerUrl, character.PicName)
             };
             AniDB_Seiyuu seiyuu = character.GetSeiyuu();
             if (seiyuu != null)
             {
                 contract.SeiyuuID = seiyuu.AniDB_SeiyuuID;
                 contract.SeiyuuName = seiyuu.SeiyuuName;
-                contract.SeiyuuImageURL = string.Format(Constants.URLS.AniDB_Images, seiyuu.PicName);
+                contract.SeiyuuImageURL = string.Format(ShokoService.AnidbProcessor.ImageServerUrl, seiyuu.PicName);
             }
 
             return contract;

--- a/Shoko.Server/LZ4/LZ4Codec.Safe.cs
+++ b/Shoko.Server/LZ4/LZ4Codec.Safe.cs
@@ -28,6 +28,9 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // ReSharper disable CheckNamespace
 // ReSharper disable InconsistentNaming
 
+using System;
+using System.Diagnostics;
+
 namespace LZ4ps
 {
 #if !UNSAFE

--- a/Shoko.Server/Models/SVR_AniDB_Anime.cs
+++ b/Shoko.Server/Models/SVR_AniDB_Anime.cs
@@ -1824,7 +1824,7 @@ ORDER BY count(DISTINCT AnimeID) DESC, Anime_GroupName ASC";
             contract.Detail.EpisodeCountSpecial = EpisodeCountSpecial;
             contract.Detail.FanartURL = GetDefaultFanartOnlineURL();
             contract.Detail.OverallRating = this.GetAniDBRating();
-            contract.Detail.PosterURL = string.Format(Constants.URLS.AniDB_Images, Picname);
+            contract.Detail.PosterURL = string.Format(ShokoService.AnidbProcessor.ImageServerUrl, Picname);
             contract.Detail.TotalVotes = this.GetAniDBTotalVotes();
 
 


### PR DESCRIPTION
Closes #826

It is a bit useless right now, but as soon as they feel like changing it, Shoko won't break.