### PR TITLE
Update APIv3 controllers and related.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,6 @@
 
 [*]
 charset=utf-8
-end_of_line=crlf
 trim_trailing_whitespace=false
 insert_final_newline=false
 indent_style=space

--- a/Shoko.Server/API/Startup.cs
+++ b/Shoko.Server/API/Startup.cs
@@ -79,6 +79,29 @@ namespace Shoko.Server.API
                         options.SwaggerDoc(description.GroupName, CreateInfoForApiVersion(description));
                     }
 
+                    options.AddSecurityDefinition("ApiKey", new OpenApiSecurityScheme()
+                    {
+                        Description = "Shoko API Key Header",
+                        Name = "apikey",
+                        In = ParameterLocation.Header,
+                        Type = SecuritySchemeType.ApiKey,
+                        Scheme = "apikey",
+                    });
+
+                    options.AddSecurityRequirement(new OpenApiSecurityRequirement()
+                    {
+                        {
+                            new OpenApiSecurityScheme {
+                                Reference = new OpenApiReference
+                                {
+                                    Type = ReferenceType.SecurityScheme,
+                                    Id="ApiKey",
+                                },
+                            },
+                            new string[]{}
+                        },
+                    });
+
                     // add a custom operation filter which sets default values
                     //options.OperationFilter<SwaggerDefaultValues>();
 

--- a/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation.cs
+++ b/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation.cs
@@ -914,7 +914,7 @@ namespace Shoko.Server
                     // which esssential means deleting the record
 
                     AniDB_Anime_DefaultImage img =
-                        RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(animeID, (int) sizeType);
+                        RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(animeID, sizeType);
                     if (img != null)
                         RepoFactory.AniDB_Anime_DefaultImage.Delete(img.AniDB_Anime_DefaultImageID);
                 }
@@ -922,7 +922,7 @@ namespace Shoko.Server
                 {
                     // making the image the default for it's type (poster, fanart etc)
                     AniDB_Anime_DefaultImage img =
-                        RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(animeID, (int) sizeType);
+                        RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(animeID, sizeType);
                     if (img == null)
                         img = new AniDB_Anime_DefaultImage();
 

--- a/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation_Entities.cs
+++ b/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation_Entities.cs
@@ -2252,7 +2252,7 @@ namespace Shoko.Server
                 logger.Debug("Creating groups, series and episodes....");
                 ser = anime.CreateAnimeSeriesAndGroup(ser, animeGroupID);
 
-                ser.CreateAnimeEpisodes();
+                ser.CreateAnimeEpisodes(anime);
 
                 // check if we have any group status data for this associated anime
                 // if not we will download it now

--- a/Shoko.Server/API/v2/Models/common/Serie.cs
+++ b/Shoko.Server/API/v2/Models/common/Serie.cs
@@ -63,7 +63,7 @@ namespace Shoko.Server.API.v2.Models.common
             SVR_AniDB_Anime aniDB_Anime = RepoFactory.AniDB_Anime.GetByAnimeID(bookmark.AnimeID);
             if (aniDB_Anime == null)
             {
-                CommandRequest_GetAnimeHTTP cr_anime = new CommandRequest_GetAnimeHTTP(bookmark.AnimeID, true, false);
+                CommandRequest_GetAnimeHTTP cr_anime = new CommandRequest_GetAnimeHTTP(bookmark.AnimeID, true, false, false);
                 cr_anime.Save();
  
                 Serie empty_serie = new Serie

--- a/Shoko.Server/API/v2/Modules/Core.cs
+++ b/Shoko.Server/API/v2/Modules/Core.cs
@@ -290,7 +290,7 @@ namespace Shoko.Server.API.v2.Modules
                     var xml = APIUtils.LoadAnimeHTTPFromFile(animeID);
                     if (xml == null)
                     {
-                        CommandRequest_GetAnimeHTTP cmd = new CommandRequest_GetAnimeHTTP(animeID, true, false);
+                        CommandRequest_GetAnimeHTTP cmd = new CommandRequest_GetAnimeHTTP(animeID, true, false, false);
                         cmd.Save();
                         updatedAnime++;
                         continue;
@@ -299,7 +299,7 @@ namespace Shoko.Server.API.v2.Modules
                     var rawAnime = AniDBHTTPHelper.ProcessAnimeDetails(xml, animeID);
                     if (rawAnime == null)
                     {
-                        CommandRequest_GetAnimeHTTP cmd = new CommandRequest_GetAnimeHTTP(animeID, true, false);
+                        CommandRequest_GetAnimeHTTP cmd = new CommandRequest_GetAnimeHTTP(animeID, true, false, false);
                         cmd.Save();
                         updatedAnime++;
                     }

--- a/Shoko.Server/API/v3/Controllers/ActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/ActionController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using NLog;
 using Shoko.Server.API.Annotations;
 using Shoko.Server.API.v2.Models.core;
+using Shoko.Server.API.v3.Models.Shoko;
 using Shoko.Server.Commands;
 using Shoko.Server.Providers.MovieDB;
 using Shoko.Server.Providers.TraktTV;
@@ -195,8 +196,7 @@ namespace Shoko.Server.API.v3.Controllers
                     var xml = APIUtils.LoadAnimeHTTPFromFile(animeID);
                     if (xml == null)
                     {
-                        CommandRequest_GetAnimeHTTP cmd = new CommandRequest_GetAnimeHTTP(animeID, true, false);
-                        cmd.Save();
+                        Series.QueueAniDBRefresh(animeID, true, false, false);
                         updatedAnime++;
                         continue;
                     }
@@ -204,8 +204,7 @@ namespace Shoko.Server.API.v3.Controllers
                     var rawAnime = AniDBHTTPHelper.ProcessAnimeDetails(xml, animeID);
                     if (rawAnime == null)
                     {
-                        CommandRequest_GetAnimeHTTP cmd = new CommandRequest_GetAnimeHTTP(animeID, true, false);
-                        cmd.Save();
+                        Series.QueueAniDBRefresh(animeID, true, false, false);
                         updatedAnime++;
                     }
                 }

--- a/Shoko.Server/API/v3/Controllers/ActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/ActionController.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using AniDBAPI;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using NLog;
+using Microsoft.Extensions.Logging;
 using Shoko.Server.API.Annotations;
 using Shoko.Server.API.v3.Models.Shoko;
 using Shoko.Server.Commands;
@@ -13,6 +13,7 @@ using Shoko.Server.Providers.TraktTV;
 using Shoko.Server.Repositories;
 using Shoko.Server.Server;
 using Shoko.Server.Settings;
+using Shoko.Server.Tasks;
 
 namespace Shoko.Server.API.v3.Controllers
 {
@@ -20,8 +21,12 @@ namespace Shoko.Server.API.v3.Controllers
     [Authorize]
     public class ActionController : BaseController
     {
+        public ActionController(ILogger<ActionController> logger) : base()
+        {
+            Logger = logger;
+        }
         
-        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+        private readonly ILogger<ActionController> Logger;
 
         #region Common Actions
         /// <summary>
@@ -34,7 +39,7 @@ namespace Shoko.Server.API.v3.Controllers
             ShokoServer.RunImport();
             return Ok();
         }
-        
+
         /// <summary>
         /// This was for web cache hash syncing, and will be for perceptual hashing maybe eventually.
         /// </summary>
@@ -69,7 +74,7 @@ namespace Shoko.Server.API.v3.Controllers
 
             return Ok();
         }
-        
+
         /// <summary>
         /// Remove Entries in the Shoko Database for Files that are no longer accessible
         /// </summary>
@@ -102,7 +107,7 @@ namespace Shoko.Server.API.v3.Controllers
             ShokoServer.Instance.DownloadAllImages();
             return Ok();
         }
-        
+
         /// <summary>
         /// Updates All MovieDB Info
         /// </summary>
@@ -137,10 +142,10 @@ namespace Shoko.Server.API.v3.Controllers
             new CommandRequest_ValidateAllImages().Save();
             return Ok();
         }
-        #endregion        
-        
+        #endregion
+
         #region Admin Actions
-        
+
         /// <summary>
         /// Gets files whose data does not match AniDB
         /// </summary>
@@ -161,17 +166,17 @@ namespace Shoko.Server.API.v3.Controllers
                 int index = 0;
                 foreach (var path in list)
                 {
-                    Logger.Info($"AVDump Start {index + 1}/{list.Count}: {path}");
+                    Logger.LogInformation($"AVDump Start {index + 1}/{list.Count}: {path}");
                     AVDumpHelper.DumpFile(path);
-                    Logger.Info($"AVDump Finished {index + 1}/{list.Count}: {path}");
+                    Logger.LogInformation($"AVDump Finished {index + 1}/{list.Count}: {path}");
                     index++;
-                    Logger.Info($"AVDump Progress: {list.Count - index} remaining");
+                    Logger.LogInformation($"AVDump Progress: {list.Count - index} remaining");
                 }
             });
 
             return Ok();
         }
-        
+
         /// <summary>
         /// This Downloads XML data from AniDB where there is none. This should only happen:
         /// A. If someone deleted or corrupted them.
@@ -185,12 +190,12 @@ namespace Shoko.Server.API.v3.Controllers
             try
             {
                 var allAnime = RepoFactory.AniDB_Anime.GetAll().Select(a => a.AnimeID).OrderBy(a => a).ToList();
-                Logger.Info($"Starting the check for {allAnime.Count} anime XML files");
+                Logger.LogInformation($"Starting the check for {allAnime.Count} anime XML files");
                 int updatedAnime = 0;
                 for (var i = 0; i < allAnime.Count; i++)
                 {
                     var animeID = allAnime[i];
-                    if (i % 10 == 1) Logger.Info($"Checking anime {i + 1}/{allAnime.Count} for XML file");
+                    if (i % 10 == 1) Logger.LogInformation($"Checking anime {i + 1}/{allAnime.Count} for XML file");
 
                     var xml = APIUtils.LoadAnimeHTTPFromFile(animeID);
                     if (xml == null)
@@ -207,16 +212,16 @@ namespace Shoko.Server.API.v3.Controllers
                         updatedAnime++;
                     }
                 }
-                Logger.Info($"Updating {updatedAnime} anime");
+                Logger.LogInformation($"Updating {updatedAnime} anime");
             }
             catch (Exception e)
             {
-                Logger.Error($"Error checking and queuing AniDB XML Updates: {e}");
+                Logger.LogError(e, $"Error checking and queuing AniDB XML Updates: {e}");
                 return InternalError(e.Message);
             }
             return Ok();
         }
-        
+
         /// <summary>
         /// Regenerate All Episode Matchings for TvDB. Generally, don't do this unless there was an error that was fixed.
         /// In those cases, you'd be told to.
@@ -233,13 +238,13 @@ namespace Shoko.Server.API.v3.Controllers
             }
             catch (Exception e)
             {
-                Logger.Error(e);
+                Logger.LogError(e, e.Message);
                 return InternalError(e.Message);
             }
 
             return Ok();
         }
-        
+
         /// <summary>
         /// BEWARE this is a dangerous command!
         /// It syncs all of the states in Shoko's library to AniDB.
@@ -252,7 +257,7 @@ namespace Shoko.Server.API.v3.Controllers
             ShokoServer.SyncMyList();
             return Ok();
         }
-        
+
         /// <summary>
         /// Update All AniDB Series Info
         /// </summary>
@@ -274,7 +279,7 @@ namespace Shoko.Server.API.v3.Controllers
             ShokoServer.RefreshAllMediaInfo();
             return Ok();
         }
-        
+
         /// <summary>
         /// Queues commands to Update All Series Stats and Force a Recalculation of All Group Filters
         /// </summary>
@@ -295,6 +300,21 @@ namespace Shoko.Server.API.v3.Controllers
         {
             Importer.RunImport_NewFiles();
             return Ok();
+        }
+
+        /// <summary>
+        /// Recreate all <see cref="Group"/>s. This will delete any and all existing groups.
+        /// </summary>
+        /// <remarks>
+        /// This action requires an admin account because it's a destructive action.
+        /// </remarks>
+        /// <returns></returns>
+        [Authorize("admin")]
+        [HttpGet("RecreateAllGroups")]
+        public ActionResult RecreateAllGroups()
+        {
+            Task.Run(() => new AnimeGroupCreator().RecreateAllGroups());
+            return Ok("Check the server status via init/status or SignalR's Events hub");
         }
         #endregion
     }

--- a/Shoko.Server/API/v3/Controllers/ActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/ActionController.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NLog;
 using Shoko.Server.API.Annotations;
-using Shoko.Server.API.v2.Models.core;
 using Shoko.Server.API.v3.Models.Shoko;
 using Shoko.Server.Commands;
 using Shoko.Server.Providers.MovieDB;
@@ -213,9 +212,9 @@ namespace Shoko.Server.API.v3.Controllers
             catch (Exception e)
             {
                 Logger.Error($"Error checking and queuing AniDB XML Updates: {e}");
-                return APIStatus.InternalError(e.Message);
+                return InternalError(e.Message);
             }
-            return APIStatus.OK();
+            return Ok();
         }
         
         /// <summary>
@@ -235,10 +234,10 @@ namespace Shoko.Server.API.v3.Controllers
             catch (Exception e)
             {
                 Logger.Error(e);
-                return APIStatus.InternalError(e.Message);
+                return InternalError(e.Message);
             }
 
-            return APIStatus.OK();
+            return Ok();
         }
         
         /// <summary>

--- a/Shoko.Server/API/v3/Controllers/EpisodeController.cs
+++ b/Shoko.Server/API/v3/Controllers/EpisodeController.cs
@@ -93,7 +93,9 @@ namespace Shoko.Server.API.v3.Controllers
             if (episode == null)
                 return NotFound(EpisodeNotFoundWithEpisodeID);
 
-            return Episode.GetTvDBInfo(episode.AniDB_EpisodeID);
+            return episode.TvDBEpisodes
+                .Select(a => new Episode.TvDB(a))
+                .ToList();
         }
 
         /// <summary>

--- a/Shoko.Server/API/v3/Controllers/FileController.cs
+++ b/Shoko.Server/API/v3/Controllers/FileController.cs
@@ -15,6 +15,7 @@ using Shoko.Server.Providers.TraktTV;
 using Shoko.Server.Commands;
 using Shoko.Server.Repositories;
 using Shoko.Server.Settings;
+using CommandRequestPriority = Shoko.Server.Server.CommandRequestPriority;
 using File = Shoko.Server.API.v3.Models.Shoko.File;
 using Path = System.IO.Path;
 
@@ -287,9 +288,10 @@ namespace Shoko.Server.API.v3.Controllers
         /// Rescan a file on AniDB.
         /// </summary>
         /// <param name="fileID">VideoLocal ID</param>
+        /// <param name="priority">Increase the priority to the max for the queued command.</param>
         /// <returns></returns>
         [HttpPost("{fileID}/Rescan")]
-        public ActionResult RescanFile([FromRoute] int fileID)
+        public ActionResult RescanFile([FromRoute] int fileID, [FromQuery] bool priority = false)
         {
             var file = RepoFactory.VideoLocal.GetByID(fileID);
             if (file == null)
@@ -300,6 +302,7 @@ namespace Shoko.Server.API.v3.Controllers
                 return BadRequest(FileNoPath);
 
             var command = new CommandRequest_ProcessFile(file.VideoLocalID, true);
+            if (priority) command.Priority = (int) CommandRequestPriority.Priority1;
             command.Save();
             return Ok();
         }

--- a/Shoko.Server/API/v3/Controllers/FilterController.cs
+++ b/Shoko.Server/API/v3/Controllers/FilterController.cs
@@ -93,7 +93,7 @@ namespace Shoko.Server.API.v3.Controllers
             return groupIDs
                 .Select(a => RepoFactory.AnimeGroup.GetByID(a))
                 .Where(a => a != null)
-                .GroupFilterSort(groupFilter)
+                .OrderByGroupFilter(groupFilter)
                 .Select(a => new Group(HttpContext, a))
                 .ToList();
         }

--- a/Shoko.Server/API/v3/Controllers/FilterController.cs
+++ b/Shoko.Server/API/v3/Controllers/FilterController.cs
@@ -15,35 +15,121 @@ namespace Shoko.Server.API.v3.Controllers
     [Authorize]
     public class FilterController : BaseController
     {
+        internal static string FilterNotFound = "No Filter entry for the given filterID";
+
         /// <summary>
-        /// Get Filter with id
+        /// Get All <see cref="Filter"/>s
         /// </summary>
-        /// <param name="filterID"></param>
+        /// <param name="includeEmpty"></param>
+        /// <param name="includeInvisible"></param>
+        /// <param name="page"></param>
+        /// <param name="pageSize"></param>
+        /// <returns></returns>
+        [HttpGet]
+        public ActionResult<List<Filter>> GetAllFilters([FromQuery] bool includeEmpty = false, [FromQuery] bool includeInvisible = false, [FromQuery] int page = 0, [FromQuery] int pageSize = 10)
+        {
+            var groupFilters = RepoFactory.GroupFilter.GetTopLevel()
+                .Where(filter =>
+                {
+                    if (filter.InvisibleInClients != 0 && !includeInvisible)
+                        return false;
+                    if (filter.GroupsIds.ContainsKey(User.JMMUserID) && filter.GroupsIds[User.JMMUserID].Count > 0 || includeEmpty)
+                        return true;
+                    return ((GroupFilterType)filter.FilterType).HasFlag(GroupFilterType.Directory);
+                })
+                .OrderBy(filter => filter.GroupFilterName);
+
+            if (pageSize <= 0)
+                return groupFilters
+                    .Select(filter => new Filter(HttpContext, filter))
+                    .ToList();
+
+            if (page <= 0) page = 0;
+            return groupFilters
+                .Skip(page * pageSize)
+                .Take(pageSize)
+                .Select(filter => new Filter(HttpContext, filter))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Create or update a filter
+        /// </summary>
+        /// <param name="body"></param>
+        /// <returns>The resulting Filter, with ID</returns>
+        [HttpPost]
+        public ActionResult<Filter> SaveFilter(Filter.FullFilter body)
+        {
+            SVR_GroupFilter groupFilter = null;
+            if (body.IDs.ID != 0)
+            {
+                groupFilter = RepoFactory.GroupFilter.GetByID(body.IDs.ID);
+                if (groupFilter == null)
+                    return NotFound(FilterNotFound);
+                if (groupFilter.Locked == 1)
+                    return Forbid("Filter is Locked");
+            }
+            groupFilter = body.ToServerModel(groupFilter);
+            groupFilter.CalculateGroupsAndSeries();
+            RepoFactory.GroupFilter.Save(groupFilter);
+
+            return new Filter(HttpContext, groupFilter);
+        }
+
+        /// <summary>
+        /// Preview the Groups that will be in the filter if the changes are applied
+        /// </summary>
+        /// <param name="body"></param>
+        /// <returns></returns>
+        [HttpPost("Preview")]
+        public ActionResult<List<Group>> PreviewFilterChanges(Filter.FullFilter body)
+        {
+            var groupFilter = body.ToServerModel();
+            groupFilter.CalculateGroupsAndSeries();
+
+            if (!groupFilter.GroupsIds.TryGetValue(User.JMMUserID, out var groupIDs))
+                return new List<Group>();
+
+            return groupIDs
+                .Select(a => RepoFactory.AnimeGroup.GetByID(a))
+                .Where(a => a != null)
+                .GroupFilterSort(groupFilter)
+                .Select(a => new Group(HttpContext, a))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Get the <see cref="Filter"/> for the given <paramref name="filterID"/>.
+        /// </summary>
+        /// <param name="filterID">Filter ID</param>
         /// <returns></returns>
         [HttpGet("{filterID}")]
         public ActionResult<Filter> GetFilter(int filterID)
         {
-            var gf = RepoFactory.GroupFilter.GetByID(filterID);
-            if (gf == null) return BadRequest("No filter with id");
-            return new Filter(HttpContext, gf);
+            var groupFilter = RepoFactory.GroupFilter.GetByID(filterID);
+            if (groupFilter == null)
+                return NotFound(FilterNotFound);
+
+            return new Filter(HttpContext, groupFilter);
         }
 
         /// <summary>
-        /// Get Filter with id
+        /// Delete a filter
         /// </summary>
         /// <param name="filterID"></param>
         /// <returns></returns>
-        [HttpGet("{filterID}/Filter")]
-        public ActionResult<List<Filter>> GetSubFilters(int filterID)
+        [Authorize("admin")]
+        [HttpDelete("{filterID}")]
+        public ActionResult DeleteFilter(int filterID)
         {
-            var gf = RepoFactory.GroupFilter.GetByID(filterID);
-            if (gf == null) return BadRequest("No filter with id");
-            if (!((GroupFilterType) gf.FilterType).HasFlag(GroupFilterType.Directory))
-                return BadRequest("Filter should be a Directory Filter");
-            return RepoFactory.GroupFilter.GetByParentID(filterID).Select(a => new Filter(HttpContext, a))
-                .OrderBy(a => a.Name).ToList();
+            var groupFilter = RepoFactory.GroupFilter.GetByID(filterID);
+            if (groupFilter == null)
+                return NotFound(FilterNotFound);
+
+            RepoFactory.GroupFilter.Delete(groupFilter);
+            return NoContent();
         }
-        
+
         /// <summary>
         /// Get Conditions for Filter with id
         /// </summary>
@@ -52,11 +138,13 @@ namespace Shoko.Server.API.v3.Controllers
         [HttpGet("{filterID}/Conditions")]
         public ActionResult<Filter.FilterConditions> GetFilterConditions(int filterID)
         {
-            var gf = RepoFactory.GroupFilter.GetByID(filterID);
-            if (gf == null) return BadRequest("No filter with id");
-            return Filter.GetConditions(gf);
+            var groupFilter = RepoFactory.GroupFilter.GetByID(filterID);
+            if (groupFilter == null)
+                return NotFound(FilterNotFound);
+
+            return Filter.GetConditions(groupFilter);
         }
-        
+
         /// <summary>
         /// Get Sorting Criteria for Filter with id
         /// </summary>
@@ -65,61 +153,11 @@ namespace Shoko.Server.API.v3.Controllers
         [HttpGet("{filterID}/Sorting")]
         public ActionResult<List<Filter.SortingCriteria>> GetFilterSortingCriteria(int filterID)
         {
-            var gf = RepoFactory.GroupFilter.GetByID(filterID);
-            if (gf == null) return BadRequest("No filter with id");
-            return Filter.GetSortingCriteria(gf);
-        }
+            var groupFilter = RepoFactory.GroupFilter.GetByID(filterID);
+            if (groupFilter == null)
+                return NotFound(FilterNotFound);
 
-        /// <summary>
-        /// Preview the Groups that will be in the filter if the changes are applied
-        /// </summary>
-        /// <param name="filter"></param>
-        /// <returns></returns>
-        [HttpPost("Preview")]
-        public ActionResult<List<Group>> PreviewFilterChanges(Filter.FullFilter filter)
-        {
-            SVR_GroupFilter gf = filter.ToServerModel();
-            gf.CalculateGroupsAndSeries();
-
-            if (!gf.GroupsIds.ContainsKey(User.JMMUserID)) return new List<Group>();
-            return gf.GroupsIds[User.JMMUserID].Select(a => RepoFactory.AnimeGroup.GetByID(a))
-                .Where(a => a != null).GroupFilterSort(gf).Select(a => new Group(HttpContext, a)).ToList();
-        }
-        
-        /// <summary>
-        /// Create or update a filter
-        /// </summary>
-        /// <param name="filter"></param>
-        /// <returns>The resulting Filter, with ID</returns>
-        [HttpPost]
-        public ActionResult<Filter> SaveFilter(Filter.FullFilter filter)
-        {
-            SVR_GroupFilter gf = null;
-            if (filter.IDs.ID != 0)
-            {
-                gf = RepoFactory.GroupFilter.GetByID(filter.IDs.ID);
-                if (gf == null) return BadRequest("No Filter with ID");
-                if (gf.Locked == 1) return BadRequest("Filter is Locked");
-            }
-            gf = filter.ToServerModel(gf);
-            gf.CalculateGroupsAndSeries();
-            RepoFactory.GroupFilter.Save(gf);
-
-            return new Filter(HttpContext, gf);
-        }
-
-        /// <summary>
-        /// Delete a filter
-        /// </summary>
-        /// <param name="filterID"></param>
-        /// <returns></returns>
-        [HttpDelete("{filterID}")]
-        public ActionResult DeleteFilter(int filterID)
-        {
-            var gf = RepoFactory.GroupFilter.GetByID(filterID);
-            if (gf == null) return BadRequest("No filter with id");
-            RepoFactory.GroupFilter.Delete(gf);
-            return Ok();
+            return Filter.GetSortingCriteria(groupFilter);
         }
     }
 }

--- a/Shoko.Server/API/v3/Controllers/FolderController.cs
+++ b/Shoko.Server/API/v3/Controllers/FolderController.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.API.v3.Controllers
 {
     [ApiController, Route("/api/v{version:apiVersion}/[controller]"), ApiV3]
     [Authorize]
-    public class FolderController : Controller
+    public class FolderController : BaseController
     {
         [HttpGet("drives")]
         public ActionResult<IEnumerable<Drive>> GetDrives()

--- a/Shoko.Server/API/v3/Controllers/GroupController.cs
+++ b/Shoko.Server/API/v3/Controllers/GroupController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,16 +16,200 @@ namespace Shoko.Server.API.v3.Controllers
     [Authorize]
     public class GroupController : BaseController
     {
+        #region Return messages
+
+        internal static string GroupNotFound = "No Group entry for the given groupID";
+
+        internal static string GroupForbiddenForUser = "Accessing Group is not allowed for the current user";
+
+        #endregion
+        #region Metadata
+        #region Get Many
         /// <summary>
         /// Get a list of all groups available to the current user
         /// </summary>
+        /// <param name="page">The page index.</param>
+        /// <param name="pageSize">The page size.</param>
+        /// <param name="topLevelOnly">Only list the top level groups if set.</param>
         /// <returns></returns>
         [HttpGet]
-        public ActionResult<List<Group>> GetAllGroups()
+        public ActionResult<List<Group>> GetAllGroups([FromQuery] int page = 0, [FromQuery] int pageSize = 50, bool topLevelOnly = false)
         {
-            var allGroups = RepoFactory.AnimeGroup.GetAll().Where(a => User.AllowedGroup(a)).ToList();
-            return allGroups.Select(a => new Group(HttpContext, a)).ToList();
+            var groups = RepoFactory.AnimeGroup.GetAll()
+                .Where(group =>
+                {
+                    if (topLevelOnly && group.AnimeGroupParentID.HasValue)
+                        return false;
+
+                    return User.AllowedGroup(group);
+                })
+                .OrderBy(group => group.GroupName);
+
+            if (pageSize <= 0)
+                return groups
+                    .Select(g => new Group(HttpContext, g))
+                    .ToList();
+
+            if (page <= 0) page = 0;
+            return groups
+                .Skip(page * pageSize)
+                .Take(pageSize)
+                .Select(g => new Group(HttpContext, g))
+                .ToList();
         }
+
+        #endregion
+        #region Create new or update existing
+
+        /// <summary>
+        /// Create a new or merge with an existing group.
+        /// Use <see cref="SeriesController.MoveSeries"/> to move series to the group.
+        /// </summary>
+        /// <param name="body"></param>
+        /// <param name="merge">Merge with the first existing group of the same name.</param>
+        /// <returns></returns>
+        [HttpPost]
+        public ActionResult<Group> CreateOrUpdateGroup([FromBody] Group.Input.CreateGroupBody body, [FromQuery] bool merge = false)
+        {
+            // Validate if the parent exists if a parent id is set.
+            var parentID = body.ParentID ?? 0;
+            if (parentID != 0)
+            {
+                var parent = RepoFactory.AnimeGroup.GetByID(parentID);
+                if (parent == null)
+                    return BadRequest("Invalid parent group id supplied.");
+            }
+
+            // Try to find the group to merge with if we provided an id.
+            bool isNew = false;
+            SVR_AnimeGroup group = null;
+            if (body.ID.HasValue && body.ID.Value != 0)
+            {
+                // Make sure merging is requested.
+                // A merge request without the 'merge' query parameter set is an
+                // error.
+                if (!merge)
+                    return BadRequest("A group id have been supplied. Set the merge query parameter to continue.");
+
+                group = RepoFactory.AnimeGroup.GetByID(body.ID.Value);
+
+                // Make sure the group actually exists.
+                if (group == null)
+                    return BadRequest("No Group entry for the given id.");
+            }
+            // Try to find an existing group exists for the given name or create a new one.
+            else
+            {
+                // Look for an existing group if force is not set.
+                group = RepoFactory.AnimeGroup.GetByParentID(parentID)
+                    .FirstOrDefault(grp => string.Equals(grp.GroupName, body.Name, StringComparison.InvariantCultureIgnoreCase));
+
+                // If no group was found (either because we forced it or because a group by the same name was not found) then
+                if (group == null)
+                {
+                    // It's safe to use the group name.
+                    isNew = true;
+                    group = new()
+                    {
+                        Description = string.Empty,
+                        IsManuallyNamed = 0,
+                        DateTimeCreated = DateTime.Now,
+                        DateTimeUpdated = DateTime.Now,
+                        MissingEpisodeCount = 0,
+                        MissingEpisodeCountGroups = 0,
+                        OverrideDescription = 0,
+
+                    };
+                }
+                // Else we need to provide the query parameter to either merge
+                // or forcefully create a new group.
+                else if (!merge)
+                {
+                    return BadRequest("A group with the given name already exists. Set the merge or force query parameter to continue.");
+                }
+            }
+
+            // Get the series and validate the series ids.
+            var seriesList = body.SeriesIDs?.Select(id => RepoFactory.AnimeSeries.GetByID(id)).Where(s => s != null).ToList() ?? new();
+            if (seriesList.Count != (body.SeriesIDs?.Length ?? 0))
+                return BadRequest("One or more series ids are invalid.");
+            // Trying to merge 0 series with an existing group is an error.
+            // Trying to create an empty group is also an error.
+            if (seriesList.Count == 0)
+                return BadRequest("No series ids have been spesified.");
+
+            // Nor spesifying a group name is an error.
+            body.Name = body.Name?.Trim() ?? "";
+            if (string.IsNullOrEmpty(body.Name))
+                return BadRequest("A name must be present and contain at least one character.");
+
+            group.AnimeGroupParentID = parentID != 0 ? parentID : null;
+            group.GroupName = body.Name;
+            group.SortName = string.IsNullOrEmpty(body.SortName?.Trim()) ? body.Name : body.SortName;
+            group.Description = body.Description ?? null;
+            group.IsManuallyNamed = body.HasCustomName ? 1 : 0;
+            group.OverrideDescription = 0;
+
+            // Create a new or update an existing group entry.
+            RepoFactory.AnimeGroup.Save(group, true, false, false);
+
+            // Iterate over the series list to calculate the groups to update
+            // and to assign the series to the group.
+            var oldGroups = new Dictionary<int, int>();
+            foreach (var series in seriesList)
+            {
+                // Skip the series if it's already in the group.
+                if (series.AnimeGroupID == group.AnimeGroupID)
+                    continue;
+
+                // Count the number of series in each group.
+                var oldGroupID = series.AnimeGroupID;
+                if (oldGroups.TryGetValue(oldGroupID, out var count))
+                    oldGroups[oldGroupID] = count + 1;
+                else
+                    oldGroups[oldGroupID] = 1;
+
+                // Assign the series to the new group and update the series
+                // entry.
+                series.AnimeGroupID = group.AnimeGroupID;
+                series.UpdateStats(true, true, false);
+            }
+
+            // We don't need to update the group twice, and we don't need to
+            // check if the group we're creating/updating needs to be
+            // removed.
+            if (oldGroups.Keys.Contains(group.AnimeGroupID))
+                oldGroups.Remove(group.AnimeGroupID);
+
+            // Remove or update groups stats for the old groups.
+            foreach (var (oldGroupID, seriesCount) in oldGroups)
+            {
+                var oldGroup = RepoFactory.AnimeGroup.GetByID(oldGroupID)?.TopLevelAnimeGroup;
+                // The old group may have already been removed, so silently skip it.
+                if (oldGroup == null)
+                    continue;
+                // Delete the sub-groups if the old group doesn't contain any other series.
+                if (oldGroup.GetAllSeries().Count <= seriesCount)
+                {
+                    RepoFactory.AnimeGroup.Delete(oldGroup.GetAllChildGroups());
+                    RepoFactory.AnimeGroup.Delete(oldGroup);
+                }
+                else
+                {
+                    oldGroup.UpdateStatsFromTopLevel(false, true, true);
+                }
+            }
+
+            // Update the group stats for the new group.
+            group.UpdateStatsFromTopLevel(false, true, true);
+
+            // Return the info for the newly created or updated group.
+            var dto = new Group(HttpContext, group);
+            return isNew ? Created($"./{group.AnimeGroupID}", dto) : Ok(dto);
+        }
+
+        #endregion
+        #region Get One
 
         /// <summary>
         /// Get the group with ID
@@ -32,48 +217,18 @@ namespace Shoko.Server.API.v3.Controllers
         /// <param name="groupID"></param>
         /// <returns></returns>
         [HttpGet("{groupID}")]
-        public ActionResult<Group> GetGroup(int groupID)
+        public ActionResult<Group> GetGroup([FromRoute] int groupID)
         {
-            var grp = RepoFactory.AnimeGroup.GetByID(groupID);
-            if (grp == null) return BadRequest("No Group with ID");
-            return new Group(HttpContext, grp);
+            var group = RepoFactory.AnimeGroup.GetByID(groupID);
+            if (group == null)
+                return NotFound(GroupNotFound);
+
+            return new Group(HttpContext, group);
         }
 
-        /// <summary>
-        /// Save or create a group.
-        /// Use <see cref="SeriesController.MoveSeries"/> to move series to the group.
-        /// </summary>
-        /// <param name="group"></param>
-        /// <returns></returns>
-        [HttpPost]
-        public ActionResult<Group> SaveGroup(Group.FullGroup group)
-        {
-            SVR_AnimeGroup g = null;
-            if (group.IDs.ID != 0)
-            {
-                g = RepoFactory.AnimeGroup.GetByID(group.IDs.ID);
-                if (g == null) return BadRequest("No Group with ID");
-            }
-            g = group.ToServerModel(g);
-            RepoFactory.AnimeGroup.Save(g);
-
-            return new Group(HttpContext, g);
-        }
-
-        /// <summary>
-        /// Recalculate all stats and contracts for a group
-        /// </summary>
-        /// <param name="groupID"></param>
-        /// <returns></returns>
-        [HttpPost("{groupID}/Recalculate")]
-        public ActionResult RecalculateStats(int groupID)
-        {
-            var grp = RepoFactory.AnimeGroup.GetByID(groupID);
-            if (grp == null) return BadRequest("No Group with ID");
-            AnimeGroupCreator groupCreator = new AnimeGroupCreator();
-            groupCreator.RecalculateStatsContractsForGroup(grp);
-            return Ok();
-        }
+        #endregion
+        #endregion
+        #region Delete
 
         /// <summary>
         /// Delete a group recursively.
@@ -86,28 +241,57 @@ namespace Shoko.Server.API.v3.Controllers
         [HttpDelete("{groupID}")]
         public ActionResult DeleteGroup(int groupID, bool deleteSeries = false, bool deleteFiles = false)
         {
-            var grp = RepoFactory.AnimeGroup.GetByID(groupID);
-            if (grp == null) return BadRequest("No Group with ID");
-            if (!deleteSeries && grp.GetAllSeries().Any())
-                return BadRequest(
-                    $"{nameof(deleteSeries)} is not true, and the group contains series. Move them, or set {nameof(deleteSeries)} to true");
+            var group = RepoFactory.AnimeGroup.GetByID(groupID);
+            if (group == null)
+                return NotFound("No Group with ID");
 
-            foreach (var series in grp.GetAllSeries())
-            {
+            if (!deleteSeries && group.GetAllSeries().Any())
+                return BadRequest($"{nameof(deleteSeries)} is not true, and the group contains series. Move them, or set {nameof(deleteSeries)} to true");
+
+            foreach (var series in group.GetAllSeries())
                 series.DeleteSeries(deleteFiles, false);
-            }
 
-            grp.DeleteGroup();
+            group.DeleteGroup();
 
+            return NoContent();
+        }
+
+        #endregion
+        #region Recalculate
+
+        /// <summary>
+        /// Recalculate all stats and contracts for a group
+        /// </summary>
+        /// <param name="groupID"></param>
+        /// <returns></returns>
+        [HttpPost("{groupID}/Recalculate")]
+        public ActionResult RecalculateStats(int groupID)
+        {
+            var group = RepoFactory.AnimeGroup.GetByID(groupID);
+            if (group == null)
+                return NotFound(GroupNotFound);
+
+            AnimeGroupCreator groupCreator = new AnimeGroupCreator();
+            groupCreator.RecalculateStatsContractsForGroup(group);
             return Ok();
         }
 
+        #endregion
+        #region Obsolete
+
+        /// <summary>
+        /// Recreate all groups from scratch. Use <see cref="ActionController.RecreateAllGroups"/> instead.
+        /// </summary>
+        /// <returns></returns>
         [Authorize("admin")]
         [HttpGet("RecreateAllGroups")]
+        [Obsolete]
         public ActionResult RecreateAllGroups()
         {
             Task.Run(() => new AnimeGroupCreator().RecreateAllGroups());
             return Ok("Check the server status via init/status or SignalR's Events hub");
         }
+
+        #endregion
     }
 }

--- a/Shoko.Server/API/v3/Controllers/ReverseTreeController.cs
+++ b/Shoko.Server/API/v3/Controllers/ReverseTreeController.cs
@@ -19,46 +19,134 @@ namespace Shoko.Server.API.v3.Controllers
     public class ReverseTreeController : BaseController
     {
         /// <summary>
-        /// Get Group for Series with seriesID.
+        /// Get the parent <see cref="Filter"/> for the <see cref="Filter"/> with the given <paramref name="filterID"/>.
         /// </summary>
+        /// <remarks>
+        /// This endpoint can be used to get the direct <see cref="Filter"/> parent to a <see cref="Filter"/> (in case
+        /// it's within a sub-Filter) or to always get the top-level  <see cref="Filter"/> regardless if
+        /// <paramref name="topLevel"/> is set to <code>true</code>.
+        /// 
+        /// Trying to get the parent of a top-level <see cref="Filter"/> is an user error and will throw a complaint.
+        /// </remarks>
+        /// <param name="filterID"><see cref="Filter"/> ID</param>
+        /// <param name="topLevel">Always get the top-level <see cref="Filter"/></param>
+        /// <returns></returns>
+        [HttpGet("Filter/{filterID}/Parent")]
+        public ActionResult<Filter> GetFilterFromFilter([FromRoute] int filterID, [FromQuery] bool topLevel = false)
+        {
+            var filter = RepoFactory.GroupFilter.GetByID(filterID);
+            if (filter == null)
+                return NotFound(FilterController.FilterNotFound);
+
+            if (!filter.ParentGroupFilterID.HasValue || filter.ParentGroupFilterID.Value == 0)
+                return BadRequest("Unable to get parent Filter for a top-level Filter");
+
+            var parentGroup = topLevel ? filter.TopLevelGroupFilter : filter.Parent;
+            if (parentGroup == null)
+                return InternalError("No parent Filter entry for the given filterID");
+
+            return new Filter(HttpContext, parentGroup);
+        }
+
+        /// <summary>
+        /// Get the parent <see cref="Group"/> for the <see cref="Group"/> with the given <paramref name="groupID"/>.
+        /// </summary>
+        /// <remarks>
+        /// This endpoint can be used to get the direct <see cref="Group"/> parent to a <see cref="Group"/> (in case
+        /// it's within a sub-group) or to always get the top-level  <see cref="Group"/> regardless if
+        /// <paramref name="topLevel"/> is set to <code>true</code>.
+        /// 
+        /// Trying to get the parent of a top-level <see cref="Group"/> is an user error and will throw a complaint.
+        /// </remarks>
+        /// <param name="groupID"><see cref="Group"/> ID</param>
+        /// <param name="topLevel">Always get the top-level <see cref="Group"/></param>
+        /// <returns></returns>
+        [HttpGet("Group/{groupID}/Parent")]
+        public ActionResult<Group> GetGroupFromGroup([FromRoute] int groupID, [FromQuery] bool topLevel = false)
+        {
+            var group = RepoFactory.AnimeGroup.GetByID(groupID);
+            if (group == null)
+                return NotFound(GroupController.GroupNotFound);
+            if (!User.AllowedGroup(group))
+                return Forbid(GroupController.GroupForbiddenForUser);
+
+            if (!group.AnimeGroupParentID.HasValue || group.AnimeGroupParentID.Value == 0)
+                return BadRequest("Unable to get parent Group for a top-level Group");
+
+            var parentGroup = topLevel ? group.TopLevelAnimeGroup : group.Parent;
+            if (parentGroup == null)
+                return InternalError("No parent Group entry for the given groupID");
+
+            return new Group(HttpContext, parentGroup);
+        }
+
+        /// <summary>
+        /// Get the <see cref="Group"/> for the <see cref="Series"/> with the given <paramref name="seriesID"/>.
+        /// </summary>
+        /// <remarks>
+        /// This endpoint can be used to get the direct <see cref="Group"/> parent to a <see cref="Series"/> (in case
+        /// it's within a sub-group) or to always get the top-level  <see cref="Group"/> regardless if
+        /// <paramref name="topLevel"/> is set to <code>true</code>.
+        /// </remarks>
+        /// <param name="seriesID"><see cref="Series"/> ID</param>
+        /// <param name="topLevel">Always get the top-level <see cref="Group"/></param>
         /// <returns></returns>
         [HttpGet("Series/{seriesID}/Group")]
-        public ActionResult<Group> GetGroupFromSeries(int seriesID)
+        public ActionResult<Group> GetGroupFromSeries([FromRoute] int seriesID, [FromQuery] bool topLevel = false)
         {
-            var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (ser == null) return BadRequest("No Series with ID");
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            var group = ser.AnimeGroup;
-            if (group == null) return BadRequest("Group not found for series");
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesController.SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesController.SeriesForbiddenForUser);
+
+            var group = topLevel ? series.TopLevelAnimeGroup : series.AnimeGroup;
+            if (group == null)
+                return InternalError("No Group entry for the Series");
+
             return new Group(HttpContext, group);
         }
 
         /// <summary>
-        /// Get Series for episode with episodeID.
+        /// Get the <see cref="Series"/> for the <see cref="Episode"/> with the given <paramref name="episodeID"/>.
         /// </summary>
+        /// <param name="episodeID"><see cref="Episode"/> ID</param>
         /// <returns></returns>
         [HttpGet("Episode/{episodeID}/Series")]
-        public ActionResult<Series> GetSeriesFromEpisode(int episodeID)
+        public ActionResult<Series> GetSeriesFromEpisode([FromRoute] int episodeID)
         {
             var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
-            if (episode == null) return BadRequest("No episode with ID");
-            var ser = episode.GetAnimeSeries();
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            return new Series(HttpContext, ser);
+            if (episode == null)
+                return NotFound(EpisodeController.EpisodeNotFoundWithEpisodeID);
+
+            var series = episode.GetAnimeSeries();
+            if (series == null)
+                return InternalError("No Series entry for the Episode");
+            if (!User.AllowedSeries(series))
+                return Forbid(EpisodeController.EpisodeForbiddenForUser);
+
+            return new Series(HttpContext, series);
         }
 
         /// <summary>
-        /// Get Episode for file with fileID.
+        /// Get the <see cref="Episode"/>s for the <see cref="File"/> with the given <paramref name="fileID"/>.
         /// </summary>
+        /// <param name="fileID"><see cref="File"/> ID</param>
         /// <returns></returns>
         [HttpGet("File/{fileID}/Episode")]
-        public ActionResult<List<Episode>> GetEpisodeFromFile(int fileID)
+        public ActionResult<List<Episode>> GetEpisodeFromFile([FromRoute] int fileID)
         {
-            var videoLocal = RepoFactory.VideoLocal.GetByID(fileID);
-            if (videoLocal == null) return BadRequest("No file with ID");
-            var eps = videoLocal.GetAnimeEpisodes();
-            if (!eps.All(a => User.AllowedSeries(a.GetAnimeSeries()))) return BadRequest("Series not allowed for current user");
-            return eps.Select(a => new Episode(HttpContext, a)).ToList();
+            var file = RepoFactory.VideoLocal.GetByID(fileID);
+            if (file == null)
+                return NotFound(FileController.FileNotFoundWithFileID);
+
+            var episodes = file.GetAnimeEpisodes();
+            if (!episodes.All(episode => User.AllowedSeries(episode.GetAnimeSeries())))
+                return Forbid(FileController.FileForbiddenForUser);
+
+            return episodes
+                .Select(a => new Episode(HttpContext, a))
+                .ToList();
         }
     }
 }

--- a/Shoko.Server/API/v3/Controllers/SeriesController.cs
+++ b/Shoko.Server/API/v3/Controllers/SeriesController.cs
@@ -25,15 +25,48 @@ namespace Shoko.Server.API.v3.Controllers
     [Authorize]
     public class SeriesController : BaseController
     {
+        #region Return messages
+
+        internal static string SeriesNotFoundWithSeriesID = "No Series entry for the given seriesID";
+
+        internal static string SeriesNotFoundWithAnidbID = "No Series entry for the given anidbID";
+
+        internal static string SeriesForbiddenForUser = "Accessing Series is not allowed for the current user";
+
+        internal static string AnidbNotFoundForSeriesDB = "No Series.AniDB entry for the given seriesID";
+
+        internal static string AnidbNotFoundForAniDB = "No Series.AniDB entry for the given anidbID";
+
+        internal static string AnidbForbiddenForUser = "Accessing Series.AniDB is not allowed for the current user";
+
+        #endregion
+        #region Metadata
+        #region Shoko
+
         /// <summary>
-        /// Get a list of all series available to the current user
+        /// Get a paginated list of all <see cref="Series"/> available to the current <see cref="User"/>.
         /// </summary>
+        /// <param name="page">The page index.</param>
+        /// <param name="pageSize">The page size.</param>
         /// <returns></returns>
         [HttpGet]
-        public ActionResult<List<Series>> GetAllSeries()
+        public ActionResult<List<Series>> GetAllSeries([FromQuery] int page = 0, [FromQuery] int pageSize = 50)
         {
-            var allSeries = RepoFactory.AnimeSeries.GetAll().Where(a => User.AllowedSeries(a));
-            return allSeries.Select(a => new Series(HttpContext, a)).OrderBy(a => a.Name).ToList();
+            var series = RepoFactory.AnimeSeries.GetAll()
+                .Where(a => User.AllowedSeries(a))
+                .OrderBy(a => a.GetSeriesName());
+
+            if (pageSize <= 0)
+                return series
+                    .Select(a => new Series(HttpContext, a))
+                    .ToList();
+
+            if (page <= 0) page = 0;
+            return series
+                .Skip(page * pageSize)
+                .Take(pageSize)
+                .Select(a => new Series(HttpContext, a))
+                .ToList();
         }
 
         /// <summary>
@@ -44,11 +77,36 @@ namespace Shoko.Server.API.v3.Controllers
         [HttpGet("{seriesID}")]
         public ActionResult<Series> GetSeries([FromRoute] int seriesID)
         {
-            var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (ser == null) return BadRequest("No Series with ID");
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            return new Series(HttpContext, ser);
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
+
+            return new Series(HttpContext, series);
         }
+
+        /// <summary>
+        /// Delete a Series
+        /// </summary>
+        /// <param name="seriesID">The ID of the Series</param>
+        /// <param name="deleteFiles">Whether to delete all of the files in the series from the disk.</param>
+        /// <returns></returns>
+        [Authorize("admin")]
+        [HttpDelete("{seriesID}")]
+        public ActionResult DeleteSeries([FromRoute] int seriesID, [FromQuery] bool deleteFiles = false)
+        {
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+
+            series.DeleteSeries(deleteFiles, true);
+
+            return Ok();
+        }
+        
+        #endregion
+        #region AniDB
 
         /// <summary>
         /// Get AniDB Info for series with ID
@@ -56,14 +114,19 @@ namespace Shoko.Server.API.v3.Controllers
         /// <param name="seriesID">Shoko ID</param>
         /// <returns></returns>
         [HttpGet("{seriesID}/AniDB")]
-        public ActionResult<Series.AniDB> GetSeriesAniDBDetails([FromRoute] int seriesID)
+        public ActionResult<Series.AniDB> GetSeriesAnidbBySeriesID([FromRoute] int seriesID)
         {
-            var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (ser == null) return BadRequest("No Series with ID");
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            var anime = ser.GetAnime();
-            if (anime == null) return BadRequest("No AniDB_Anime for Series");
-            return new Series.AniDB(HttpContext, anime);
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
+
+            var anidb = series.GetAnime();
+            if (anidb == null)
+                return InternalError(AnidbNotFoundForSeriesDB);
+
+            return new Series.AniDB(HttpContext, anidb);
         }
 
         /// <summary>
@@ -72,12 +135,15 @@ namespace Shoko.Server.API.v3.Controllers
         /// <param name="anidbID">AniDB ID</param>
         /// <returns></returns>
         [HttpGet("AniDB/{anidbID}")]
-        public ActionResult<Series.AniDB> GetSeriesAnidbDetailsByAnidbID([FromRoute] int anidbID)
+        public ActionResult<Series.AniDB> GetSeriesAnidbByAnidbID([FromRoute] int anidbID)
         {
-            var anime = RepoFactory.AniDB_Anime.GetByAnimeID(anidbID);
-            if (anime == null) return NotFound("No Series.AniDB entry for the given id");
-            if (!User.AllowedAnime(anime)) return Forbid("Accessing Series.AniDB is not allowed for the current user");
-            return new Series.AniDB(HttpContext, anime);
+            var anidb = RepoFactory.AniDB_Anime.GetByAnimeID(anidbID);
+            if (anidb == null)
+                return NotFound(AnidbNotFoundForAniDB);
+            if (!User.AllowedAnime(anidb))
+                return Forbid(AnidbForbiddenForUser);
+
+            return new Series.AniDB(HttpContext, anidb);
         }
 
         /// <summary>
@@ -86,12 +152,15 @@ namespace Shoko.Server.API.v3.Controllers
         /// <param name="anidbID">AniDB ID</param>
         /// <returns></returns>
         [HttpGet("AniDB/{anidbID}/Series")]
-        public ActionResult<Series> GetSeriesByAniDBID([FromRoute] int anidbID)
+        public ActionResult<Series> GetSeriesByAnidbID([FromRoute] int anidbID)
         {
-            var ser = RepoFactory.AnimeSeries.GetByAnimeID(anidbID);
-            if (ser == null) return BadRequest("No Series with ID");
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            return new Series(HttpContext, ser);
+            var series = RepoFactory.AnimeSeries.GetByAnimeID(anidbID);
+            if (series == null)
+                return NotFound(SeriesNotFoundWithAnidbID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
+
+            return new Series(HttpContext, series);
         }
 
         /// <summary>
@@ -104,11 +173,11 @@ namespace Shoko.Server.API.v3.Controllers
         /// <param name="immediate">Try to immediately refresh the data if we're not HTTP banned.</param>
         /// <returns>True if the refresh is done, otherwise false if it was queued.</returns>
         [HttpPost("AniDB/{anidbID}/Refresh")]
-        public ActionResult<bool> QueueAniDBRefreshFromAniDBID([FromRoute] int anidbID, [FromQuery] bool force = false, [FromQuery] bool downloadRelations = false, [FromQuery] bool? createSeriesEntry = null, [FromQuery] bool immediate = false)
+        public ActionResult<bool> RefreshAnidbByAnidbID([FromRoute] int anidbID, [FromQuery] bool force = false, [FromQuery] bool downloadRelations = false, [FromQuery] bool? createSeriesEntry = null, [FromQuery] bool immediate = false)
         {
-            if (!createSeriesEntry.HasValue) {
+            if (!createSeriesEntry.HasValue)
                 createSeriesEntry = ServerSettings.Instance.AniDb.AutomaticallyImportSeries;
-            }
+
             return Series.QueueAniDBRefresh(anidbID, force, downloadRelations, createSeriesEntry.Value, immediate);
         }
 
@@ -122,17 +191,22 @@ namespace Shoko.Server.API.v3.Controllers
         /// <param name="immediate">Try to immediately refresh the data if we're not HTTP banned.</param>
         /// <returns>True if the refresh is done, otherwise false if it was queued.</returns>
         [HttpPost("{seriesID}/AniDB/Refresh")]
-        public ActionResult<bool> QueueAniDBRefresh([FromRoute] int seriesID, [FromQuery] bool force = false, [FromQuery] bool downloadRelations = false, [FromQuery] bool? createSeriesEntry = null, [FromQuery] bool immediate = false)
+        public ActionResult<bool> RefreshAnidbBySeriesID([FromRoute] int seriesID, [FromQuery] bool force = false, [FromQuery] bool downloadRelations = false, [FromQuery] bool? createSeriesEntry = null, [FromQuery] bool immediate = false)
         {
-            if (!createSeriesEntry.HasValue) {
+            if (!createSeriesEntry.HasValue)
                 createSeriesEntry = ServerSettings.Instance.AniDb.AutomaticallyImportSeries;
-            }
-            var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (ser == null) return BadRequest("No Series with ID");
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            var anime = ser.GetAnime();
-            if (anime == null) return BadRequest("No AniDB_Anime for Series");
-            return Series.QueueAniDBRefresh(anime.AnimeID, force, downloadRelations, createSeriesEntry.Value, immediate);
+
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
+
+            var anidb = series.GetAnime();
+            if (anidb == null)
+                return InternalError(AnidbNotFoundForSeriesDB);
+
+            return Series.QueueAniDBRefresh(anidb.AnimeID, force, downloadRelations, createSeriesEntry.Value, immediate);
         }
 
         /// <summary>
@@ -141,15 +215,44 @@ namespace Shoko.Server.API.v3.Controllers
         /// <param name="seriesID">Shoko ID</param>
         /// <returns>True if the refresh is done, otherwise false if it failed.</returns>
         [HttpPost("{seriesID}/AniDB/Refresh/ForceFromXML")]
-        public ActionResult<bool> RefreshAniDBFromXML([FromRoute] int seriesID)
+        public ActionResult<bool> RefreshAnidbFromXML([FromRoute] int seriesID)
         {
-            var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (ser == null) return BadRequest("No Series with ID");
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            var anime = ser.GetAnime();
-            if (anime == null) return BadRequest("No AniDB_Anime for Series");
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
+
+            var anime = series.GetAnime();
+            if (anime == null)
+                return InternalError(AnidbNotFoundForSeriesDB);
+
             return Series.RefreshAniDBFromCachedXML(HttpContext, anime);
         }
+    
+        #endregion
+        #region TvDB
+
+        /// <summary>
+        /// Get TvDB Info for series with ID
+        /// </summary>
+        /// <param name="seriesID">Shoko ID</param>
+        /// <returns></returns>
+        [HttpGet("{seriesID}/TvDB")]
+        public ActionResult<List<Series.TvDB>> GetSeriesTvdb([FromRoute] int seriesID)
+        {
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
+
+            return Series.GetTvDBInfo(HttpContext, series);
+        }
+        
+        #endregion
+        #endregion
+        #region Vote
 
         /// <summary>
         /// Add a permanent or temprary user-submitted rating for the series.
@@ -160,32 +263,35 @@ namespace Shoko.Server.API.v3.Controllers
         [HttpPost("{seriesID}/Vote")]
         public ActionResult PostSeriesUserVote([FromRoute] int seriesID, [FromBody] Vote vote)
         {
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
+
             if (vote.Value < 0)
                 return BadRequest("Value must be greater than or equal to 0.");
             if (vote.Value > vote.MaxValue)
                 return BadRequest($"Value must be less than or equal to the set max value ({vote.MaxValue}).");
             if (vote.MaxValue <= 0)
                 return BadRequest("Max value must be an integer above 0.");
-            var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (ser == null) return BadRequest("No Series with ID");
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            Series.AddSeriesVote(HttpContext, ser, User.JMMUserID, vote);
+
+            Series.AddSeriesVote(HttpContext, series, User.JMMUserID, vote);
+
             return NoContent();
         }
+        
+        #endregion
+        #region Images
+        #region All images
 
-        /// <summary>
-        /// Get TvDB Info for series with ID
-        /// </summary>
-        /// <param name="seriesID">Shoko ID</param>
-        /// <returns></returns>
-        [HttpGet("{seriesID}/TvDB")]
-        public ActionResult<List<Series.TvDB>> GetSeriesTvDBDetails([FromRoute] int seriesID)
-        {
-            var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (ser == null) return BadRequest("No Series with ID");
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            return Series.GetTvDBInfo(HttpContext, ser);
-        }
+        private static HashSet<Image.ImageType> AllowedImageTypes = new() { Image.ImageType.Poster, Image.ImageType.Banner, Image.ImageType.Fanart };
+
+        private static string InvalidIDForSource = "Invalid image id for selected source.";
+
+        private static string InvalidImageTypeForSeries = "Invalid image type for series images.";
+
+        private static string InvalidImageIsDisabled = "Image is disabled.";
 
         /// <summary>
         /// Get all images for series with ID, optionally with Disabled images, as well.
@@ -196,300 +302,188 @@ namespace Shoko.Server.API.v3.Controllers
         [HttpGet("{seriesID}/Images")]
         public ActionResult<Images> GetSeriesImages([FromRoute] int seriesID, [FromQuery] bool includeDisabled)
         {
-            var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (ser == null) return BadRequest("No Series with ID");
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            return Series.GetArt(HttpContext, ser.AniDB_ID, includeDisabled);
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
+
+            return Series.GetArt(HttpContext, series.AniDB_ID, includeDisabled);
         }
 
-        /// <summary>
-        /// Get all images for series with ID, optionally with Disabled images, as well.
-        /// </summary>
-        /// <param name="seriesID">Shoko ID</param>
-        /// <param name="includeDisabled"></param>
-        /// <returns></returns>
-        [HttpGet("{seriesID}/Images/{IncludeDisabled}")]
-        [Obsolete]
-        public ActionResult<Images> GetSeriesImagesFromPath([FromRoute] int seriesID, [FromRoute] bool includeDisabled)
-            => GetSeriesImages(seriesID, includeDisabled);
+        #endregion
+        #region Default image
 
         /// <summary>
-        /// Get the default poster for a series.
+        /// Get the default <see cref="Image"/> for the given <paramref name="imageType"/> for the <see cref="Series"/>.
         /// </summary>
         /// <param name="seriesID">Series ID</param>
+        /// <param name="imageType">Poster, Banner, Fanart</param>
         /// <returns></returns>
-        [HttpGet("{seriesID}/Images/Poster")]
-        public ActionResult<Image> GetSeriesDefaultPoster([FromRoute] int seriesID)
+        [HttpGet("{seriesID}/Images/{imageType}")]
+        public ActionResult<Image> GetSeriesDefaultImageForType([FromRoute] int seriesID, [FromRoute] Image.ImageType imageType)
         {
             var series = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (series == null) return NotFound("No Series with ID");
-            if (!User.AllowedSeries(series)) return Forbid("Series not allowed for current user");
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
 
-            var defaultImage = Series.GetDefaultImage(series.AniDB_ID, ImageSizeType.Poster);
-            if (defaultImage != null)
-            {
-                return defaultImage;
-            }
+            if (!AllowedImageTypes.Contains(imageType))
+                return BadRequest(InvalidImageTypeForSeries);
+
+            var imageSizeType = Image.GetImageSizeTypeFromType(imageType);
+            var defaultBanner = Series.GetDefaultImage(series.AniDB_ID, imageSizeType);
+            if (defaultBanner != null)
+                return defaultBanner;
+
             var images = Series.GetArt(HttpContext, series.AniDB_ID);
-            return images.Posters.FirstOrDefault();
+            return imageSizeType switch
+            {
+                ImageSizeType.Poster => images.Posters.FirstOrDefault(),
+                ImageSizeType.WideBanner => images.Banners.FirstOrDefault(),
+                ImageSizeType.Fanart => images.Fanarts.FirstOrDefault(),
+                _ => null,
+            };
         }
 
+
         /// <summary>
-        /// Set the default poster for a series.
+        /// Set the default <see cref="Image"/> for the given <paramref name="imageType"/> for the <see cref="Series"/>.
         /// </summary>
         /// <param name="seriesID">Series ID</param>
-        /// <param name="body">The body containing the source and id used to set the poster.</param>
+        /// <param name="imageType">Poster, Banner, Fanart</param>
+        /// <param name="body">The body containing the source and id used to set.</param>
         /// <returns></returns>
-        [HttpPatch("{seriesID}/Images/Poster")]
-        public ActionResult<Image> SetSeriesDefaultPoster([FromRoute] int seriesID, [FromBody] Image.Input.DefaultImageBody body)
+        [HttpPatch("{seriesID}/Images/{imageType}")]
+        public ActionResult<Image> SetSeriesDefaultImageForType([FromRoute] int seriesID, [FromRoute] Image.ImageType imageType, [FromBody] Image.Input.DefaultImageBody body)
         {
             var series = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (series == null) return NotFound("No Series with ID");
-            if (!User.AllowedSeries(series)) return Forbid("Series not allowed for current user");
-            
-            if (!int.TryParse(body.ID, out var imageID))
-                return BadRequest("Invalid body id. Id must be a stringified int.");
-            
-            var imageEntityType = Image.GetImageTypeFromSourceAndType(body.Source, "Poster");
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
+
+            if (!AllowedImageTypes.Contains(imageType))
+                return BadRequest(InvalidImageTypeForSeries);
+
+            var imageEntityType = Image.GetImageTypeFromSourceAndType(body.Source, imageType);
             if (!imageEntityType.HasValue)
                 return BadRequest("Invalid body source");
-            
-            switch (imageEntityType.Value) {
-                case ImageEntityType.AniDB_Cover: {
+
+            // All dynamic ids are stringified ints, so extract the image id from the body.
+            if (!int.TryParse(body.ID, out var imageID))
+                return BadRequest("Invalid body id. Id must be a stringified int.");
+
+            // Check if the id is valid for the given type and source.
+
+            switch (imageEntityType.Value)
+            {
+                // Posters
+                case ImageEntityType.AniDB_Cover:
                     if (imageID != series.AniDB_ID)
-                        return BadRequest("Invalid image id for selected source and id");
+                        return BadRequest(InvalidIDForSource);
                     break;
-                }
-                case ImageEntityType.TvDB_Cover: {
-                    var poster = RepoFactory.TvDB_ImagePoster.GetByID(imageID);
-                    if (poster == null)
-                        return BadRequest("Invalid image id for selected source and id");
-                    if (poster.Enabled != 1)
-                        return BadRequest("Image is disabled");
+                case ImageEntityType.TvDB_Cover:
+                    {
+                        var tvdbPoster = RepoFactory.TvDB_ImagePoster.GetByID(imageID);
+                        if (tvdbPoster == null)
+                            return BadRequest(InvalidIDForSource);
+                        if (tvdbPoster.Enabled != 1)
+                            return BadRequest(InvalidImageIsDisabled);
+                        break;
+                    }
+                case ImageEntityType.MovieDB_Poster:
+                    var tmdbPoster = RepoFactory.MovieDB_Poster.GetByID(imageID);
+                    if (tmdbPoster == null)
+                        return BadRequest(InvalidIDForSource);
+                    if (tmdbPoster.Enabled != 1)
+                        return BadRequest(InvalidImageIsDisabled);
                     break;
-                }
-                case ImageEntityType.MovieDB_Poster: {
-                    var poster = RepoFactory.MovieDB_Poster.GetByID(imageID);
-                    if (poster == null)
-                        return BadRequest("Invalid image id for selected source and id");
-                    if (poster.Enabled != 1)
-                        return BadRequest("Image is disabled");
+
+                // Banners
+                case ImageEntityType.TvDB_Banner:
+                    var tvdbBanner = RepoFactory.TvDB_ImageWideBanner.GetByID(imageID);
+                    if (tvdbBanner == null)
+                        return BadRequest(InvalidIDForSource);
+                    if (tvdbBanner.Enabled != 1)
+                        return BadRequest(InvalidImageIsDisabled);
                     break;
-                }
+
+                // Fanart
+                case ImageEntityType.TvDB_FanArt:
+                    var tvdbFanart = RepoFactory.TvDB_ImageFanart.GetByID(imageID);
+                    if (tvdbFanart == null)
+                        return BadRequest(InvalidIDForSource);
+                    if (tvdbFanart.Enabled != 1)
+                        return BadRequest(InvalidImageIsDisabled);
+                    break;
+                case ImageEntityType.MovieDB_FanArt:
+                    var tmdbFanart = RepoFactory.MovieDB_Fanart.GetByID(imageID);
+                    if (tmdbFanart == null)
+                        return BadRequest(InvalidIDForSource);
+                    if (tmdbFanart.Enabled != 1)
+                        return BadRequest(InvalidImageIsDisabled);
+                    break;
+
+                // Not allowed.
                 default:
-                    return BadRequest("Invalid source");
+                    return BadRequest("Invalid source and/or type");
             }
 
-            var defaultImage = RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(series.AniDB_ID, ImageSizeType.Poster) ?? new() { AnimeID = series.AniDB_ID };
-
+            var imageSizeType = Image.GetImageSizeTypeFromType(imageType);
+            var defaultImage = RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(series.AniDB_ID, imageSizeType) ?? new() { AnimeID = series.AniDB_ID, ImageType = (int)imageSizeType };
             defaultImage.ImageParentID = imageID;
-            defaultImage.ImageParentType = (int) imageEntityType.Value;
-            defaultImage.ImageType = (int) ImageSizeType.Poster;
+            defaultImage.ImageParentType = (int)imageEntityType.Value;
+
+            // Create or update the entry.
             RepoFactory.AniDB_Anime_DefaultImage.Save(defaultImage);
-            return new Image(imageID, imageEntityType.Value, true);
-        }
 
-        /// <summary>
-        /// Unset the default poster for a series.
-        /// </summary>
-        /// <param name="seriesID">Series ID</param>
-        /// <returns></returns>
-        [HttpDelete("{seriesID}/Images/Poster")]
-        public ActionResult DeleteSeriesDefaultPoster([FromRoute] int seriesID)
-        {
-            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (series == null) return NotFound("No Series with ID");
-            if (!User.AllowedSeries(series)) return Forbid("Series not allowed for current user");
-
-            var defaultImage = RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(series.AniDB_ID, ImageSizeType.Poster);
-            if (defaultImage == null)
-                return BadRequest("No default poster.");
-
-            RepoFactory.AniDB_Anime_DefaultImage.Delete(defaultImage);
-            
             // Update the contract data (used by Shoko Desktop).
             RepoFactory.AnimeSeries.Save(series, false);
-            return NoContent();
-        }
 
-        /// <summary>
-        /// Get the default banner for a series.
-        /// </summary>
-        /// <param name="seriesID">Series ID</param>
-        /// <returns></returns>
-        [HttpGet("{seriesID}/Images/Banner")]
-        public ActionResult<Image> GetSeriesDefaultBanner([FromRoute] int seriesID)
-        {
-            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (series == null) return NotFound("No Series with ID");
-            if (!User.AllowedSeries(series)) return Forbid("Series not allowed for current user");
-
-            var defaultBanner = Series.GetDefaultImage(series.AniDB_ID, ImageSizeType.WideBanner);
-            if (defaultBanner != null)
-            {
-                return defaultBanner;
-            }
-            var images = Series.GetArt(HttpContext, series.AniDB_ID);
-            return images.Banners.FirstOrDefault();
-        }
-
-        /// <summary>
-        /// Set the default banner for a series.
-        /// </summary>
-        /// <param name="seriesID">Series ID</param>
-        /// <param name="body">The body containing the source and id used to set the banner.</param>
-        /// <returns></returns>
-        [HttpPatch("{seriesID}/Images/Banner")]
-        public ActionResult<Image> SetSeriesDefaultBanner([FromRoute] int seriesID, [FromBody] Image.Input.DefaultImageBody body)
-        {
-            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (series == null) return NotFound("No Series with ID");
-            if (!User.AllowedSeries(series)) return Forbid("Series not allowed for current user");
-            
-            if (!int.TryParse(body.ID, out var imageID))
-                return BadRequest("Invalid body id. Id must be a stringified int.");
-            
-            var imageEntityType = Image.GetImageTypeFromSourceAndType(body.Source, "Banner");
-            if (!imageEntityType.HasValue)
-                return BadRequest("Invalid body source");
-            
-            switch (imageEntityType.Value) {
-                case ImageEntityType.TvDB_Banner:
-                    var wideBanner = RepoFactory.TvDB_ImageWideBanner.GetByID(imageID);
-                    if (wideBanner == null)
-                        return BadRequest("Invalid image id for selected source and id");
-                    if (wideBanner.Enabled != 1)
-                        return BadRequest("Image is disabled");
-                    break;
-                default:
-                    return BadRequest("Invalid source");
-            }
-
-            var defaultImage = RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(series.AniDB_ID, ImageSizeType.WideBanner) ?? new() { AnimeID = series.AniDB_ID };
-
-            defaultImage.ImageParentID = imageID;
-            defaultImage.ImageParentType = (int) imageEntityType.Value;
-            defaultImage.ImageType = (int) ImageSizeType.WideBanner;
-            RepoFactory.AniDB_Anime_DefaultImage.Save(defaultImage);
             return new Image(imageID, imageEntityType.Value, true);
         }
 
         /// <summary>
-        /// Unset the default banner for a series.
+        /// Unset the default <see cref="Image"/> for the given <paramref name="imageType"/> for the <see cref="Series"/>.
         /// </summary>
         /// <param name="seriesID"></param>
+        /// <param name="imageType">Poster, Banner, Fanart</param>
         /// <returns></returns>
-        [HttpDelete("{seriesID}/Images/Banner")]
-        public ActionResult DeleteSeriesDefaultBanner([FromRoute] int seriesID)
+        [HttpDelete("{seriesID}/Images/{imageType}")]
+        public ActionResult DeleteSeriesDefaultImageForType([FromRoute] int seriesID, [FromRoute] Image.ImageType imageType)
         {
+            // Check if the series exists and if the user can access the series.
             var series = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (series == null) return NotFound("No Series with ID");
-            if (!User.AllowedSeries(series)) return Forbid("Series not allowed for current user");
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
 
-            var defaultImage = RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(series.AniDB_ID, ImageSizeType.WideBanner);
+            // Check if
+            if (!AllowedImageTypes.Contains(imageType))
+                return BadRequest(InvalidImageTypeForSeries);
+
+            // Check if a default image is set.
+            var imageSizeType = Image.GetImageSizeTypeFromType(imageType);
+            var defaultImage = RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(series.AniDB_ID, imageSizeType);
             if (defaultImage == null)
                 return BadRequest("No default banner.");
 
+            // Delete the entry.
             RepoFactory.AniDB_Anime_DefaultImage.Delete(defaultImage);
-            
+
             // Update the contract data (used by Shoko Desktop).
             RepoFactory.AnimeSeries.Save(series, false);
+
+            // Don't return any content.
             return NoContent();
-        }
-
-        /// <summary>
-        /// Get the default fanart for the series.
-        /// </summary>
-        /// <param name="seriesID">Series ID</param>
-        /// <returns></returns>
-        [HttpGet("{seriesID}/Images/Fanart")]
-        public ActionResult<Image> GetSeriesDefaultFanart([FromRoute] int seriesID)
-        {
-            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (series == null) return NotFound("No Series with ID");
-            if (!User.AllowedSeries(series)) return Forbid("Series not allowed for current user");
-
-            var defaultImage = Series.GetDefaultImage(series.AniDB_ID, ImageSizeType.Fanart);
-            if (defaultImage != null)
-            {
-                return defaultImage;
-            }
-            var images = Series.GetArt(HttpContext, series.AniDB_ID);
-            return images.Fanarts.FirstOrDefault();
         }
         
-        /// <summary>
-        /// Set the default fanart for the series.
-        /// </summary>
-        /// <param name="seriesID">Series ID</param>
-        /// <param name="body"></param>
-        /// <returns></returns>
-        [HttpPatch("{seriesID}/Images/Fanart")]
-        public ActionResult<Image> SetSeriesDefaultFanart([FromRoute] int seriesID, [FromBody] Image.Input.DefaultImageBody body)
-        {
-            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (series == null) return NotFound("No Series with ID");
-            if (!User.AllowedSeries(series)) return Forbid("Series not allowed for current user");
-            
-            if (!int.TryParse(body.ID, out var imageID))
-                return BadRequest("Invalid body id. Id must be a stringified int.");
-            
-            var imageEntityType = Image.GetImageTypeFromSourceAndType(body.Source, "Fanart");
-            if (!imageEntityType.HasValue)
-                return BadRequest("Invalid body source");
-            
-            switch (imageEntityType.Value) {
-                case ImageEntityType.TvDB_FanArt: {
-                    var fanart = RepoFactory.TvDB_ImageFanart.GetByID(imageID);
-                    if (fanart == null)
-                        return BadRequest("Invalid image id for selected source and id");
-                    if (fanart.Enabled != 1)
-                        return BadRequest("Image is disabled");
-                    break;
-                }
-                case ImageEntityType.MovieDB_FanArt: {
-                    var fanart = RepoFactory.MovieDB_Fanart.GetByID(imageID);
-                    if (fanart == null)
-                        return BadRequest("Invalid image id for selected source and id");
-                    if (fanart.Enabled != 1)
-                        return BadRequest("Image is disabled");
-                    break;
-                }
-                default:
-                    return BadRequest("Invalid source");
-            }
-
-            var defaultImage = RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(series.AniDB_ID, ImageSizeType.Fanart) ?? new() { AnimeID = series.AniDB_ID };
-
-            defaultImage.ImageParentID = imageID;
-            defaultImage.ImageParentType = (int) imageEntityType.Value;
-            defaultImage.ImageType = (int) ImageSizeType.Fanart;
-            RepoFactory.AniDB_Anime_DefaultImage.Save(defaultImage);
-            return new Image(imageID, imageEntityType.Value, true);
-        }
-
-        /// <summary>
-        /// Unset the default fanart for the series.
-        /// </summary>
-        /// <param name="seriesID"></param>
-        /// <returns></returns>
-        [HttpDelete("{seriesID}/Images/Fanart")]
-        public ActionResult DeleteSeriesDefaultFanart([FromRoute] int seriesID)
-        {
-            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (series == null) return NotFound("No Series with ID");
-            if (!User.AllowedSeries(series)) return Forbid("Series not allowed for current user");
-
-            var defaultImage = RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(series.AniDB_ID, ImageSizeType.Fanart);
-            if (defaultImage == null)
-                return BadRequest("No default Fanart.");
-
-            RepoFactory.AniDB_Anime_DefaultImage.Delete(defaultImage);
-            
-            // Update the contract data (used by Shoko Desktop).
-            RepoFactory.AnimeSeries.Save(series, false);
-            return NoContent();
-        }
+        #endregion
+        #endregion
+        #region Tags
 
         /// <summary>
         /// Get tags for Series with ID, optionally applying the given <see cref="TagFilter.Filter" />
@@ -501,12 +495,16 @@ namespace Shoko.Server.API.v3.Controllers
         [HttpGet("{seriesID}/Tags")]
         public ActionResult<List<Tag>> GetSeriesTags([FromRoute] int seriesID, [FromQuery] TagFilter.Filter filter = 0, [FromQuery] bool excludeDescriptions = false)
         {
-            var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (ser == null) return BadRequest("No Series with ID");
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            var anime = ser.GetAnime();
-            if (anime == null) return BadRequest("No AniDB_Anime for Series");
-            return Series.GetTags(HttpContext, anime, filter, excludeDescriptions);
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
+
+            var anidb = series.GetAnime();
+            if (anidb == null) return new List<Tag>();
+
+            return Series.GetTags(HttpContext, anidb, filter, excludeDescriptions);
         }
 
         /// <summary>
@@ -522,6 +520,9 @@ namespace Shoko.Server.API.v3.Controllers
         public ActionResult<List<Tag>> GetSeriesTagsFromPath([FromRoute] int seriesID, [FromRoute] TagFilter.Filter filter, [FromQuery] bool excludeDescriptions = false)
             => GetSeriesTags(seriesID, filter, excludeDescriptions);
 
+        #endregion
+        #region Cast
+
         /// <summary>
         /// Get the cast listing for series with ID
         /// </summary>
@@ -531,47 +532,44 @@ namespace Shoko.Server.API.v3.Controllers
         [HttpGet("{seriesID}/Cast")]
         public ActionResult<List<Role>> GetSeriesCast([FromRoute] int seriesID, [FromQuery] Role.CreatorRoleType? roleType = null)
         {
-            var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (ser == null) return BadRequest("No Series with ID");
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            return Series.GetCast(HttpContext, ser.AniDB_ID, roleType);
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
+
+            return Series.GetCast(HttpContext, series.AniDB_ID, roleType);
         }
 
+        #endregion
+        #region Group
+        
         /// <summary>
         /// Move the series to a new group, and update accordingly
         /// </summary>
         /// <param name="seriesID">Shoko ID</param>
-        /// <param name="newGroupID"></param>
-        /// <returns></returns>
-        [HttpPatch("{seriesID}/Move/{newGroupID}")]
-        public ActionResult MoveSeries([FromRoute] int seriesID, int newGroupID)
-        {
-            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (series == null) return BadRequest("No Series with ID");
-            var grp = RepoFactory.AnimeGroup.GetByID(newGroupID);
-            if (grp == null) return BadRequest("No Group with ID");
-            series.MoveSeries(grp);
-            return Ok();
-        }
-
-        /// <summary>
-        /// Delete a Series
-        /// </summary>
-        /// <param name="seriesID">The ID of the Series</param>
-        /// <param name="deleteFiles">Whether to delete all of the files in the series from the disk.</param>
+        /// <param name="groupID"></param>
         /// <returns></returns>
         [Authorize("admin")]
-        [HttpDelete("{seriesID}")]
-        public ActionResult DeleteSeries([FromRoute] int seriesID, [FromQuery] bool deleteFiles = false)
+        [HttpPatch("{seriesID}/Move/{groupID}")]
+        public ActionResult MoveSeries([FromRoute] int seriesID, [FromRoute] int groupID)
         {
             var series = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (series == null) return BadRequest("No Series with ID");
+            if (series == null)
+                return NotFound(SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesForbiddenForUser);
 
-            series.DeleteSeries(deleteFiles, true);
+            var group = RepoFactory.AnimeGroup.GetByID(groupID);
+            if (group == null)
+                return BadRequest("No Group entry for the given groupID");
+
+            series.MoveSeries(group);
 
             return Ok();
         }
 
+        #endregion
         #region Search
 
         /// <summary>
@@ -643,7 +641,7 @@ namespace Shoko.Server.API.v3.Controllers
 
             return seriesList;
         }
-        
+
         /// <summary>
         /// Search the title dump for the given query or directly using the anidb id.
         /// </summary>
@@ -651,7 +649,7 @@ namespace Shoko.Server.API.v3.Controllers
         /// <param name="includeTitles">Include titles</param>
         /// <returns></returns>
         [HttpGet("AniDB/Search/{query}")]
-        public List<Series.AniDBSearchResult> OnlineAnimeTitleSearch([FromRoute] string query, [FromQuery] bool includeTitles = true)
+        public ActionResult<List<Series.AniDBSearchResult>> OnlineAnimeTitleSearch([FromRoute] string query, [FromQuery] bool includeTitles = true)
         {
             List<Series.AniDBSearchResult> list = new List<Series.AniDBSearchResult>();
 
@@ -736,7 +734,7 @@ namespace Shoko.Server.API.v3.Controllers
         /// <param name="limit"></param>
         /// <returns></returns>
         [HttpGet("StartsWith/{query}")]
-        public ActionResult<List<SeriesSearchResult>> StartsWith([FromRoute] string query, int limit = int.MaxValue)
+        public ActionResult<List<SeriesSearchResult>> StartsWith([FromRoute] string query, [FromQuery] int limit = int.MaxValue)
         {
             query = query.ToLowerInvariant();
 
@@ -787,7 +785,7 @@ namespace Shoko.Server.API.v3.Controllers
                 .Where(ser => ser == null || User.AllowedSeries(ser)).Select(a => new Series(HttpContext, a)).ToList();
         }
 
-        #region internal function
+        #region Helpers
 
         /// <summary>
         /// function used in fuzzy search

--- a/Shoko.Server/API/v3/Controllers/SeriesController.cs
+++ b/Shoko.Server/API/v3/Controllers/SeriesController.cs
@@ -83,11 +83,14 @@ namespace Shoko.Server.API.v3.Controllers
         /// Queue a refresh of the AniDB Info for series with AniDB ID
         /// </summary>
         /// <param name="anidbID">AniDB ID</param>
+        /// <param name="force">Forcefully retrive updated data from AniDB</param>
+        /// <param name="downloadRelations">Download relations for the series</param>
+        /// <param name="createSeriesEntry">Create a Shoko Series entry if it doesn't exist</param>
         /// <returns></returns>
         [HttpPost("AniDB/{anidbID}/Refresh")]
-        public ActionResult QueueAniDBRefreshFromAniDBID([FromRoute] int anidbID)
+        public ActionResult QueueAniDBRefreshFromAniDBID([FromRoute] int anidbID, [FromQuery] bool force = false, [FromQuery] bool downloadRelations = false, [FromQuery] bool createSeriesEntry = false)
         {
-            Series.QueueAniDBRefresh(anidbID);
+            Series.QueueAniDBRefresh(anidbID, force, downloadRelations, createSeriesEntry);
             return NoContent();
         }
 
@@ -95,16 +98,18 @@ namespace Shoko.Server.API.v3.Controllers
         /// Queue a refresh of the AniDB Info for series with ID
         /// </summary>
         /// <param name="seriesID">Shoko ID</param>
+        /// <param name="force">Forcefully retrive updated data from AniDB</param>
+        /// <param name="downloadRelations">Download relations for the series</param>
         /// <returns></returns>
         [HttpPost("{seriesID}/AniDB/Refresh")]
-        public ActionResult QueueAniDBRefresh([FromRoute] int seriesID)
+        public ActionResult QueueAniDBRefresh([FromRoute] int seriesID, [FromQuery] bool force = false, [FromQuery] bool downloadRelations = false)
         {
             var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
             if (ser == null) return BadRequest("No Series with ID");
             if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
             var anime = ser.GetAnime();
             if (anime == null) return BadRequest("No AniDB_Anime for Series");
-            Series.QueueAniDBRefresh(anime.AnimeID);
+            Series.QueueAniDBRefresh(anime.AnimeID, force, downloadRelations, false);
             return NoContent();
         }
 
@@ -113,7 +118,7 @@ namespace Shoko.Server.API.v3.Controllers
         /// </summary>
         /// <param name="seriesID">Shoko ID</param>
         /// <returns></returns>
-        [HttpGet("{seriesID}/AniDB/ForceRefreshFromXML")]
+        [HttpPost("{seriesID}/AniDB/Refresh/ForceFromXML")]
         public ActionResult RefreshAniDBFromXML([FromRoute] int seriesID)
         {
             var ser = RepoFactory.AnimeSeries.GetByID(seriesID);

--- a/Shoko.Server/API/v3/Controllers/SeriesController.cs
+++ b/Shoko.Server/API/v3/Controllers/SeriesController.cs
@@ -86,12 +86,12 @@ namespace Shoko.Server.API.v3.Controllers
         /// <param name="force">Forcefully retrive updated data from AniDB</param>
         /// <param name="downloadRelations">Download relations for the series</param>
         /// <param name="createSeriesEntry">Create a Shoko Series entry if it doesn't exist</param>
-        /// <returns></returns>
+        /// <param name="immediate">Try to immediately refresh the data if we're not HTTP banned.</param>
+        /// <returns>True if the refresh is done, otherwise false</returns>
         [HttpPost("AniDB/{anidbID}/Refresh")]
-        public ActionResult QueueAniDBRefreshFromAniDBID([FromRoute] int anidbID, [FromQuery] bool force = false, [FromQuery] bool downloadRelations = false, [FromQuery] bool createSeriesEntry = false)
+        public ActionResult<bool> QueueAniDBRefreshFromAniDBID([FromRoute] int anidbID, [FromQuery] bool force = false, [FromQuery] bool downloadRelations = false, [FromQuery] bool createSeriesEntry = false, [FromQuery] bool immediate = false)
         {
-            Series.QueueAniDBRefresh(anidbID, force, downloadRelations, createSeriesEntry);
-            return NoContent();
+            return Series.QueueAniDBRefresh(anidbID, force, downloadRelations, createSeriesEntry, immediate);
         }
 
         /// <summary>
@@ -100,34 +100,33 @@ namespace Shoko.Server.API.v3.Controllers
         /// <param name="seriesID">Shoko ID</param>
         /// <param name="force">Forcefully retrive updated data from AniDB</param>
         /// <param name="downloadRelations">Download relations for the series</param>
-        /// <returns></returns>
+        /// <param name="immediate">Try to immediately refresh the data if we're not HTTP banned.</param>
+        /// <returns>True if the refresh is done, otherwise false</returns>
         [HttpPost("{seriesID}/AniDB/Refresh")]
-        public ActionResult QueueAniDBRefresh([FromRoute] int seriesID, [FromQuery] bool force = false, [FromQuery] bool downloadRelations = false)
+        public ActionResult<bool> QueueAniDBRefresh([FromRoute] int seriesID, [FromQuery] bool force = false, [FromQuery] bool downloadRelations = false, [FromQuery] bool immediate = false)
         {
             var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
             if (ser == null) return BadRequest("No Series with ID");
             if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
             var anime = ser.GetAnime();
             if (anime == null) return BadRequest("No AniDB_Anime for Series");
-            Series.QueueAniDBRefresh(anime.AnimeID, force, downloadRelations, false);
-            return NoContent();
+            return Series.QueueAniDBRefresh(anime.AnimeID, force, downloadRelations, false, immediate);
         }
 
         /// <summary>
         /// Forcefully refresh the AniDB Info from XML on disk for series with ID
         /// </summary>
         /// <param name="seriesID">Shoko ID</param>
-        /// <returns></returns>
+        /// <returns>True if the refresh is done, otherwise false</returns>
         [HttpPost("{seriesID}/AniDB/Refresh/ForceFromXML")]
-        public ActionResult RefreshAniDBFromXML([FromRoute] int seriesID)
+        public ActionResult<bool> RefreshAniDBFromXML([FromRoute] int seriesID)
         {
             var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
             if (ser == null) return BadRequest("No Series with ID");
             if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
             var anime = ser.GetAnime();
             if (anime == null) return BadRequest("No AniDB_Anime for Series");
-            Series.RefreshAniDBFromCachedXML(HttpContext, anime);
-            return NoContent();
+            return Series.RefreshAniDBFromCachedXML(HttpContext, anime);
         }
 
         /// <summary>

--- a/Shoko.Server/API/v3/Controllers/TreeController.cs
+++ b/Shoko.Server/API/v3/Controllers/TreeController.cs
@@ -75,7 +75,7 @@ namespace Shoko.Server.API.v3.Controllers
 
             return f.SeriesIds[User.JMMUserID].Select(id => RepoFactory.AnimeSeries.GetByID(id))
                 .Where(ser => ser?.AnimeGroupID == groupID).Select(ser => new Series(HttpContext, ser)).OrderBy(a =>
-                    Series.GetAniDBInfo(HttpContext, RepoFactory.AniDB_Anime.GetByAnimeID(a.IDs.ID)).AirDate)
+                    new Series.AniDB(HttpContext, RepoFactory.AniDB_Anime.GetByAnimeID(a.IDs.ID)).AirDate)
                 .ToList();
         }
         

--- a/Shoko.Server/API/v3/Controllers/TreeController.cs
+++ b/Shoko.Server/API/v3/Controllers/TreeController.cs
@@ -221,9 +221,10 @@ namespace Shoko.Server.API.v3.Controllers
         /// </remarks>
         /// <param name="groupID"><see cref="Group"/> ID</param>
         /// <param name="recursive">Show all the <see cref="Series"/> within the <see cref="Group"/></param>
+        /// <param name="includeMissing">Include series with missing episodes in the list.</param>
         /// <returns></returns>
         [HttpGet("Group/{groupID}/Series")]
-        public ActionResult<List<Series>> GetSeriesInGroup([FromRoute] int groupID, [FromQuery] bool recursive = false)
+        public ActionResult<List<Series>> GetSeriesInGroup([FromRoute] int groupID, [FromQuery] bool recursive = false, [FromQuery] bool includeMissing = false)
         {
             // Check if the group exists.
             var group = RepoFactory.AnimeGroup.GetByID(groupID);
@@ -234,6 +235,7 @@ namespace Shoko.Server.API.v3.Controllers
                 .Where(a => User.AllowedSeries(a))
                 .OrderBy(OrderByAirDate)
                 .Select(series => new Series(HttpContext, series))
+                .Where(series => series.Size > 0 || includeMissing)
                 .ToList();
         }
 
@@ -289,7 +291,6 @@ namespace Shoko.Server.API.v3.Controllers
                 .Select(file => new File.FileDetailed(file))
                 .ToList();
         }
-
 
         #endregion
         #region Ordering helpers

--- a/Shoko.Server/API/v3/Controllers/TreeController.cs
+++ b/Shoko.Server/API/v3/Controllers/TreeController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
@@ -6,6 +7,7 @@ using Shoko.Models.Enums;
 using Shoko.Server.API.Annotations;
 using Shoko.Server.API.v3.Helpers;
 using Shoko.Server.API.v3.Models.Shoko;
+using Shoko.Server.Models;
 using Shoko.Server.Repositories;
 
 namespace Shoko.Server.API.v3.Controllers
@@ -18,81 +20,302 @@ namespace Shoko.Server.API.v3.Controllers
     [Authorize]
     public class TreeController : BaseController
     {
-        
+        #region Filter
+
         /// <summary>
-        /// Get All Filters
+        /// Get a list of all the sub-<see cref="Filter"/> for the <see cref="Filter"/> with the given <paramref name="filterID"/>.
         /// </summary>
+        /// <remarks>
+        /// The <see cref="Filter"/> must have <see cref="Filter.Directory"/> set to true to use
+        /// this endpoint.
+        /// </remarks>
+        /// <param name="filterID"><see cref="Filter"/> ID</param>
+        /// <param name="page">The page index.</param>
+        /// <param name="pageSize">The page size. Set to <code>0</code> to disable pagination.</param>
         /// <returns></returns>
-        [HttpGet("Filter")]
-        public ActionResult<List<Filter>> GetFilters(bool includeEmpty = false, bool includeInvisible = false)
+        [HttpGet("Filter/{filterID}/Filter")]
+        public ActionResult<List<Filter>> GetSubFilters(int filterID, [FromQuery] int page = 0, [FromQuery] int pageSize = 50)
         {
-            var fs = RepoFactory.GroupFilter.GetTopLevel();
-            return fs.Where(a =>
-                {
-                    if (a.InvisibleInClients != 0 && !includeInvisible) return false;
-                    if (a.GroupsIds.ContainsKey(User.JMMUserID) && a.GroupsIds[User.JMMUserID].Count > 0 || includeEmpty)
-                        return true;
-                    return ((GroupFilterType) a.FilterType).HasFlag(GroupFilterType.Directory);
-                })
-                .Select(a => new Filter(HttpContext, a)).OrderBy(a => a.Name).ToList();
-        }
-        
-        /// <summary>
-        /// Get groups for filter with ID
-        /// </summary>
-        /// <returns></returns>
-        [HttpGet("Filter/{filterID}/Group")]
-        public ActionResult<List<Group>> GetGroups(int filterID)
-        {
-            var f = RepoFactory.GroupFilter.GetByID(filterID);
-            if (f == null) return BadRequest("No Filter with ID");
-            if (!f.GroupsIds.ContainsKey(User.JMMUserID)) return new List<Group>();
-            return f.GroupsIds[User.JMMUserID].Select(a => RepoFactory.AnimeGroup.GetByID(a))
-                .Where(a => a != null).GroupFilterSort(f).Select(a => new Group(HttpContext, a)).ToList();
-        }
-        
-        /// <summary>
-        /// Get series for group with ID. Pass a <see cref="filterID"/> of 0 to apply no filtering
-        /// </summary>
-        /// <returns></returns>
-        [HttpGet("Filter/{filterID}/Group/{groupID}/Series")]
-        public ActionResult<List<Series>> GetSeries(int filterID, int groupID)
-        {
-            var grp = RepoFactory.AnimeGroup.GetByID(groupID);
-            if (grp == null) return BadRequest("No Group with ID");
-            if (filterID == 0)
-                return grp.GetSeries().Where(a => User.AllowedSeries(a)).Select(a => new Series(HttpContext, a))
-                    .ToList();
+            var groupFilter = RepoFactory.GroupFilter.GetByID(filterID);
+            if (groupFilter == null)
+                return NotFound(FilterController.FilterNotFound);
 
-            var f = RepoFactory.GroupFilter.GetByID(filterID);
-            if (f == null) return BadRequest("No Filter with ID");
+            if (!((GroupFilterType)groupFilter.FilterType).HasFlag(GroupFilterType.Directory))
+                return BadRequest("Filter contains no sub-filters.");
 
-            if (f.ApplyToSeries != 1)
-                return grp.GetSeries().Where(a => User.AllowedSeries(a)).Select(a => new Series(HttpContext, a))
-                    .ToList();
+            IEnumerable<SVR_GroupFilter> subGroupFilters = RepoFactory.GroupFilter.GetByParentID(filterID)
+                .OrderBy(OrderByName);
 
-            if (!f.SeriesIds.ContainsKey(User.JMMUserID)) return new List<Series>();
+            if (pageSize > 0)
+                subGroupFilters = subGroupFilters
+                    .Skip(page > 0 ? page * pageSize : 0)
+                    .Take(pageSize);
 
-            return f.SeriesIds[User.JMMUserID].Select(id => RepoFactory.AnimeSeries.GetByID(id))
-                .Where(ser => ser?.AnimeGroupID == groupID).Select(ser => new Series(HttpContext, ser)).OrderBy(a =>
-                    new Series.AniDB(HttpContext, RepoFactory.AniDB_Anime.GetByAnimeID(a.IDs.ID)).AirDate)
+            return subGroupFilters
+                .Select(f => new Filter(HttpContext, f))
                 .ToList();
         }
-        
+
         /// <summary>
-        /// Get Episodes for Series with seriesID. Filter or group info is irrelevant at this level
+        /// Get a paginated list of all the top-level <see cref="Group"/>s for the <see cref="Filter"/> with the given <paramref name="filterID"/>.
         /// </summary>
+        /// <param name="filterID"><see cref="Filter"/> ID</param>
+        /// <param name="page">The page index.</param>
+        /// <param name="pageSize">The page size. Set to <code>0</code> to disable pagination.</param>
+        /// <returns></returns>
+        [HttpGet("Filter/{filterID}/Group")]
+        public ActionResult<List<Group>> GetFilteredGroups([FromRoute] int filterID, [FromQuery] int page = 0, [FromQuery] int pageSize = 0)
+        {
+            // Return the top level groups with no filter.
+            IEnumerable<SVR_AnimeGroup> groups;
+            if (filterID == 0)
+            {
+                groups = RepoFactory.AnimeGroup.GetAll()
+                    .Where(group => group.AnimeGroupParentID.HasValue && User.AllowedGroup(group))
+                    .OrderBy(OrderByName);
+            }
+            else
+            {
+                var groupFilter = RepoFactory.GroupFilter.GetByID(filterID);
+                if (groupFilter == null)
+                    return NotFound(FilterController.FilterNotFound);
+
+                // Fast path when user is not in the filter
+                if (!groupFilter.GroupsIds.TryGetValue(User.JMMUserID, out var groupIds))
+                    return new List<Group>();
+
+                groups = groupIds
+                    .Select(group => RepoFactory.AnimeGroup.GetByID(group))
+                    .Where(group => group != null)
+                    .OrderByGroupFilter(groupFilter);
+            }
+
+            if (pageSize > 0)
+                groups = groups
+                    .Skip(page > 0 ? page * pageSize : 0)
+                    .Take(pageSize);
+
+            return groups
+                .Select(group => new Group(HttpContext, group))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Get a list of all the sub-<see cref="Group"/>s belonging to the <see cref="Group"/> with the given <paramref name="groupID"/> and which are present within the <see cref="Filter"/> with the given <paramref name="filterID"/>.
+        /// </summary>
+        /// <param name="filterID"><see cref="Filter"/> ID</param>
+        /// <param name="groupID"><see cref="Group"/> ID</param>
+        /// <returns></returns>
+        [HttpGet("Filter/{filterID}/Group/{groupID}/Group")]
+        public ActionResult<List<Group>> GetFilteredSubGroups([FromRoute] int filterID, [FromRoute] int groupID)
+        {
+            // Return sub-groups with no group filter applied.
+            if (filterID == 0)
+                return GetSubGroups(groupID);
+
+            var groupFilter = RepoFactory.GroupFilter.GetByID(filterID);
+            if (groupFilter == null)
+                return NotFound(FilterController.FilterNotFound);
+
+            // Check if the group exists.
+            var group = RepoFactory.AnimeGroup.GetByID(groupID);
+            if (group == null)
+                return NotFound(GroupController.GroupNotFound);
+
+
+            if (!groupFilter.SeriesIds.TryGetValue(User.JMMUserID, out var seriesIDs))
+                seriesIDs = new();
+
+            return group.GetChildGroups()
+                .Where(subGroup =>
+                {
+                    if (subGroup == null)
+                        return false;
+
+                    if (User.AllowedGroup(subGroup))
+                        return false;
+
+                    if (groupFilter.ApplyToSeries != 1)
+                        return true;
+
+                    return subGroup.GetAllSeries().Any(series => seriesIDs.Contains(series.AnimeSeriesID));
+                })
+                .OrderByGroupFilter(groupFilter)
+                .Select(group => new Group(HttpContext, group))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Get a list of all the <see cref="Series"/> for the <see cref="Group"/> within the <see cref="Filter"/>.
+        /// </summary>
+        /// <remarks>
+        ///  Pass a <paramref name="filterID"/> of <code>0</code> to disable filter or .
+        /// </remarks>
+        /// <param name="filterID"><see cref="Filter"/> ID</param>
+        /// <param name="groupID"><see cref="Group"/> ID</param>
+        /// <param name="recursive">Show all the <see cref="Series"/> within the <see cref="Group"/>. Even the <see cref="Series"/> within the sub-<see cref="Group"/>s.</param>
+        /// <returns></returns>
+        [HttpGet("Filter/{filterID}/Group/{groupID}/Series")]
+        public ActionResult<List<Series>> GetSeriesInFilteredGroup([FromRoute] int filterID, [FromRoute] int groupID, [FromQuery] bool recursive = false)
+        {
+            // Return the groups with no group filter applied.
+            if (filterID == 0)
+                return GetSeriesInGroup(groupID, recursive);
+
+            // Check if the group filter exists.
+            var groupFilter = RepoFactory.GroupFilter.GetByID(filterID);
+            if (groupFilter == null)
+                return NotFound(FilterController.FilterNotFound);
+
+            // Check if the group exists.
+            var group = RepoFactory.AnimeGroup.GetByID(groupID);
+            if (group == null)
+                return NotFound(GroupController.GroupNotFound);
+
+            if (groupFilter.ApplyToSeries != 1)
+                return (recursive ? group.GetAllSeries() : group.GetSeries())
+                    .Where(series => User.AllowedSeries(series))
+                    .OrderBy(OrderByAirDate)
+                    .Select(series => new Series(HttpContext, series))
+                    .ToList();
+
+            if (!groupFilter.SeriesIds.TryGetValue(User.JMMUserID, out var seriesIDs))
+                return new List<Series>();
+
+            return (recursive ? group.GetAllSeries() : group.GetSeries())
+                .Where(series => seriesIDs.Contains(series.AnimeSeriesID))
+                .OrderBy(OrderByAirDate)
+                .Select(series => new Series(HttpContext, series))
+                .ToList();
+        }
+
+        #endregion
+        #region Group
+
+        /// <summary>
+        /// Get a list of sub-<see cref="Group"/>s a the <see cref="Group"/>.
+        /// </summary>
+        /// <param name="groupID"></param>
+        /// <returns></returns>
+        [HttpGet("Group/{groupID}/Group")]
+        public ActionResult<List<Group>> GetSubGroups([FromRoute] int groupID)
+        {
+            // Check if the group exists.
+            var group = RepoFactory.AnimeGroup.GetByID(groupID);
+            if (group == null)
+                return NotFound(GroupController.GroupNotFound);
+
+            return group.GetChildGroups()
+                .Where(a => User.AllowedGroup(a))
+                .OrderBy(OrderByName)
+                .Select(series => new Group(HttpContext, series))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Get a list of <see cref="Series"/> within a <see cref="Group"/>.
+        /// </summary>
+        /// <remarks>
+        /// It will return all the <see cref="Series"/> within the group and all sub-groups if
+        /// <paramref name="recursive"/> is set to <code>true</code>.
+        /// </remarks>
+        /// <param name="groupID"><see cref="Group"/> ID</param>
+        /// <param name="recursive">Show all the <see cref="Series"/> within the <see cref="Group"/></param>
+        /// <returns></returns>
+        [HttpGet("Group/{groupID}/Series")]
+        public ActionResult<List<Series>> GetSeriesInGroup([FromRoute] int groupID, [FromQuery] bool recursive = false)
+        {
+            // Check if the group exists.
+            var group = RepoFactory.AnimeGroup.GetByID(groupID);
+            if (group == null)
+                return NotFound(GroupController.GroupNotFound);
+
+            return (recursive ? group.GetAllSeries() : group.GetSeries())
+                .Where(a => User.AllowedSeries(a))
+                .OrderBy(OrderByAirDate)
+                .Select(series => new Series(HttpContext, series))
+                .ToList();
+        }
+
+        #endregion
+        #region Series
+
+        /// <summary>
+        /// Get the <see cref="Episode"/>s for the <see cref="Series"/> with <paramref name="seriesID"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Filter"/> or <see cref="Group"/> is irrelevant at this level.
+        /// </remarks>
+        /// <param name="seriesID">Series ID</param>
+        /// <param name="includeMissing">Include missing episodes in the list.</param>
         /// <returns></returns>
         [HttpGet("Series/{seriesID}/Episode")]
-        public ActionResult<List<Episode>> GetEpisodes(int seriesID, bool includeMissing = false)
+        public ActionResult<List<Episode>> GetEpisodes([FromRoute] int seriesID, [FromQuery] bool includeMissing = false)
         {
-            var ser = RepoFactory.AnimeSeries.GetByID(seriesID);
-            if (ser == null) return BadRequest("No Series with ID");
-            if (!User.AllowedSeries(ser)) return BadRequest("Series not allowed for current user");
-            return ser.GetAnimeEpisodes().Select(a => new Episode(HttpContext, a))
-                .Where(a => a.Size > 0 || includeMissing).ToList();
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesController.SeriesNotFoundWithSeriesID);
+            if (!User.AllowedSeries(series))
+                return Forbid(SeriesController.SeriesForbiddenForUser);
+
+            return series.GetAnimeEpisodes()
+                .Select(a => new Episode(HttpContext, a))
+                .Where(a => a.Size > 0 || includeMissing)
+                .ToList();
         }
+
+        #endregion
+        #region Episode
+
+        /// <summary>
+        /// Get the <see cref="File.FileDetailed"/>s for the <see cref="Episode"/> with the given <paramref name="episodeID"/>.
+        /// </summary>
+        /// <param name="episodeID">Episode ID</param>
+        /// <returns></returns>
+        [HttpGet("Episode/{episodeID}/File")]
+        public ActionResult<List<File.FileDetailed>> GetFiles([FromRoute] int episodeID)
+        {
+            var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
+            if (episode == null)
+                return NotFound(EpisodeController.EpisodeNotFoundWithEpisodeID);
+
+            var series = episode.GetAnimeSeries();
+            if (series == null)
+                return InternalError("No Series entry for given Episode");
+            if (!User.AllowedSeries(series))
+                return Forbid(EpisodeController.EpisodeForbiddenForUser);
+
+            return episode.GetVideoLocals()
+                .Select(file => new File.FileDetailed(file))
+                .ToList();
+        }
+
+
+        #endregion
+        #region Ordering helpers
+
+        [NonAction]
+        private DateTime? OrderByAirDate(SVR_AnimeSeries series)
+        {
+            var anime = RepoFactory.AniDB_Anime.GetByAnimeID(series.AniDB_ID);
+            if (anime.AirDate.HasValue && anime.AirDate.Value != DateTime.MinValue)
+                return anime.AirDate;
+
+            return null;
+        }
+
+        [NonAction]
+        private string OrderByName(SVR_AnimeGroup group)
+        {
+            return group.SortName;
+        }
+
+        [NonAction]
+        private string OrderByName(SVR_GroupFilter group)
+        {
+            return group.GroupFilterName;
+        }
+
+        #endregion
     }
-    
-    
 }

--- a/Shoko.Server/API/v3/Models/Common/Image.cs
+++ b/Shoko.Server/API/v3/Models/Common/Image.cs
@@ -114,7 +114,7 @@ namespace Shoko.Server.API.v3.Models.Common
                 case ImageEntityType.Staff:
                     return "Staff";
                 case ImageEntityType.Static:
-                    return "Shoko";
+                    return "Static";
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), type, null);
             }
@@ -135,7 +135,7 @@ namespace Shoko.Server.API.v3.Models.Common
                     return "TvDB";
                 case ImageEntityType.MovieDB_FanArt:
                 case ImageEntityType.MovieDB_Poster:
-                    return "MovieDB";
+                    return "TMDB";
                 case ImageEntityType.Character:
                 case ImageEntityType.Staff:
                 case ImageEntityType.Static:
@@ -146,51 +146,63 @@ namespace Shoko.Server.API.v3.Models.Common
         }
         
         /// <summary>
-        /// Gets the enum ImageEntityType from the text url segments
+        /// Gets the <see cref="ImageEntityType"/> for the given <paramref name="source"/> and <paramref name="imageType"/>.
         /// </summary>
         /// <param name="source"></param>
-        /// <param name="type"></param>
+        /// <param name="imageType"></param>
         /// <returns></returns>
-        public static ImageEntityType GetImageTypeFromSourceAndType(string source, string type)
+        public static ImageEntityType? GetImageTypeFromSourceAndType(string source, string imageType)
         {
-            source = source.ToUpper(CultureInfo.InvariantCulture);
-            type = type.ToUpper(CultureInfo.InvariantCulture);
-            string msg = @"The type is not valid for the selected provider.";
-            switch (source)
-            {
-                case "ANIDB":
-                    switch (type)
-                    {
-                        case "POSTER": return ImageEntityType.AniDB_Cover;
-                        default: throw new ArgumentOutOfRangeException(nameof(type), type, msg);
-                    }
-                case "TVDB":
-                    switch (type)
-                    {
-                        case "POSTER": return ImageEntityType.TvDB_Cover;
-                        case "FANART": return ImageEntityType.TvDB_FanArt;
-                        case "BANNER": return ImageEntityType.TvDB_Banner;
-                        case "THUMB": return ImageEntityType.TvDB_Episode;
-                        default: throw new ArgumentOutOfRangeException(nameof(type), type, msg);
-                    }
-                case "MOVIEDB":
-                    switch (type)
-                    {
-                        case "POSTER": return ImageEntityType.MovieDB_Poster;
-                        case "FANART": return ImageEntityType.MovieDB_FanArt;
-                        default: throw new ArgumentOutOfRangeException(nameof(type), type, msg);
-                    }
-                    case "SHOKO":
-                        switch (type)
-                        {
-                            case "STATIC": return ImageEntityType.Static;
-                            case "CHARACTER": return ImageEntityType.Character;
-                            case "STAFF": return ImageEntityType.Staff;
-                            default: throw new ArgumentOutOfRangeException(nameof(type), type, msg);
-                        }
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(source), source, @"The provider was not valid.");
-            }
+            return (source.ToLower(CultureInfo.InvariantCulture)) switch {
+                "anidb" => (imageType.ToLower(CultureInfo.InvariantCulture)) switch {
+                    "poster" => ImageEntityType.AniDB_Cover,
+                    "character" => ImageEntityType.AniDB_Character,
+                    "staff" => ImageEntityType.AniDB_Creator,
+                    _ => null,
+                },
+                "tvdb" => (imageType.ToLower(CultureInfo.InvariantCulture)) switch {
+                    "poster" => ImageEntityType.TvDB_Cover,
+                    "banner" => ImageEntityType.TvDB_Banner,
+                    "thumb" => ImageEntityType.TvDB_Episode,
+                    "fanart" => ImageEntityType.TvDB_FanArt,
+                    _ => null,
+                },
+                "tmdb" => (imageType.ToLower(CultureInfo.InvariantCulture)) switch {
+                    "poster" => ImageEntityType.MovieDB_Poster,
+                    "fanart" => ImageEntityType.MovieDB_FanArt,
+                    _ => null,
+                },
+                "shoko" => (imageType.ToLower(CultureInfo.InvariantCulture)) switch {
+                    "static" => ImageEntityType.Static,
+                    "character" => ImageEntityType.Character,
+                    "staff" => ImageEntityType.Staff,
+                    _ => null,
+                },
+                _ => null,
+            };
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ImageSizeType"/> from the given <paramref name="imageEntityType"/>.
+        /// </summary>
+        /// <param name="imageEntityType">Image entity type.</param>
+        /// <returns>The <see cref="ImageSizeType"/></returns>
+        public static ImageSizeType? GetImageSizeTypeFromImageEntityType(ImageEntityType imageEntityType)
+        {
+            return imageEntityType switch {
+                // Posters
+                ImageEntityType.AniDB_Cover => ImageSizeType.Poster,
+                ImageEntityType.TvDB_Cover => ImageSizeType.Poster,
+                ImageEntityType.MovieDB_Poster => ImageSizeType.Poster,
+
+                // Banners
+                ImageEntityType.TvDB_Banner => ImageSizeType.WideBanner,
+
+                // Fanart
+                ImageEntityType.TvDB_FanArt => ImageSizeType.Fanart,
+                ImageEntityType.MovieDB_FanArt => ImageSizeType.Fanart,
+                _ => null,
+            };
         }
         
         public static string GetImagePath(ImageEntityType type, int id)
@@ -348,6 +360,21 @@ namespace Shoko.Server.API.v3.Models.Common
             }
 
             return path;
+        }
+        
+        /// <summary>
+        /// Input models.
+        /// </summary>
+        public class Input
+        {
+            public class DefaultImageBody
+            {
+                [Required]
+                public string ID { get; set; }
+                
+                [Required]
+                public string Source { get; set; }
+            }
         }
     }
 }

--- a/Shoko.Server/API/v3/Models/Common/SeriesRelation.cs
+++ b/Shoko.Server/API/v3/Models/Common/SeriesRelation.cs
@@ -1,0 +1,160 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Shoko.Models.Server;
+
+namespace Shoko.Server.API.v3.Models.Common
+{
+    /// <summary>
+    /// Describes relations between two series entries.
+    /// </summary>
+    public class SeriesRelation
+    {
+        /// <summary>
+        /// Relation IDs.
+        /// </summary>
+        public RelationIDs IDs;
+
+        /// <summary>
+        /// The relation between <see cref="RelationIDs.Series"/> and <see cref="RelationIDs.RelatedSeries"/>.
+        /// </summary>
+        [Required]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public RelationType Type { get; set; }
+
+        /// <summary>
+        /// AniDB, etc.
+        /// </summary>
+        [Required]
+        public string Source { get; set; }
+
+        public SeriesRelation(HttpContext context, AniDB_Anime_Relation relation)
+        {
+            IDs = new RelationIDs { ID = relation.AniDB_Anime_RelationID, Series = relation.AnimeID, RelatedSeries = relation.RelatedAnimeID };
+            Type = GetRelationTypeFromAnidbRelationType(relation.RelationType);
+            Source = "AniDB";
+        }
+
+        public SeriesRelation(HttpContext context, AniDB_Anime_Relation relation, AnimeSeries series, AnimeSeries relatedSeries)
+        {
+            IDs = new RelationIDs { ID = relation.AniDB_Anime_RelationID, Series = series.AnimeSeriesID, RelatedSeries = relatedSeries.AnimeSeriesID };
+            Type = GetRelationTypeFromAnidbRelationType(relation.RelationType);
+            Source = "AniDB";
+        }
+
+        internal static RelationType GetRelationTypeFromAnidbRelationType(string anidbType)
+        {
+            return (anidbType.ToLowerInvariant()) switch
+            {
+                "prequel" => RelationType.Prequel,
+                "sequel" => RelationType.Sequel,
+                "parent story" => RelationType.MainStory,
+                "side story" => RelationType.SideStory,
+                "full story" => RelationType.FullStory,
+                "summary" => RelationType.Summary,
+                "other" => RelationType.Other,
+                "alternative setting" => RelationType.AlternativeSetting,
+                "same setting" => RelationType.SameSetting,
+                "character" => RelationType.SharedCharacters,
+                
+                _ => RelationType.Other,
+            };
+        }
+
+        /// <summary>
+        /// Explains how the main entry relates to the related entry.
+        /// </summary>
+        public enum RelationType
+        {
+            /// <summary>
+            /// The relation between the entries cannot be explained in simple terms.
+            /// </summary>
+            Other = 0,
+
+            /// <summary>
+            /// The entries use the same setting, but follow different stories.
+            /// </summary>
+            SameSetting = 1,
+
+            /// <summary>
+            /// The entries use the same base story, but is set in alternate settings.
+            /// </summary>
+            AlternativeSetting = 2,
+
+            /// <summary>
+            /// The entries tell different stories in different settings but othwerwise shares some character(s).
+            /// </summary>
+            SharedCharacters = 3,
+
+            /// <summary>
+            /// The first story either continues, or expands upon the story of the related entry.
+            /// </summary>
+            Prequel = 20,
+
+            /// <summary>
+            /// The related entry is the main-story for the main entry, which is a side-story.
+            /// </summary>
+            MainStory = 21,
+
+            /// <summary>
+            /// The related entry is a longer version of the summerized events in the main entry.
+            /// </summary>
+            FullStory = 22,
+
+            /// <summary>
+            /// The related entry either continues, or expands upon the story of the main entry.
+            /// </summary>
+            Sequel = 40,
+
+            /// <summary>
+            /// The related entry is a side-story for the main entry, which is the main-story.
+            /// </summary>
+            SideStory = 41,
+
+            /// <summary>
+            /// The related entry summerizes the events of the story in the main entry.
+            /// </summary>
+            Summary = 42,
+        }
+
+        /// <summary>
+        /// Relation IDs.
+        /// </summary>
+        public class RelationIDs : IDs
+        {
+            /// <summary>
+            /// The ID of the main entry in this relation.
+            /// </summary>
+            public int Series { get; set; }
+
+            /// <summary>
+            /// The ID of the related entry in this relation.
+            /// </summary>
+            public int RelatedSeries { get; set; }
+        }
+    }
+
+    public static class RelationExtensions
+    {
+        /// <summary>
+        /// Reverse the relation.
+        /// </summary>
+        /// <param name="type">The relation to reverse.</param>
+        /// <returns>The reversed relation.</returns>
+        public static SeriesRelation.RelationType Reverse(this SeriesRelation.RelationType type)
+        {
+            return (type) switch
+            {
+                SeriesRelation.RelationType.Prequel => SeriesRelation.RelationType.Sequel,
+                SeriesRelation.RelationType.Sequel => SeriesRelation.RelationType.Prequel,
+                SeriesRelation.RelationType.MainStory => SeriesRelation.RelationType.SideStory,
+                SeriesRelation.RelationType.SideStory => SeriesRelation.RelationType.MainStory,
+                SeriesRelation.RelationType.FullStory => SeriesRelation.RelationType.Summary,
+                SeriesRelation.RelationType.Summary => SeriesRelation.RelationType.FullStory,
+                _ => type,
+            };
+        }
+    }
+}

--- a/Shoko.Server/API/v3/Models/Common/Vote.cs
+++ b/Shoko.Server/API/v3/Models/Common/Vote.cs
@@ -13,7 +13,8 @@ namespace Shoko.Server.API.v3.Models.Common
     {
         /// <summary>
         /// The normalised user-submitted rating in the range [0, <paramref name="maxValue" />].
-        /// /// </summary>
+        /// </summary>
+        /// <param name="maxValue">The max value to use.</param>
         /// <returns></returns>
         public decimal GetRating(int maxValue = 10)
             => Math.Clamp((Math.Clamp(Value, 0, MaxValue) / MaxValue) * maxValue, 0, maxValue);

--- a/Shoko.Server/API/v3/Models/Shoko/Episode.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Episode.cs
@@ -79,22 +79,6 @@ namespace Shoko.Server.API.v3.Models.Shoko
             }
         }
 
-        /// <summary>
-        /// Get TvDB data from AniDBEpisode ID
-        /// </summary>
-        /// <param name="id">AniDB Episode ID</param>
-        /// <returns></returns>
-        public static List<TvDB> GetTvDBInfo(int id)
-        {
-            return RepoFactory.CrossRef_AniDB_TvDB_Episode.GetByAniDBEpisodeID(id)
-                .Select(a => RepoFactory.TvDB_Episode.GetByTvDBID(a.TvDBEpisodeID))
-                .Where(a => a != null)
-                .Select(a => new TvDB(a))
-                .OrderBy(a => a.Season)
-                .ThenBy(a => a.Number)
-                .ToList();
-        }
-
         public static void AddEpisodeVote(HttpContext context, SVR_AnimeEpisode ep, int userID, Vote vote)
         {
             AniDB_Vote dbVote = RepoFactory.AniDB_Vote.GetByEntityAndType(ep.AnimeEpisodeID, AniDBVoteType.Episode);

--- a/Shoko.Server/API/v3/Models/Shoko/Episode.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Episode.cs
@@ -79,76 +79,20 @@ namespace Shoko.Server.API.v3.Models.Shoko
             }
         }
 
-        public static AniDB GetAniDBInfo(AniDB_Episode ep)
-        {
-            decimal rating = 0;
-            int votes = 0;
-            try
-            {
-                rating = decimal.Parse(ep.Rating);
-                votes = int.Parse(ep.Votes);
-            }
-            catch {}
-
-            var titles = RepoFactory.AniDB_Episode_Title.GetByEpisodeID(ep.EpisodeID);
-            return new AniDB
-            {
-                ID = ep.EpisodeID,
-                Type = MapAniDBEpisodeType((AniDBEpisodeType)ep.EpisodeType),
-                EpisodeNumber = ep.EpisodeNumber,
-                AirDate = ep.GetAirDateAsDate(),
-                Description = ep.Description,
-                Rating = new Rating
-                {
-                    Source = "AniDB",
-                    Value = rating,
-                    MaxValue = 10,
-                    Votes = votes
-                },
-                Titles = titles.Select(a => new Title
-                    {
-                        Name = a.Title,
-                        Language = a.Language.ToLower(),
-                        Default = false,
-                        Source = "AniDB",
-                    }
-                ).ToList(),
-            };
-        }
-
         /// <summary>
         /// Get TvDB data from AniDBEpisode ID
         /// </summary>
         /// <param name="id">AniDB Episode ID</param>
         /// <returns></returns>
-        public static ActionResult<List<TvDB>> GetTvDBInfo(int id)
+        public static List<TvDB> GetTvDBInfo(int id)
         {
-            var tvdbEps = RepoFactory.CrossRef_AniDB_TvDB_Episode.GetByAniDBEpisodeID(id);
-            return tvdbEps.Select(a => RepoFactory.TvDB_Episode.GetByTvDBID(a.TvDBEpisodeID)).Where(a => a != null)
-                .Select(a =>
-                {
-                    Rating rating = a.Rating == null ? null : new Rating
-                    {
-                        Source = "TvDB",
-                        Value = a.Rating.Value,
-                        MaxValue = 10
-                    };
-                    return new TvDB
-                    {
-                        ID = a.Id,
-                        Season = a.SeasonNumber,
-                        Number = a.EpisodeNumber,
-                        AbsoluteNumber = a.AbsoluteNumber ?? 0,
-                        Title = a.EpisodeName,
-                        Description = a.Overview,
-                        AirDate = a.AirDate,
-                        Rating = rating,
-                        AirsAfterSeason = a.AirsAfterSeason ?? 0,
-                        AirsBeforeSeason = a.AirsBeforeSeason ?? 0,
-                        AirsBeforeEpisode = a.AirsBeforeEpisode ?? 0,
-                        Thumbnail = new Image(a.Id, ImageEntityType.TvDB_Episode, true)
-                    };
-                }).OrderBy(a => a.Season).ThenBy(a => a.ID).ThenBy(a => a.Number).ToList();
+            return RepoFactory.CrossRef_AniDB_TvDB_Episode.GetByAniDBEpisodeID(id)
+                .Select(a => RepoFactory.TvDB_Episode.GetByTvDBID(a.TvDBEpisodeID))
+                .Where(a => a != null)
+                .Select(a => new TvDB(a))
+                .OrderBy(a => a.Season)
+                .ThenBy(a => a.Number)
+                .ToList();
         }
 
         public static void AddEpisodeVote(HttpContext context, SVR_AnimeEpisode ep, int userID, Vote vote)
@@ -177,6 +121,36 @@ namespace Shoko.Server.API.v3.Models.Shoko
         /// </summary>
         public class AniDB
         {
+            public AniDB(AniDB_Episode ep)
+            {
+                if (!decimal.TryParse(ep.Rating, out var rating))
+                    rating = 0;
+                if (!int.TryParse(ep.Votes, out var votes))
+                    votes = 0;
+                var titles = RepoFactory.AniDB_Episode_Title.GetByEpisodeID(ep.EpisodeID);
+
+                ID = ep.EpisodeID;
+                Type = MapAniDBEpisodeType((AniDBEpisodeType)ep.EpisodeType);
+                EpisodeNumber = ep.EpisodeNumber;
+                AirDate = ep.GetAirDateAsDate();
+                Description = ep.Description;
+                Rating = new Rating
+                {
+                    MaxValue = 10,
+                    Value = rating,
+                    Votes = votes,
+                    Source = "AniDB",
+                };
+                Titles = titles.Select(a => new Title
+                    {
+                        Name = a.Title,
+                        Language = a.Language.ToLower(),
+                        Default = false,
+                        Source = "AniDB",
+                    }
+                ).ToList();
+            }
+
             /// <summary>
             /// AniDB Episode ID
             /// </summary>
@@ -216,6 +190,28 @@ namespace Shoko.Server.API.v3.Models.Shoko
 
         public class TvDB
         {
+            public TvDB(TvDB_Episode tvDBEpisode)
+            {
+                Rating rating = tvDBEpisode.Rating == null ? null : new Rating
+                {
+                    MaxValue = 10,
+                    Value = tvDBEpisode.Rating.Value,
+                    Source = "TvDB",
+                };
+                ID = tvDBEpisode.Id;
+                Season = tvDBEpisode.SeasonNumber;
+                Number = tvDBEpisode.EpisodeNumber;
+                AbsoluteNumber = tvDBEpisode.AbsoluteNumber ?? 0;
+                Title = tvDBEpisode.EpisodeName;
+                Description = tvDBEpisode.Overview;
+                AirDate = tvDBEpisode.AirDate;
+                Rating = rating;
+                AirsAfterSeason = tvDBEpisode.AirsAfterSeason ?? 0;
+                AirsBeforeSeason = tvDBEpisode.AirsBeforeSeason ?? 0;
+                AirsBeforeEpisode = tvDBEpisode.AirsBeforeEpisode ?? 0;
+                Thumbnail = (new Image(tvDBEpisode.Id, ImageEntityType.TvDB_Episode, true));
+            }
+            
             /// <summary>
             /// TvDB Episode ID
             /// </summary>

--- a/Shoko.Server/API/v3/Models/Shoko/File.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/File.cs
@@ -351,6 +351,26 @@ namespace Shoko.Server.API.v3.Models.Shoko
             }
 
             /// <summary>
+            /// Link a file to multiple episodes.
+            /// </summary>
+            public class LinkMultipleFilesBody
+            {
+                /// <summary>
+                /// An array of file identifiers to link in batch.
+                /// </summary>
+                /// <value></value>
+                [Required]
+                public int[] fileIDs { get; set; }
+
+                /// <summary>
+                /// The episode identifier.
+                /// </summary>
+                /// <value></value>
+                [Required]
+                public int episodeID { get; set; }
+            }
+
+            /// <summary>
             /// Link a file to an episode range in a series.
             /// </summary>
             public class LinkSeriesBody

--- a/Shoko.Server/API/v3/Models/Shoko/File.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/File.cs
@@ -40,12 +40,12 @@ namespace Shoko.Server.API.v3.Models.Shoko
         /// The last watched date for the current user. Is null if unwatched
         /// </summary>
         /// <value></value>
-        public DateTime? Watched { get; set; }
+        public DateTime? Watched { get; set; }
 
         /// <summary>
         /// Number of ticks into the video to resume from
         /// </summary>
-        public long? ResumePosition { get; set; }
+        public long? ResumePosition { get; set; }
         
         /// <summary>
         /// Try to fit this file's resolution to something like 1080p, 480p, etc
@@ -92,51 +92,6 @@ namespace Shoko.Server.API.v3.Models.Shoko
             return vl?.Media;
         }
 
-
-        /// <summary>
-        /// This isn't a list, because AniDB only has one File mapping, even if there are multiple episodes
-        /// </summary>
-        /// <param name="id"></param>
-        /// <returns></returns>
-        public static AniDB GetAniDBInfo(int id)
-        {
-            var vl = RepoFactory.VideoLocal.GetByID(id);
-            if (vl == null) return null;
-            var anidb = RepoFactory.AniDB_File.GetByHash(vl.Hash);
-            // this will be true for all Manual Links
-            if (anidb == null) return null;
-
-            return new AniDB
-            {
-                Chaptered = anidb.IsChaptered == 1,
-                Duration = new TimeSpan(0, 0, anidb.File_LengthSeconds),
-                Resolution = anidb.File_VideoResolution,
-                VideoCodec = anidb.File_VideoCodec,
-                OriginalFileName = anidb.FileName,
-                Source = anidb.File_Source,
-                FileSize = anidb.FileSize,
-                ID = anidb.FileID,
-                ReleaseDate = anidb.File_ReleaseDate == 0
-                    ? null
-                    : Commons.Utils.AniDB.GetAniDBDateAsDate(anidb.File_ReleaseDate),
-                IsCensored = anidb.IsCensored == 1,
-                IsDeprecated = anidb.IsDeprecated == 1,
-                Version = anidb.FileVersion,
-                Description = anidb.File_Description,
-                Updated = anidb.DateTimeUpdated,
-                ReleaseGroup = new AniDB.AniDBReleaseGroup
-                {
-                    ID = anidb.GroupID,
-                    Name = anidb.Anime_GroupName,
-                    ShortName = anidb.Anime_GroupNameShort
-                },
-                AudioCodecs = anidb.File_AudioCodec.Split(new[] {'\'', '`', '"'}, StringSplitOptions.RemoveEmptyEntries)
-                    .ToList(),
-                AudioLanguages = anidb.Languages.Select(a => a.LanguageName).ToList(),
-                SubLanguages = anidb.Subtitles.Select(a => a.LanguageName).ToList()
-            };
-        }
-
         public class Location
         {
             /// <summary>
@@ -161,6 +116,34 @@ namespace Shoko.Server.API.v3.Models.Shoko
         /// </summary>
         public class AniDB
         {
+            public AniDB(SVR_AniDB_File anidb)
+            {
+                ID = anidb.FileID;
+                Source = anidb.File_Source;
+                ReleaseGroup = new AniDB.AniDBReleaseGroup
+                {
+                    ID = anidb.GroupID,
+                    Name = anidb.Anime_GroupName,
+                    ShortName = anidb.Anime_GroupNameShort,
+                };
+                ReleaseDate = anidb.File_ReleaseDate == 0 ? null : Commons.Utils.AniDB.GetAniDBDateAsDate(anidb.File_ReleaseDate);
+                Version = anidb.FileVersion;
+                IsDeprecated = anidb.IsDeprecated == 1;
+                IsCensored = anidb.IsCensored == 1;
+                Chaptered = anidb.IsChaptered == 1;
+                Duration = (new TimeSpan(0, 0, anidb.File_LengthSeconds));
+                Resolution = anidb.File_VideoResolution;
+                VideoCodec = anidb.File_VideoCodec;
+                OriginalFileName = anidb.FileName;
+                FileSize = anidb.FileSize;
+                Description = anidb.File_Description;
+                Updated = anidb.DateTimeUpdated;
+                AudioCodecs = anidb.File_AudioCodec.Split(new[] {'\'', '`', '"'}, StringSplitOptions.RemoveEmptyEntries)
+                    .ToList();
+                AudioLanguages = anidb.Languages.Select(a => a.LanguageName).ToList();
+                SubLanguages = anidb.Subtitles.Select(a => a.LanguageName).ToList();
+            }
+            
             /// <summary>
             /// The AniDB File ID
             /// </summary>
@@ -180,16 +163,16 @@ namespace Shoko.Server.API.v3.Models.Shoko
             /// The file's release date. This is probably not filled in
             /// </summary>
             public DateTime? ReleaseDate { get; set; }
-
-            /// <summary>
-            /// Is the file marked as deprecated. Generally, yes if there's a V2, and this isn't it
-            /// </summary>
-            public bool IsDeprecated { get; set; }
             
             /// <summary>
             /// The file's version, Usually 1, sometimes more when there are edits released later
             /// </summary>
             public int Version { get; set; }
+
+            /// <summary>
+            /// Is the file marked as deprecated. Generally, yes if there's a V2, and this isn't it
+            /// </summary>
+            public bool IsDeprecated { get; set; }
 
             /// <summary>
             /// Mostly applicable to hentai, but on occasion a TV release is censored enough to earn this.
@@ -364,7 +347,7 @@ namespace Shoko.Server.API.v3.Models.Shoko
                 /// </summary>
                 /// <value></value>
                 [Required]
-                public int[] episodeIDs { get; set; }
+                public int[] episodeIDs { get; set; }
             }
 
             /// <summary>
@@ -377,21 +360,21 @@ namespace Shoko.Server.API.v3.Models.Shoko
                 /// </summary>
                 /// <value></value>
                 [Required]
-                public int seriesID { get; set; }
+                public int seriesID { get; set; }
 
                 /// <summary>
                 /// The start of the range of episodes to link to the file. Append a type prefix to use another episode type.
                 /// </summary>
                 /// <value></value>
                 [Required]
-                public string rangeStart { get; set; }
+                public string rangeStart { get; set; }
 
                 /// <summary>
                 /// The end of the range of episodes to link to the file. The prefix used should be the same as in <see cref="rangeStart"/>.
                 /// </summary>
                 /// <value></value>
                 [Required]
-                public  string rangeEnd { get; set; }
+                public  string rangeEnd { get; set; }
             }
 
             /// <summary>
@@ -404,7 +387,7 @@ namespace Shoko.Server.API.v3.Models.Shoko
                 /// </summary>
                 /// <value></value>
                 [Required]
-                public int[] fileIDs { get; set; }
+                public int[] fileIDs { get; set; }
 
                 /// <summary>
                 /// The series identifier.
@@ -418,14 +401,14 @@ namespace Shoko.Server.API.v3.Models.Shoko
                 /// </summary>
                 /// <value></value>
                 [Required]
-                public string rangeStart { get; set; }
+                public string rangeStart { get; set; }
 
                 /// <summary>
                 /// If true then files will be linked to a single episode instead of a range spanning the amount of files to add.
                 /// </summary>
                 /// <value></value>
                 [DefaultValue(false)]
-                public bool singleEpisode { get; set; }
+                public bool singleEpisode { get; set; }
             }
 
             /// <summary>
@@ -438,7 +421,7 @@ namespace Shoko.Server.API.v3.Models.Shoko
                 /// </summary>
                 /// <value></value>
                 [Required]
-                public int[] episodeIDs { get; set; }
+                public int[] episodeIDs { get; set; }
             }
 
             /// <summary>
@@ -451,7 +434,7 @@ namespace Shoko.Server.API.v3.Models.Shoko
                 /// </summary>
                 /// <value></value>
                 [Required]
-                public int[] fileIDs { get; set; }
+                public int[] fileIDs { get; set; }
             }
         }
     }

--- a/Shoko.Server/API/v3/Models/Shoko/Group.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Group.cs
@@ -26,16 +26,16 @@ namespace Shoko.Server.API.v3.Models.Shoko
         /// IDs such as the group ID, default series, parent group, etc.
         /// </summary>
         public GroupIDs IDs { get; set; }
-        
+
         /// <summary>
         /// The sort name for the group.
         /// </summary>
-        public string SortName { get; set; }
-        
+        public string SortName { get; set; }
+
         /// <summary>
-        /// 
+        /// A short description of the group.
         /// </summary>
-        public string Description { get; set; }
+        public string Description { get; set; }
 
         /// <summary>
         /// Marked as true when you rename a group to something custom. Different from using a default Series's name
@@ -54,7 +54,12 @@ namespace Shoko.Server.API.v3.Models.Shoko
             List<SVR_AnimeEpisode> ael = allSeries.SelectMany(a => a.GetAnimeEpisodes()).ToList();
 
             IDs = new GroupIDs { ID = group.AnimeGroupID };
-            if (group.DefaultAnimeSeriesID != null) IDs.DefaultSeries = group.DefaultAnimeSeriesID.Value;
+            if (group.DefaultAnimeSeriesID != null)
+                IDs.DefaultSeries = group.DefaultAnimeSeriesID.Value;
+            if (group.AnimeGroupParentID.HasValue)
+                IDs.ParentGroup = group.AnimeGroupParentID.Value;
+            IDs.TopLevelGroup = group.TopLevelAnimeGroup.AnimeGroupID;
+            
 
             Name = group.GroupName;
             SortName = group.SortName;
@@ -91,9 +96,16 @@ namespace Shoko.Server.API.v3.Models.Shoko
             public int DefaultSeries { get; set; }
 
             /// <summary>
-            /// Parent Group, if it has one
+            /// The ID of the direct parent group, if it has one.
             /// </summary>
-            public int ParentGroup { get; set; }
+            public int? ParentGroup { get; set; }
+
+            /// <summary>
+            /// The ID of the top-level (ancestor) group this group belongs to.
+            /// If the current group is a top-level group then it refers to
+            /// itself.
+            /// </summary>
+            public int TopLevelGroup { get; set; }
         }
 
         /// <summary>

--- a/Shoko.Server/API/v3/Models/Shoko/Series.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Series.cs
@@ -275,10 +275,8 @@ namespace Shoko.Server.API.v3.Models.Shoko
         {
             var ael = ser.GetAnimeEpisodes();
             return RepoFactory.CrossRef_AniDB_TvDB.GetByAnimeID(ser.AniDB_ID)
-                .Select(xref => {
-                    var tvdbSer = RepoFactory.TvDB_Series.GetByTvDBID(xref.TvDBID);
-                    return new TvDB(ctx, tvdbSer, ser, ael);
-                })
+                .Select(xref => RepoFactory.TvDB_Series.GetByTvDBID(xref.TvDBID))
+                .Select(tvdbSer => new TvDB(ctx, tvdbSer, ser, ael))
                 .ToList();
         }
 

--- a/Shoko.Server/API/v3/Models/Shoko/Series.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Series.cs
@@ -128,27 +128,34 @@ namespace Shoko.Server.API.v3.Models.Shoko
         public static SeriesIDs GetIDs(SVR_AnimeSeries ser)
         {
             // Shoko
-            var ids = new SeriesIDs {ID = ser.AnimeSeriesID};
+            var ids = new SeriesIDs { ID = ser.AnimeSeriesID };
+            
             // AniDB
-            var anime = ser.GetAnime();
-            if (anime != null) ids.AniDB = anime.AnimeID;
+            var anidbId = ser.GetAnime()?.AnimeID;
+            if (anidbId.HasValue) ids.AniDB = anidbId.Value;
+            
             // TvDB
-            var tvdbs = RepoFactory.CrossRef_AniDB_TvDB.GetByAnimeID(ser.AniDB_ID);
-            if (tvdbs.Any()) ids.TvDB.AddRange(tvdbs.Select(a => a.TvDBID).Distinct());
-            // TODO Cache the rest of these, so that they don't severely slow down the API
-            // MovieDB
-            // TODO make this able to support more than one, in fact move it to its own and remove CrossRef_Other
-            //var moviedb = RepoFactory.CrossRef_AniDB_Other.GetByAnimeIDAndType(ser.AniDB_ID, CrossRefType.MovieDB);
-            //if (moviedb != null && int.TryParse(moviedb.CrossRefID, out int movieID)) ids.MovieDB.Add(movieID);
+            var tvdbIds = RepoFactory.CrossRef_AniDB_TvDB.GetByAnimeID(ser.AniDB_ID);
+            if (tvdbIds.Any()) ids.TvDB.AddRange(tvdbIds.Select(a => a.TvDBID).Distinct());
+            
+            // TODO: Cache the rest of these, so that they don't severely slow down the API
+
+            // TMDB
+            // TODO: make this able to support more than one, in fact move it to its own and remove CrossRef_Other
+            var tmdbId = RepoFactory.CrossRef_AniDB_Other.GetByAnimeIDAndType(ser.AniDB_ID, CrossRefType.MovieDB);
+            if (tmdbId != null && int.TryParse(tmdbId.CrossRefID, out int movieID)) ids.TMDB.Add(movieID);
+            
             // Trakt
-            //var traktids = RepoFactory.CrossRef_AniDB_TraktV2.GetByAnimeID(ser.AniDB_ID).Select(a => a.TraktID)
-            //    .Distinct().ToList();
-            //if (traktids.Any()) ids.TraktTv.AddRange(traktids);
+            // var traktIds = RepoFactory.CrossRef_AniDB_TraktV2.GetByAnimeID(ser.AniDB_ID).Select(a => a.TraktID)
+            //     .Distinct().ToList();
+            // if (traktIds.Any()) ids.TraktTv.AddRange(traktIds);
+            
             // MAL
-            var malids = RepoFactory.CrossRef_AniDB_MAL.GetByAnimeID(ser.AniDB_ID).Select(a => a.MALID).Distinct()
+            var malIds = RepoFactory.CrossRef_AniDB_MAL.GetByAnimeID(ser.AniDB_ID).Select(a => a.MALID).Distinct()
                 .ToList();
-            if (malids.Any()) ids.MAL.AddRange(malids);
-            // TODO AniList later
+            if (malIds.Any()) ids.MAL.AddRange(malIds);
+            
+            // TODO: AniList later
             return ids;
         }
 
@@ -644,9 +651,9 @@ namespace Shoko.Server.API.v3.Models.Shoko
         // TODO Support for TvDB string IDs (like in the new URLs) one day maybe
 
         /// <summary>
-        /// The MovieDB IDs
+        /// The Movie DB IDs
         /// </summary>
-        public List<int> MovieDB { get; set; } = new List<int>();
+        public List<int> TMDB { get; set; } = new List<int>();
 
         /// <summary>
         /// The MyAnimeList IDs

--- a/Shoko.Server/API/v3/Models/Shoko/Series.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Series.cs
@@ -110,9 +110,9 @@ namespace Shoko.Server.API.v3.Models.Shoko
             SSS.ShokoService.AnidbProcessor.UpdateCachedAnimeInfoHTTP(anime);
         }
 
-        public static void QueueAniDBRefresh(int animeID)
+        public static void QueueAniDBRefresh(int animeID, bool force, bool downloadRelations, bool createSeriesEntry)
         {
-            CommandRequest_GetAnimeHTTP command = new CommandRequest_GetAnimeHTTP(animeID, false, false, 0);
+            var command = new CommandRequest_GetAnimeHTTP(animeID, force, downloadRelations, createSeriesEntry);
             command.Save();
         }
 

--- a/Shoko.Server/API/v3/Models/Shoko/Series.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Series.cs
@@ -213,7 +213,7 @@ namespace Shoko.Server.API.v3.Models.Shoko
                     {
                         Name = character.Name,
                         AlternateName = character.AlternateName,
-                        Image = new Image(xref.RoleID.Value, ImageEntityType.Character),
+                        Image = new Image(character.CharacterID, ImageEntityType.Character),
                         Description = character.Description
                     } : null,
                     Staff = new Role.Person
@@ -221,7 +221,7 @@ namespace Shoko.Server.API.v3.Models.Shoko
                         Name = staff.Name,
                         AlternateName = staff.AlternateName,
                         Description = staff.Description,
-                        Image = new Image(xref.StaffID, ImageEntityType.Staff),
+                        Image = staff.ImagePath != null ? new Image(staff.StaffID, ImageEntityType.Staff) : null,
                     },
                     RoleName = (Role.CreatorRoleType) xref.RoleType,
                     RoleDetails = xref.Role

--- a/Shoko.Server/API/v3/Models/Shoko/Series.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Series.cs
@@ -128,7 +128,12 @@ namespace Shoko.Server.API.v3.Models.Shoko
         public static SeriesIDs GetIDs(SVR_AnimeSeries ser)
         {
             // Shoko
-            var ids = new SeriesIDs { ID = ser.AnimeSeriesID };
+            var ids = new SeriesIDs
+            {
+                ID = ser.AnimeSeriesID,
+                ParentGroup = ser.AnimeGroupID,
+                TopLevelGroup = ser.TopLevelAnimeGroup.AnimeGroupID,
+            };
             
             // AniDB
             var anidbId = ser.GetAnime()?.AnimeID;
@@ -631,6 +636,19 @@ namespace Shoko.Server.API.v3.Models.Shoko
 
     public class SeriesIDs : IDs
     {
+        #region Groups
+
+        /// <summary>
+        /// The ID of the direct parent group, if it has one.
+        /// </summary>
+        public int ParentGroup { get; set; }
+
+        /// <summary>
+        /// The ID of the top-level (ancestor) group this series belongs to.
+        /// </summary>
+        public int TopLevelGroup { get; set; }
+
+        #endregion
         #region XRefs
 
         // These are useful for many things, but for clients, it is mostly auxiliary

--- a/Shoko.Server/Commands/AniDB/CommandRequest_GetAnimeHTTP.cs
+++ b/Shoko.Server/Commands/AniDB/CommandRequest_GetAnimeHTTP.cs
@@ -28,15 +28,13 @@ namespace Shoko.Server.Commands
 
         public int RelDepth { get; set; }
 
+        public bool CreateSeriesEntry { get; set; }
+
         public CommandRequest_GetAnimeHTTP()
         {
         }
 
-        public CommandRequest_GetAnimeHTTP(int animeid, bool forced, bool downloadRelations) : this(animeid, forced, downloadRelations, 0)
-        { }
-
-
-        public CommandRequest_GetAnimeHTTP(int animeid, bool forced, bool downloadRelations, int relDepth)
+        public CommandRequest_GetAnimeHTTP(int animeid, bool forced, bool downloadRelations, bool createSeriesEntry, int relDepth = 0)
         {
             AnimeID = animeid;
             DownloadRelations = downloadRelations;
@@ -44,6 +42,7 @@ namespace Shoko.Server.Commands
             Priority = (int) DefaultPriority;
             if (RepoFactory.AniDB_Anime.GetByAnimeID(animeid) == null) Priority = (int) CommandRequestPriority.Priority1;
             RelDepth = relDepth;
+            CreateSeriesEntry = createSeriesEntry;
 
             GenerateCommandID();
         }
@@ -55,7 +54,7 @@ namespace Shoko.Server.Commands
             try
             {
                 SVR_AniDB_Anime anime =
-                    ShokoService.AnidbProcessor.GetAnimeInfoHTTP(AnimeID, ForceRefresh, DownloadRelations, RelDepth);
+                    ShokoService.AnidbProcessor.GetAnimeInfoHTTP(AnimeID, ForceRefresh, DownloadRelations, RelDepth, CreateSeriesEntry);
 
                 // NOTE - related anime are downloaded when the relations are created
 
@@ -98,13 +97,14 @@ namespace Shoko.Server.Commands
                 docCreator.LoadXml(CommandDetails);
 
                 // populate the fields
-                AnimeID = int.Parse(TryGetProperty(docCreator, "CommandRequest_GetAnimeHTTP", "AnimeID"));
+                AnimeID = int.Parse(TryGetProperty(docCreator, nameof(CommandRequest_GetAnimeHTTP), nameof(AnimeID)));
                 if (RepoFactory.AniDB_Anime.GetByAnimeID(AnimeID) == null) Priority = (int) CommandRequestPriority.Priority1;
                 DownloadRelations =
-                    bool.Parse(TryGetProperty(docCreator, "CommandRequest_GetAnimeHTTP", "DownloadRelations"));
+                    bool.Parse(TryGetProperty(docCreator, nameof(CommandRequest_GetAnimeHTTP), nameof(DownloadRelations)));
                 ForceRefresh = bool.Parse(
-                    TryGetProperty(docCreator, "CommandRequest_GetAnimeHTTP", "ForceRefresh"));
+                    TryGetProperty(docCreator, nameof(CommandRequest_GetAnimeHTTP), nameof(ForceRefresh)));
                 RelDepth = int.Parse(TryGetProperty(docCreator, nameof(CommandRequest_GetAnimeHTTP), nameof(RelDepth)));
+                CreateSeriesEntry = bool.Parse(TryGetProperty(docCreator, nameof(CommandRequest_GetAnimeHTTP), nameof(CreateSeriesEntry)));
             }
 
             return true;

--- a/Shoko.Server/Commands/AniDB/CommandRequest_GetCalendar.cs
+++ b/Shoko.Server/Commands/AniDB/CommandRequest_GetCalendar.cs
@@ -83,8 +83,7 @@ namespace Shoko.Server.Commands
                         TimeSpan ts = DateTime.Now - update.UpdatedAt;
                         if (ts.TotalDays >= 2)
                         {
-                            CommandRequest_GetAnimeHTTP cmdAnime = new CommandRequest_GetAnimeHTTP(cal.AnimeID, true,
-                                false);
+                            CommandRequest_GetAnimeHTTP cmdAnime = new CommandRequest_GetAnimeHTTP(cal.AnimeID, true, false, false);
                             cmdAnime.Save();
                         }
                         else
@@ -102,8 +101,7 @@ namespace Shoko.Server.Commands
                     }
                     else
                     {
-                        CommandRequest_GetAnimeHTTP cmdAnime =
-                            new CommandRequest_GetAnimeHTTP(cal.AnimeID, true, false);
+                        CommandRequest_GetAnimeHTTP cmdAnime = new CommandRequest_GetAnimeHTTP(cal.AnimeID, true, false, false);
                         cmdAnime.Save();
                     }
                 }

--- a/Shoko.Server/Commands/AniDB/CommandRequest_GetUpdated.cs
+++ b/Shoko.Server/Commands/AniDB/CommandRequest_GetUpdated.cs
@@ -124,7 +124,7 @@ namespace Shoko.Server.Commands
                     TimeSpan ts = DateTime.Now - update.UpdatedAt;
                     if (ts.TotalHours > 4)
                     {
-                        CommandRequest_GetAnimeHTTP cmdAnime = new CommandRequest_GetAnimeHTTP(animeID, true, false);
+                        CommandRequest_GetAnimeHTTP cmdAnime = new CommandRequest_GetAnimeHTTP(animeID, true, false, false);
                         cmdAnime.Save();
                         countAnime++;
                     }

--- a/Shoko.Server/Commands/AniDB/CommandRequest_SyncMyVotes.cs
+++ b/Shoko.Server/Commands/AniDB/CommandRequest_SyncMyVotes.cs
@@ -82,8 +82,7 @@ namespace Shoko.Server.Commands
                         if (myVote.VoteType == AniDBVoteType.Anime || myVote.VoteType == AniDBVoteType.AnimeTemp)
                         {
                             // download the anime info if the user doesn't already have it
-                            CommandRequest_GetAnimeHTTP cmdAnime = new CommandRequest_GetAnimeHTTP(thisVote.EntityID,
-                                false, false);
+                            CommandRequest_GetAnimeHTTP cmdAnime = new CommandRequest_GetAnimeHTTP(thisVote.EntityID, false, false, false);
                             cmdAnime.Save();
                         }
                     }

--- a/Shoko.Server/Commands/Import/CommandRequest_ProcessFile.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_ProcessFile.cs
@@ -267,7 +267,7 @@ namespace Shoko.Server.Commands
                 {
                     logger.Warn($"Unable to create AniDB_Anime for file: {vidLocal.FileName}");
                     logger.Warn($"Queuing GET for AniDB_Anime: {animeID}");
-                    CommandRequest_GetAnimeHTTP animeCommand = new CommandRequest_GetAnimeHTTP(animeID, true, true);
+                    CommandRequest_GetAnimeHTTP animeCommand = new CommandRequest_GetAnimeHTTP(animeID, true, true, ServerSettings.Instance.AniDb.AutomaticallyImportSeries);
                     animeCommand.Save();
                     return;
                 }
@@ -280,7 +280,7 @@ namespace Shoko.Server.Commands
                 {
                     // We will put UpdatedAt in the CreateAnimeSeriesAndGroup method, to ensure it exists at first write
                     ser = anime.CreateAnimeSeriesAndGroup();
-                    ser.CreateAnimeEpisodes();
+                    ser.CreateAnimeEpisodes(anime);
                 }
                 else
                 {
@@ -293,7 +293,7 @@ namespace Shoko.Server.Commands
                         {
                             logger.Info(
                                 $"Series {anime.MainTitle} needs episodes regenerated (an episode was added or deleted from AniDB)");
-                            ser.CreateAnimeEpisodes();
+                            ser.CreateAnimeEpisodes(anime);
                             ser.UpdatedAt = DateTime.Now;
                         }
                     }

--- a/Shoko.Server/Commands/Import/CommandRequest_ProcessFile.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_ProcessFile.cs
@@ -150,7 +150,7 @@ namespace Shoko.Server.Commands
                         {
                             AniDB_Episode ep = RepoFactory.AniDB_Episode.GetByEpisodeID(xref.EpisodeID);
 
-                            if (animeIDs.ContainsKey(xref.AnimeID)) animeIDs[xref.AnimeID] = ep == null;
+                            if (animeIDs.ContainsKey(xref.AnimeID)) animeIDs[xref.AnimeID] = animeIDs[xref.AnimeID] || ep == null;
                             else animeIDs.Add(xref.AnimeID, ep == null);
                         }
                     }

--- a/Shoko.Server/Databases/DatabaseFixes.cs
+++ b/Shoko.Server/Databases/DatabaseFixes.cs
@@ -351,7 +351,7 @@ namespace Shoko.Server.Databases
                     logger.Info($"Recreating Episodes for {anime.MainTitle}");
                     SVR_AnimeSeries series = RepoFactory.AnimeSeries.GetByAnimeID(anime.AnimeID);
                     if (series == null) continue;
-                    series.CreateAnimeEpisodes();
+                    series.CreateAnimeEpisodes(anime);
                 }
                 catch (Exception e)
                 {
@@ -530,7 +530,7 @@ namespace Shoko.Server.Databases
                     if (getAnimeCmd.Anime == null) continue;
                     using (var session = DatabaseFactory.SessionFactory.OpenSession())
                     {
-                        ShokoService.AnidbProcessor.SaveResultsForAnimeXML(session, animeID, false, false, getAnimeCmd, 0);
+                        ShokoService.AnidbProcessor.SaveResultsForAnimeXML(session, animeID, false, false, getAnimeCmd, 0, false);
                     }
                 }
                 catch (Exception e)

--- a/Shoko.Server/Import/Importer.cs
+++ b/Shoko.Server/Import/Importer.cs
@@ -761,7 +761,7 @@ namespace Shoko.Server
 
             foreach (var anime in RepoFactory.AniDB_Anime.GetAll())
             {
-                var cmd = new CommandRequest_GetAnimeHTTP(anime.AnimeID, true, false);
+                var cmd = new CommandRequest_GetAnimeHTTP(anime.AnimeID, true, false, false);
                 cmd.Save();
             }
         }

--- a/Shoko.Server/Models/SVR_AniDB_Anime.cs
+++ b/Shoko.Server/Models/SVR_AniDB_Anime.cs
@@ -854,7 +854,7 @@ ORDER BY count(DISTINCT AnimeID) DESC, Anime_GroupName ASC";
             List<Raw_AniDB_Anime_Title> titles, List<Raw_AniDB_Tag> tags, List<Raw_AniDB_Character> chars, List<Raw_AniDB_Staff> staff,
             List<Raw_AniDB_ResourceLink> resources,
             List<Raw_AniDB_RelatedAnime> rels, List<Raw_AniDB_SimilarAnime> sims,
-            List<Raw_AniDB_Recommendation> recs, bool downloadRelations, int relDepth)
+            List<Raw_AniDB_Recommendation> recs, bool downloadRelations, int relDepth, bool createSeriesEntry)
         {
             logger.Trace("------------------------------------------------");
             logger.Trace($"PopulateAndSaveFromHTTP: for {animeInfo.AnimeID} - {animeInfo.MainTitle} @ Depth: {relDepth}/{ServerSettings.Instance.AniDb.MaxRelationDepth}");
@@ -907,7 +907,7 @@ ORDER BY count(DISTINCT AnimeID) DESC, Anime_GroupName ASC";
             logger.Trace("CreateResources in : " + taskTimer.ElapsedMilliseconds);
             taskTimer.Restart();
 
-            CreateRelations(session, rels, downloadRelations, relDepth);
+            CreateRelations(session, rels, downloadRelations, relDepth, createSeriesEntry);
             taskTimer.Stop();
             logger.Trace("CreateRelations in : " + taskTimer.ElapsedMilliseconds);
             taskTimer.Restart();
@@ -1416,7 +1416,7 @@ ORDER BY count(DISTINCT AnimeID) DESC, Anime_GroupName ASC";
         }
 
         private void CreateRelations(ISession session, List<Raw_AniDB_RelatedAnime> rels, bool downloadRelations,
-            int relDepth)
+            int relDepth, bool createSeriesEntry)
         {
             if (rels == null) return;
 
@@ -1442,9 +1442,9 @@ ORDER BY count(DISTINCT AnimeID) DESC, Anime_GroupName ASC";
                     // I have disable the downloading of relations here because of banning issues
                     // basically we will download immediate relations, but not relations of relations
 
-                    //CommandRequest_GetAnimeHTTP cr_anime = new CommandRequest_GetAnimeHTTP(rawrel.RelatedAnimeID, false, downloadRelations);
-                    CommandRequest_GetAnimeHTTP cr_anime = new CommandRequest_GetAnimeHTTP(anime_rel.RelatedAnimeID,
-                        false, false, relDepth + 1);
+                    // I have reverted the change. those who don't want to get banned can turn down the max relation depth.
+
+                    CommandRequest_GetAnimeHTTP cr_anime = new CommandRequest_GetAnimeHTTP(anime_rel.RelatedAnimeID, false, downloadRelations, createSeriesEntry, relDepth + 1);
                     cmdsToSave.Add(cr_anime);
                 }
             }

--- a/Shoko.Server/Models/SVR_AniDB_Anime.cs
+++ b/Shoko.Server/Models/SVR_AniDB_Anime.cs
@@ -312,7 +312,7 @@ ORDER BY count(DISTINCT AnimeID) DESC, Anime_GroupName ASC";
         }
 
         public AniDB_Anime_DefaultImage GetDefaultPoster() =>
-            RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(AnimeID, (int) ImageSizeType.Poster);
+            RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(AnimeID, ImageSizeType.Poster);
 
         public string PosterPathNoDefault
         {
@@ -427,7 +427,7 @@ ORDER BY count(DISTINCT AnimeID) DESC, Anime_GroupName ASC";
         }
 
         public AniDB_Anime_DefaultImage GetDefaultFanart() =>
-            RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(AnimeID, (int) ImageSizeType.Fanart);
+            RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(AnimeID, ImageSizeType.Fanart);
 
         public ImageDetails GetDefaultFanartDetailsNoBlanks()
         {
@@ -526,7 +526,7 @@ ORDER BY count(DISTINCT AnimeID) DESC, Anime_GroupName ASC";
         }
 
         public AniDB_Anime_DefaultImage GetDefaultWideBanner() =>
-            RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(AnimeID, (int) ImageSizeType.WideBanner);
+            RepoFactory.AniDB_Anime_DefaultImage.GetByAnimeIDAndImagezSizeType(AnimeID, ImageSizeType.WideBanner);
 
         public ImageDetails GetDefaultWideBannerDetailsNoBlanks()
         {

--- a/Shoko.Server/Models/SVR_AnimeSeries.cs
+++ b/Shoko.Server/Models/SVR_AnimeSeries.cs
@@ -395,17 +395,17 @@ namespace Shoko.Server.Models
             SeriesNameOverride = string.Empty;
         }
 
-        public void CreateAnimeEpisodes()
+        public void CreateAnimeEpisodes(SVR_AniDB_Anime anime = null)
         {
             using (var session = DatabaseFactory.SessionFactory.OpenSession())
             {
-                CreateAnimeEpisodes(session);
+                CreateAnimeEpisodes(session, anime);
             }
         }
 
-        public void CreateAnimeEpisodes(ISession session)
+        public void CreateAnimeEpisodes(ISession session, SVR_AniDB_Anime anime = null)
         {
-            SVR_AniDB_Anime anime = GetAnime();
+            anime = anime ?? GetAnime();
             if (anime == null) return;
 
             var eps = anime.GetAniDBEpisodes();

--- a/Shoko.Server/Models/SVR_GroupFilter.cs
+++ b/Shoko.Server/Models/SVR_GroupFilter.cs
@@ -35,6 +35,29 @@ namespace Shoko.Server.Models
         internal Dictionary<int, HashSet<int>> _groupsId = new Dictionary<int, HashSet<int>>();
         internal Dictionary<int, HashSet<int>> _seriesId = new Dictionary<int, HashSet<int>>();
         internal List<GroupFilterCondition> _conditions = new List<GroupFilterCondition>();
+        
+        public SVR_GroupFilter Parent
+        {
+            get
+            {
+                return ParentGroupFilterID.HasValue ? RepoFactory.GroupFilter.GetByID(ParentGroupFilterID.Value) : null;
+            }
+        }
+
+        public SVR_GroupFilter TopLevelGroupFilter
+        {
+            get
+            {
+                var parent = Parent;
+                if (parent == null) return this;
+                while (true)
+                {
+                    var next = parent.Parent;
+                    if (next == null) return parent;
+                    parent = next;
+                }
+            }
+        }
 
 
         public virtual HashSet<GroupFilterConditionType> Types

--- a/Shoko.Server/Repositories/Cached/AniDB_Anime_DefaultImageRepository.cs
+++ b/Shoko.Server/Repositories/Cached/AniDB_Anime_DefaultImageRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using NutzCode.InMemoryIndex;
+using Shoko.Models.Enums;
 using Shoko.Models.Server;
 
 namespace Shoko.Server.Repositories.Cached
@@ -9,9 +10,20 @@ namespace Shoko.Server.Repositories.Cached
     {
         private PocoIndex<int, AniDB_Anime_DefaultImage, int> Animes;
 
-        public AniDB_Anime_DefaultImage GetByAnimeIDAndImagezSizeType(int animeid, int imageType)
+        public AniDB_Anime_DefaultImage GetByAnimeIDAndImagezSizeType(int animeid, ImageSizeType imageType)
         {
-            return Animes.GetMultiple(animeid).FirstOrDefault(a => a.ImageType == imageType);
+            return Animes.GetMultiple(animeid).FirstOrDefault(a => a.ImageType == (int) imageType);
+        }
+
+        public AniDB_Anime_DefaultImage GetByAnimeIDAndImagezSizeTypeAndImageEntityType(int animeid, ImageSizeType imageType, ImageEntityType entityType)
+        {
+            var defaultImage = GetByAnimeIDAndImagezSizeType(animeid, imageType);
+            return defaultImage != null && defaultImage.ImageParentType == (int) entityType ? defaultImage : null;
+        }
+
+        public AniDB_Anime_DefaultImage GetByAnimeIDAndImageEntityType(int animeid, ImageEntityType entityType)
+        {
+            return Animes.GetMultiple(animeid).FirstOrDefault(a => a.ImageParentType == (int) entityType);
         }
 
         public List<AniDB_Anime_DefaultImage> GetByAnimeID(int id)

--- a/Shoko.Server/Server/ShokoServer.cs
+++ b/Shoko.Server/Server/ShokoServer.cs
@@ -1757,7 +1757,7 @@ namespace Shoko.Server.Server
 
         private static void CreateTestCommandRequests()
         {
-            CommandRequest_GetAnimeHTTP cr_anime = new CommandRequest_GetAnimeHTTP(5415, false, true);
+            CommandRequest_GetAnimeHTTP cr_anime = new CommandRequest_GetAnimeHTTP(5415, false, true, false);
             cr_anime.Save();
 
             /*

--- a/Shoko.Server/Settings/AniDbSettings.cs
+++ b/Shoko.Server/Settings/AniDbSettings.cs
@@ -59,5 +59,6 @@ namespace Shoko.Server.Settings
         [Range(0, 5, ErrorMessage = "Max Relation Depth may only be between 0 and 5")]
         public int MaxRelationDepth { get; set; } = 3;
 
+        public bool AutomaticallyImportSeries { get; set; } = false;
     }
 }


### PR DESCRIPTION
Add the ability to automatically create the corresponding `AnimeSeries`
entry if it doesn't already exists for related series (behind a setting
that's off by default) under import of a file, or manually in the
v3 api.