### PR TITLE
Add scrobble events and send watch state to trakt

### DIFF
--- a/Shoko.Server/API/v3/Controllers/FileController.cs
+++ b/Shoko.Server/API/v3/Controllers/FileController.cs
@@ -93,15 +93,15 @@ namespace Shoko.Server.API.v3.Controllers
         public ActionResult ScrobbleFileAndEpisode([FromRoute] int fileID, [FromQuery(Name = "event")] string eventName = null, [FromQuery] int? episodeID = null, [FromQuery] bool? watched = null, [FromQuery] long? resumePosition = null)
         {
             // Handle legacy scrobble events.
-            if (string.IsNullOrEmpty(eventName) || !episodeID.HasValue) {
+            if (string.IsNullOrEmpty(eventName)) {
                 return ScrobbleStatusOnFile(fileID, watched, resumePosition);
             }
 
             var file = RepoFactory.VideoLocal.GetByID(fileID);
             if (file == null) return BadRequest("Could not get VideoLocal with ID: " + fileID);
 
-            var episode = RepoFactory.AnimeEpisode.GetByID(episodeID.Value);
-            if (episode == null) return BadRequest("Could not get AnimeEpisode with ID: " + fileID);
+            var episode = episodeID.HasValue ? RepoFactory.AnimeEpisode.GetByID(episodeID.Value) : file.GetAnimeEpisodes()?.FirstOrDefault();
+            if (episode == null) return BadRequest("Could not get AnimeEpisode with ID: " + episodeID);
             
             var playbackPositionTicks = resumePosition ?? 0;
             var watchedTillCompletion = watched ?? false;

--- a/Shoko.Server/API/v3/Controllers/FileController.cs
+++ b/Shoko.Server/API/v3/Controllers/FileController.cs
@@ -142,6 +142,9 @@ namespace Shoko.Server.API.v3.Controllers
         [NonAction]
         private void ScrobbleToTrakt(SVR_VideoLocal file, SVR_AnimeEpisode episode, long position, ScrobblePlayingStatus status)
         {
+            if (User.IsTraktUser == 0)
+                return;
+            
             float percentage = 100 * (position / file.Duration);
             ScrobblePlayingType scrobbleType = episode.GetAnimeSeries()?.GetAnime()?.AnimeType == (int) AnimeType.Movie
                 ? ScrobblePlayingType.movie


### PR DESCRIPTION
Add scrobble-to-Trakt support in the file scrobbler endpoint (`/api/v3/File/{fileID}/Scrobble`) (in a backwards-compatible way).