### PR TITLE
Populate plugins and renamers in settings

### DIFF
--- a/Shoko.CLI/Worker.cs
+++ b/Shoko.CLI/Worker.cs
@@ -32,9 +32,9 @@ namespace Shoko.CLI
         {
             if (!string.IsNullOrEmpty(Args?.Instance)) ServerSettings.DefaultInstance = Args.Instance;
 
-            ShokoServer.Instance.InitLogger();
-            
             ServerSettings.LoadSettings();
+            ShokoServer.Instance.InitLogger();
+
             ServerState.Instance.LoadSettings();
             if (!ShokoServer.Instance.StartUpServer()) return;
 

--- a/Shoko.Server/Plugin/Loader.cs
+++ b/Shoko.Server/Plugin/Loader.cs
@@ -37,9 +37,7 @@ namespace Shoko.Server.Plugin
                 {
                     string name = Path.GetFileNameWithoutExtension(dll);
                     if (ServerSettings.Instance.Plugins.EnabledPlugins.ContainsKey(name) &&
-                        !ServerSettings.Instance.Plugins.EnabledPlugins[name] ||
-                        ServerSettings.Instance.Plugins.EnabledRenamers.ContainsKey(name) &&
-                        !ServerSettings.Instance.Plugins.EnabledRenamers[name])
+                        !ServerSettings.Instance.Plugins.EnabledPlugins[name])
                     {
                         Logger.Info($"Found {name}, but it is disabled in the Server Settings. Skipping it.");
                         continue;

--- a/Shoko.Server/Renamer/RenameFileHelper.cs
+++ b/Shoko.Server/Renamer/RenameFileHelper.cs
@@ -121,8 +121,13 @@ namespace Shoko.Server
                     }
 
                     Renamers.Add(key, (implementation, desc));
+                    if (!ServerSettings.Instance.Plugins.EnabledRenamers.ContainsKey(key))
+                        ServerSettings.Instance.Plugins.EnabledRenamers.Add(key, true);
+                    if (!ServerSettings.Instance.Plugins.RenamerPriorities.ContainsKey(key))
+                        ServerSettings.Instance.Plugins.RenamerPriorities.Add(key, 0);
                 }
             }
+            ServerSettings.Instance.SaveSettings();
         }
 
         public static IList<IRenamer> GetPluginRenamersSorted(string renamerName) => 

--- a/Shoko.TrayService/App.xaml.cs
+++ b/Shoko.TrayService/App.xaml.cs
@@ -77,9 +77,9 @@ namespace Shoko.TrayService
             var arguments = new ProgramArguments {Instance = instance};
             if (!string.IsNullOrEmpty(arguments.Instance)) ServerSettings.DefaultInstance = arguments.Instance;
 
+            ServerSettings.LoadSettings();
             ShokoServer.Instance.InitLogger();
             
-            ServerSettings.LoadSettings();
             ServerState.Instance.LoadSettings();
             if (!ShokoServer.Instance.StartUpServer()) return;
 


### PR DESCRIPTION
Create entries for plugins and renamers when they are missing. Requires loading settings before first access of ShokoServer.Instance -> ConfigureServices() -> Loader.Load() in order to save to file without replacing settings with defaults. There was already code to add missing plugins to settings, but they were overwritten by the next LoadSettings() and tried to add all found dlls, not just IPlugin dlls.