### PR TITLE
Remove constant wait when importing with aggressive FileLockChecking enabled

### DIFF
--- a/Shoko.Server/Commands/Import/CommandRequest_HashFile.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_HashFile.cs
@@ -211,7 +211,6 @@ namespace Shoko.Server.Commands
                         ServerSettings.Instance.SaveSettings();
                     }
 
-                    Thread.Sleep(waitTime);
                     numAttempts = 0;
 
                     //For systems with no locking


### PR DESCRIPTION
I was moving some directories around and re-scanning my media, and I noticed that when importing files there was always a ~4s delay even when an existing VideoLocal entry was found. I can't really tell why from the commit history, but this always waited at least once before attempting an access check (when using aggressive file lock checking). I don't think I've changed settings around here, so it seems like the default is to enable aggressive file lock checking with a 4000ms poll time, which would cause this issue for many users.

In any case, I don't think this sleep is required as we'll sleep pretty much right away if the FileModified poll fails on the first attempt.