### PR TITLE
Fix external subtitle renaming

### DIFF
--- a/Shoko.Server/FileHelper/Subtitles/SubtitleHelper.cs
+++ b/Shoko.Server/FileHelper/Subtitles/SubtitleHelper.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Shoko.Commons.Extensions;
 using Shoko.Models.MediaInfo;
 using Shoko.Server.Models;
@@ -77,42 +76,6 @@ namespace Shoko.Server.FileHelper.Subtitles
                 default:
                     return MediaInfoUtils.GetLanguageFromName(lang) ?? lang;
             }
-        }
-
-        public static string GetMediaInfoCompatibleFile(FileInfo file)
-        {
-            var f = File.OpenRead(file.FullName);
-            byte[] utf16bePre = Encoding.BigEndianUnicode.GetPreamble();
-            byte[] utf8Pre = Encoding.UTF8.GetPreamble();
-            byte[] bytes = new byte[utf8Pre.Length];
-            string tempfilepath = null;
-
-            // Check first two bytes for utf16be preamble
-            f.Read(bytes, 0, utf16bePre.Length);
-            if (bytes[..utf16bePre.Length].SequenceEqual(utf16bePre))
-            {
-                // Convert to utf16le in temp file
-                byte[] tempbytes = new byte[f.Length];
-                bytes.CopyTo(tempbytes, 0);
-                f.Read(tempbytes, utf16bePre.Length, tempbytes.Length - utf16bePre.Length);
-                tempfilepath = Path.GetTempFileName();
-                File.WriteAllBytes(tempfilepath, Encoding.Convert(Encoding.BigEndianUnicode, Encoding.Unicode, tempbytes));
-            }
-            else
-            {
-                // Check first three bytes for utf8 preamble
-                f.Read(bytes, utf16bePre.Length, utf8Pre.Length - utf16bePre.Length);
-                if (bytes.SequenceEqual(utf8Pre))
-                {
-                    // Remove utf8 preamble in temp file
-                    byte[] restOfFile = new byte[f.Length - utf8Pre.Length];
-                    f.Read(restOfFile);
-                    tempfilepath = Path.GetTempFileName();
-                    File.WriteAllBytes(tempfilepath, restOfFile);
-                }
-            }
-            f.Close();
-            return tempfilepath ?? file.FullName;
         }
     }
 }

--- a/Shoko.Server/FileHelper/Subtitles/TextSubtitles.cs
+++ b/Shoko.Server/FileHelper/Subtitles/TextSubtitles.cs
@@ -15,7 +15,7 @@ namespace Shoko.Server.FileHelper.Subtitles
             List<TextStream> streams = new List<TextStream>();
             var language = SubtitleHelper.GetLanguageFromFilename(file.Name);
 
-            MediaContainer m = MediaInfo.GetMediaInfo(file.FullName);
+            MediaContainer m = MediaInfo.GetMediaInfo(SubtitleHelper.GetMediaInfoCompatibleFile(file));
             List<TextStream> tStreams = m?.TextStreams;
             if (tStreams == null || tStreams.Count <= 0) return streams;
             tStreams.ForEach(a =>
@@ -51,7 +51,7 @@ namespace Shoko.Server.FileHelper.Subtitles
 
         public bool IsSubtitleFile(string path)
         {
-            string ext = Path.GetExtension(path).ToLower();
+            string ext = Path.GetExtension(path).ToLower().TrimStart('.');
             return Extensions.Contains(ext);
         }
     }

--- a/Shoko.Server/FileHelper/Subtitles/TextSubtitles.cs
+++ b/Shoko.Server/FileHelper/Subtitles/TextSubtitles.cs
@@ -15,7 +15,7 @@ namespace Shoko.Server.FileHelper.Subtitles
             List<TextStream> streams = new List<TextStream>();
             var language = SubtitleHelper.GetLanguageFromFilename(file.Name);
 
-            MediaContainer m = MediaInfo.GetMediaInfo(SubtitleHelper.GetMediaInfoCompatibleFile(file));
+            MediaContainer m = MediaInfo.GetMediaInfo(file.FullName);
             List<TextStream> tStreams = m?.TextStreams;
             if (tStreams == null || tStreams.Count <= 0) return streams;
             tStreams.ForEach(a =>
@@ -51,7 +51,7 @@ namespace Shoko.Server.FileHelper.Subtitles
 
         public bool IsSubtitleFile(string path)
         {
-            string ext = Path.GetExtension(path).ToLower().TrimStart('.');
+            string ext = Path.GetExtension(path).ToLower();
             return Extensions.Contains(ext);
         }
     }

--- a/Shoko.Server/FileHelper/Subtitles/TextSubtitles.cs
+++ b/Shoko.Server/FileHelper/Subtitles/TextSubtitles.cs
@@ -51,7 +51,7 @@ namespace Shoko.Server.FileHelper.Subtitles
 
         public bool IsSubtitleFile(string path)
         {
-            string ext = Path.GetExtension(path).ToLower();
+            string ext = Path.GetExtension(path).ToLower().TrimStart('.');
             return Extensions.Contains(ext);
         }
     }

--- a/Shoko.Server/FileHelper/Subtitles/VobSubSubtitles.cs
+++ b/Shoko.Server/FileHelper/Subtitles/VobSubSubtitles.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using NutzCode.CloudFileSystem;
 using Shoko.Models.MediaInfo;
 using Shoko.Server.Models;
@@ -15,7 +16,7 @@ namespace Shoko.Server.FileHelper.Subtitles
             List<TextStream> streams = new List<TextStream>();
             var language = SubtitleHelper.GetLanguageFromFilename(file.Name);
 
-            MediaContainer m = MediaInfo.GetMediaInfo(file.FullName);
+            MediaContainer m = MediaInfo.GetMediaInfo(SubtitleHelper.GetMediaInfoCompatibleFile(file));
             List<TextStream> tStreams = m?.TextStreams;
             if (tStreams == null || tStreams.Count <= 0) return streams;
             tStreams.ForEach(a =>
@@ -24,7 +25,7 @@ namespace Shoko.Server.FileHelper.Subtitles
                 a.Filename = file.Name;
                 if (language == null) return;
                 a.Language = language;
-                Tuple<string,string> mapping = MediaInfoUtils.GetLanguageMapping(language);
+                Tuple<string, string> mapping = MediaInfoUtils.GetLanguageMapping(language);
                 if (mapping == null) return;
                 a.LanguageCode = mapping.Item1;
                 a.LanguageName = mapping.Item2;
@@ -32,10 +33,10 @@ namespace Shoko.Server.FileHelper.Subtitles
             streams.AddRange(tStreams);
             return streams;
         }
-        
+
         public bool IsSubtitleFile(string path)
         {
-            string ext = Path.GetExtension(path).ToLower();
+            string ext = Path.GetExtension(path).ToLower().TrimStart('.');
             return ext.Equals("idx", StringComparison.OrdinalIgnoreCase) ||
                    ext.Equals("sub", StringComparison.OrdinalIgnoreCase);
         }

--- a/Shoko.Server/FileHelper/Subtitles/VobSubSubtitles.cs
+++ b/Shoko.Server/FileHelper/Subtitles/VobSubSubtitles.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using NutzCode.CloudFileSystem;
 using Shoko.Models.MediaInfo;
 using Shoko.Server.Models;
@@ -16,7 +15,7 @@ namespace Shoko.Server.FileHelper.Subtitles
             List<TextStream> streams = new List<TextStream>();
             var language = SubtitleHelper.GetLanguageFromFilename(file.Name);
 
-            MediaContainer m = MediaInfo.GetMediaInfo(SubtitleHelper.GetMediaInfoCompatibleFile(file));
+            MediaContainer m = MediaInfo.GetMediaInfo(file.FullName);
             List<TextStream> tStreams = m?.TextStreams;
             if (tStreams == null || tStreams.Count <= 0) return streams;
             tStreams.ForEach(a =>
@@ -25,7 +24,7 @@ namespace Shoko.Server.FileHelper.Subtitles
                 a.Filename = file.Name;
                 if (language == null) return;
                 a.Language = language;
-                Tuple<string, string> mapping = MediaInfoUtils.GetLanguageMapping(language);
+                Tuple<string,string> mapping = MediaInfoUtils.GetLanguageMapping(language);
                 if (mapping == null) return;
                 a.LanguageCode = mapping.Item1;
                 a.LanguageName = mapping.Item2;
@@ -33,10 +32,10 @@ namespace Shoko.Server.FileHelper.Subtitles
             streams.AddRange(tStreams);
             return streams;
         }
-
+        
         public bool IsSubtitleFile(string path)
         {
-            string ext = Path.GetExtension(path).ToLower().TrimStart('.');
+            string ext = Path.GetExtension(path).ToLower();
             return ext.Equals("idx", StringComparison.OrdinalIgnoreCase) ||
                    ext.Equals("sub", StringComparison.OrdinalIgnoreCase);
         }

--- a/Shoko.Server/FileHelper/Subtitles/VobSubSubtitles.cs
+++ b/Shoko.Server/FileHelper/Subtitles/VobSubSubtitles.cs
@@ -35,7 +35,7 @@ namespace Shoko.Server.FileHelper.Subtitles
         
         public bool IsSubtitleFile(string path)
         {
-            string ext = Path.GetExtension(path).ToLower();
+            string ext = Path.GetExtension(path).ToLower().TrimStart('.');
             return ext.Equals("idx", StringComparison.OrdinalIgnoreCase) ||
                    ext.Equals("sub", StringComparison.OrdinalIgnoreCase);
         }


### PR DESCRIPTION
Would not match extensions because of dot and MediaInfo does not recognize Text streams in subtitle files with utf8bom or utf16be encodings.