### PR TITLE
#840 - check if aniFile is null first

### DIFF
--- a/Shoko.Server/Commands/Import/CommandRequest_ProcessFile.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_ProcessFile.cs
@@ -316,7 +316,7 @@ namespace Shoko.Server.Commands
                     Raw_AniDB_File fileInfo = ShokoService.AnidbProcessor.GetFileInfo(vidLocal);
                     if (fileInfo != null)
                     {
-                        aniFile??= new SVR_AniDB_File();
+                        aniFile ??= new SVR_AniDB_File();
                         SVR_AniDB_File.Populate(aniFile, fileInfo);
                     }
                 }

--- a/Shoko.Server/Commands/Import/CommandRequest_ProcessFile.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_ProcessFile.cs
@@ -316,7 +316,7 @@ namespace Shoko.Server.Commands
                     Raw_AniDB_File fileInfo = ShokoService.AnidbProcessor.GetFileInfo(vidLocal);
                     if (fileInfo != null)
                     {
-                        aniFile = new SVR_AniDB_File();
+                        aniFile??= new SVR_AniDB_File();
                         SVR_AniDB_File.Populate(aniFile, fileInfo);
                     }
                 }


### PR DESCRIPTION
#840 Handle the situation where the file exists in store, but the method is forced to get from AniDB