### PR TITLE
Ensure consistant directory seperators from renamer plugins

### DIFF
--- a/Shoko.Server/Renamer/RenameFileHelper.cs
+++ b/Shoko.Server/Renamer/RenameFileHelper.cs
@@ -116,6 +116,7 @@ namespace Shoko.Server
                     if (args.Cancel) return (null, null);
                     // if no path was specified, then defer
                     if (string.IsNullOrEmpty(destPath) || destFolder == null) continue;
+                    destPath = destPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
                     destPath = RemoveFilename(place.FilePath, destPath);
 
                     var importFolder = RepoFactory.ImportFolder.GetByImportLocation(destFolder.Location);

--- a/Shoko.Server/Renamer/RenameFileHelper.cs
+++ b/Shoko.Server/Renamer/RenameFileHelper.cs
@@ -116,7 +116,9 @@ namespace Shoko.Server
                     if (args.Cancel) return (null, null);
                     // if no path was specified, then defer
                     if (string.IsNullOrEmpty(destPath) || destFolder == null) continue;
-                    destPath = destPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+                    if (Path.AltDirectorySeparatorChar != Path.DirectorySeparatorChar) {
+                        destPath = destPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+                    }
                     destPath = RemoveFilename(place.FilePath, destPath);
 
                     var importFolder = RepoFactory.ImportFolder.GetByImportLocation(destFolder.Location);


### PR DESCRIPTION
Prevents mixed forward and backslash directory separators from renamer plugins on Windows.