### PR TITLE
Allow Shoko to access and hash seeding files

### DIFF
--- a/Shoko.Server/Commands/Import/CommandRequest_HashFile.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_HashFile.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -76,7 +76,7 @@ namespace Shoko.Server.Commands
             var accessType = writeAccess ? FileAccess.ReadWrite : FileAccess.Read;
             try
             {
-                using (FileStream fs = File.Open(fileName, FileMode.Open, accessType, FileShare.None))
+                using (FileStream fs = File.Open(fileName, FileMode.Open, accessType, FileShare.ReadWrite))
                 {
                     long size = fs.Seek(0, SeekOrigin.End);
                     return size;

--- a/Shoko.Server/FileHelper/NativeHasher.cs
+++ b/Shoko.Server/FileHelper/NativeHasher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -16,7 +16,7 @@ namespace Shoko.Server.FileHelper
 
             string e2dk = "", crc32 = "", md5 = "", sha1 = "";
 
-            using (Stream source = File.OpenRead(filename))
+            using (Stream source = File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 byte[] buffer = new byte[8192];
                 int bytesRead;


### PR DESCRIPTION
Libtorrent uses FileShare.ReadWrite when opening files to seed (https://github.com/arvidn/libtorrent/blob/2ceadfb9b7378c0d8ddd9e501d7baa5f6324425a/src/file.cpp#L210). 

This can lead to issues on popular files where the file immediately begins seeding and Shoko fails to access the file to hash it. By testing access to the file using the ReadWrite flag and also opening it when hashing with the ReadWrite flag Shoko can access the file while libtorrent is also accessing it.