### PR TITLE
Fix change tracker reporting for non-local timezones.

### DIFF
--- a/Shoko.Server/Repositories/ChangeTracker.cs
+++ b/Shoko.Server/Repositories/ChangeTracker.cs
@@ -104,8 +104,8 @@ namespace Shoko.Server.Repositories
                 if (remmax > changes.LastChange)
                     changes.LastChange = remmax;
             }
-            changes.ChangedItems = new HashSet<T>(_changes.Where(a => a.Value.ToLocalTime() > date.ToLocalTime()).Select(a => a.Key));
-            changes.RemovedItems = new HashSet<T>(_removals.Where(a => a.Value.ToLocalTime() > date.ToLocalTime()).Select(a => a.Key));
+            changes.ChangedItems = new HashSet<T>(_changes.Where(a => a.Value.ToUniversalTime() > date.ToUniversalTime()).Select(a => a.Key));
+            changes.RemovedItems = new HashSet<T>(_removals.Where(a => a.Value.ToUniversalTime() > date.ToUniversalTime()).Select(a => a.Key));
             return changes;
         }
 

--- a/Shoko.Server/Repositories/ChangeTracker.cs
+++ b/Shoko.Server/Repositories/ChangeTracker.cs
@@ -104,8 +104,8 @@ namespace Shoko.Server.Repositories
                 if (remmax > changes.LastChange)
                     changes.LastChange = remmax;
             }
-            changes.ChangedItems = new HashSet<T>(_changes.Where(a => a.Value > date).Select(a => a.Key));
-            changes.RemovedItems = new HashSet<T>(_removals.Where(a => a.Value > date).Select(a => a.Key));
+            changes.ChangedItems = new HashSet<T>(_changes.Where(a => a.Value.ToLocalTime() > date.ToLocalTime()).Select(a => a.Key));
+            changes.RemovedItems = new HashSet<T>(_removals.Where(a => a.Value.ToLocalTime() > date.ToLocalTime()).Select(a => a.Key));
             return changes;
         }
 


### PR DESCRIPTION
ShokoServiceImplementation.GetAllChanges() can call with non-local timezone, causing bad/empty change sets.
To reproduce, try deleting a series in Desktop. The series will stick around until restarted (calls in UTC, probably only reproducible if you are West of the prime meridian).