### PR TITLE
Set 'Name' on 'Shoko.Server.API.v3.Models.Shoko.Episode' in constructor

### DIFF
--- a/Shoko.Server/API/v3/Models/Shoko/Episode.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Episode.cs
@@ -51,24 +51,12 @@ namespace Shoko.Server.API.v3.Models.Shoko
 
             var uid = ctx.GetUser()?.JMMUserID ?? 0;
             Watched = ep.GetUserRecord(uid)?.WatchedDate;
-            Name = GetEpisodeName(anidb);
+            Name = ep.Title;
 
             Size = ep.GetVideoLocals().Count;
         }
 
         internal static string[] TitleLanguages = new string[] { "EN", "X-JAT", "X-ZHT", "X-OTHER" };
-
-        public static string GetEpisodeName(AniDB_Episode a)
-        {
-            if (a == null) return "Episode 0";
-            var titles = RepoFactory.AniDB_Episode_Title.GetByEpisodeID(a.EpisodeID);
-            if (titles != null) foreach (string lang in TitleLanguages)
-            {
-                string title = titles.FirstOrDefault(s => s.Language == lang)?.Title;
-                if (title != null) return title;
-            }
-            return $"Episode {a.EpisodeNumber}";
-        }
 
         public static AniDB GetAniDBInfo(AniDB_Episode ep)
         {

--- a/Shoko.Server/API/v3/Models/Shoko/Episode.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Episode.cs
@@ -56,8 +56,6 @@ namespace Shoko.Server.API.v3.Models.Shoko
             Size = ep.GetVideoLocals().Count;
         }
 
-        internal static string[] TitleLanguages = new string[] { "EN", "X-JAT", "X-ZHT", "X-OTHER" };
-
         public static AniDB GetAniDBInfo(AniDB_Episode ep)
         {
             decimal rating = 0;

--- a/Shoko.Server/API/v3/Models/Shoko/Episode.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Episode.cs
@@ -51,8 +51,23 @@ namespace Shoko.Server.API.v3.Models.Shoko
 
             var uid = ctx.GetUser()?.JMMUserID ?? 0;
             Watched = ep.GetUserRecord(uid)?.WatchedDate;
+            Name = GetEpisodeName(anidb);
 
             Size = ep.GetVideoLocals().Count;
+        }
+
+        internal static string[] TitleLanguages = new string[] { "EN", "X-JAT", "X-ZHT", "X-OTHER" };
+
+        public static string GetEpisodeName(AniDB_Episode a)
+        {
+            if (a == null) return "Episode 0";
+            var titles = RepoFactory.AniDB_Episode_Title.GetByEpisodeID(a.EpisodeID);
+            if (titles != null) foreach (string lang in TitleLanguages)
+            {
+                string title = titles.FirstOrDefault(s => s.Language == lang)?.Title;
+                if (title != null) return title;
+            }
+            return $"Episode {a.EpisodeNumber}";
         }
 
         public static AniDB GetAniDBInfo(AniDB_Episode ep)


### PR DESCRIPTION
Set the `Name` property of `Shoko.Server.API.v3.Models.Shoko.Episode` mimicing the magic formula used in ShokoDesktop, but added two extra fallback languages.

[Shoko.Desktop/ViewModel/Server/VM_AniDB_Episode.cs#L12-L20/](https://github.com/ShokoAnime/ShokoDesktop/blob/master/Shoko.Desktop/ViewModel/Server/VM_AniDB_Episode.cs#L12-L20)