### PR TITLE
Add next up deck for dashboard and next up for series

### DIFF
--- a/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation_Entities.cs
+++ b/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation_Entities.cs
@@ -66,7 +66,7 @@ namespace Shoko.Server
                 var series = RepoFactory.AnimeSeries.GetByID(animeSeriesID);
                 if (series == null)
                     return null;
-                var episode = series.GetNextUnwatchedEpisode(userID);
+                var episode = series.GetNextEpisode(userID, true);
                 if (episode == null)
                     return null;
                 return episode.GetUserContract(userID);

--- a/Shoko.Server/API/v3/Controllers/DashboardController.cs
+++ b/Shoko.Server/API/v3/Controllers/DashboardController.cs
@@ -301,7 +301,7 @@ namespace Shoko.Server.API.v3.Controllers
         {
             var user = HttpContext.GetUser();
             var episodeList = RepoFactory.AnimeSeries_User.GetByUserID(user.JMMUserID)
-                .Where(record => (onlyUnwatched ? record.UnwatchedEpisodeCount > 0 : true) && record.WatchedDate.HasValue)
+                .Where(record => record.LastEpisodeUpdate.HasValue && (onlyUnwatched ? record.UnwatchedEpisodeCount > 0 : true))
                 .OrderByDescending(record => record.LastEpisodeUpdate)
                 .Select(record => record.AnimeSeries)
                 .Where(series => user.AllowedSeries(series))

--- a/Shoko.Server/API/v3/Controllers/DashboardController.cs
+++ b/Shoko.Server/API/v3/Controllers/DashboardController.cs
@@ -301,7 +301,7 @@ namespace Shoko.Server.API.v3.Controllers
             var user = HttpContext.GetUser();
             var episodeList = RepoFactory.AnimeSeries_User.GetByUserID(user.JMMUserID)
                 .Where(record => record.WatchedDate.HasValue)
-                .OrderByDescending(record => record.LastUpdated)
+                .OrderByDescending(record => record.LastEpisodeUpdate)
                 .Select(record => record.AnimeSeries)
                 .Where(series => user.AllowedSeries(series))
                 .Select(series => (series, series.GetNextUnwatchedEpisode(user.JMMUserID)))

--- a/Shoko.Server/API/v3/Controllers/DashboardController.cs
+++ b/Shoko.Server/API/v3/Controllers/DashboardController.cs
@@ -295,9 +295,10 @@ namespace Shoko.Server.API.v3.Controllers
         /// <param name="pageSize">Limits the number of results per page. Set to 0 to disable the limit.</param>
         /// <param name="page">Page number.</param>
         /// <param name="onlyUnwatched">Only show unwatched episodes.</param>
+        /// <param name="includeSpecials">Include specials in the search.</param>
         /// <returns></returns>
         [HttpGet("NextUpEpisodes")]
-        public List<Dashboard.EpisodeDetails> GetNextUpEpisodes([FromQuery] [Range(0, 100)] int pageSize = 20, [FromQuery] [Range(0, Int16.MaxValue)] int page = 0, [FromQuery] bool onlyUnwatched = true)
+        public List<Dashboard.EpisodeDetails> GetNextUpEpisodes([FromQuery] [Range(0, 100)] int pageSize = 20, [FromQuery] [Range(0, Int16.MaxValue)] int page = 0, [FromQuery] bool onlyUnwatched = true, [FromQuery] bool includeSpecials = true)
         {
             var user = HttpContext.GetUser();
             var episodeList = RepoFactory.AnimeSeries_User.GetByUserID(user.JMMUserID)
@@ -305,7 +306,7 @@ namespace Shoko.Server.API.v3.Controllers
                 .OrderByDescending(record => record.LastEpisodeUpdate)
                 .Select(record => record.AnimeSeries)
                 .Where(series => user.AllowedSeries(series))
-                .Select(series => (series, series.GetNextEpisode(user.JMMUserID, onlyUnwatched)))
+                .Select(series => (series, series.GetNextEpisode(user.JMMUserID, onlyUnwatched, includeSpecials)))
                 .Where(tuple => tuple.Item2 != null);
             if (pageSize <= 0)
                 return episodeList

--- a/Shoko.Server/API/v3/Controllers/DashboardController.cs
+++ b/Shoko.Server/API/v3/Controllers/DashboardController.cs
@@ -300,6 +300,7 @@ namespace Shoko.Server.API.v3.Controllers
         {
             var user = HttpContext.GetUser();
             var episodeList = RepoFactory.AnimeSeries_User.GetByUserID(user.JMMUserID)
+                .Where(record => record.WatchedDate.HasValue)
                 .OrderByDescending(record => record.LastUpdated)
                 .Select(record => record.AnimeSeries)
                 .Where(series => user.AllowedSeries(series))

--- a/Shoko.Server/API/v3/Controllers/TreeController.cs
+++ b/Shoko.Server/API/v3/Controllers/TreeController.cs
@@ -281,10 +281,10 @@ namespace Shoko.Server.API.v3.Controllers
         /// <see cref="Filter"/> or <see cref="Group"/> is irrelevant at this level.
         /// </remarks>
         /// <param name="seriesID">Series ID</param>
-        /// <param name="includeMissing">Include missing episodes in the list.</param>
+        /// <param name="onlyUnwatched">Only show the next unwatched episode.</param>
         /// <returns></returns>
         [HttpGet("Series/{seriesID}/Episode/NextUp")]
-        public ActionResult<Episode> GetNextUnwatchedEpisode([FromRoute] int seriesID, [FromQuery] bool includeMissing = false)
+        public ActionResult<Episode> GetNextUnwatchedEpisode([FromRoute] int seriesID, [FromQuery] bool onlyUnwatched = false)
         {
             var user = User;
             var series = RepoFactory.AnimeSeries.GetByID(seriesID);
@@ -293,7 +293,7 @@ namespace Shoko.Server.API.v3.Controllers
             if (!user.AllowedSeries(series))
                 return Forbid(SeriesController.SeriesForbiddenForUser);
 
-            var episode = series.GetNextUnwatchedEpisode(user.JMMUserID);
+            var episode = series.GetNextEpisode(user.JMMUserID, onlyUnwatched);
             if (episode == null)
                 return null;
             

--- a/Shoko.Server/API/v3/Controllers/TreeController.cs
+++ b/Shoko.Server/API/v3/Controllers/TreeController.cs
@@ -274,6 +274,32 @@ namespace Shoko.Server.API.v3.Controllers
                 .ToList();
         }
 
+        /// <summary>
+        /// Get the next <see cref="Episode"/> for the <see cref="Series"/> with <paramref name="seriesID"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Filter"/> or <see cref="Group"/> is irrelevant at this level.
+        /// </remarks>
+        /// <param name="seriesID">Series ID</param>
+        /// <param name="includeMissing">Include missing episodes in the list.</param>
+        /// <returns></returns>
+        [HttpGet("Series/{seriesID}/Episode/NextUp")]
+        public ActionResult<Episode> GetNextUnwatchedEpisode([FromRoute] int seriesID, [FromQuery] bool includeMissing = false)
+        {
+            var user = User;
+            var series = RepoFactory.AnimeSeries.GetByID(seriesID);
+            if (series == null)
+                return NotFound(SeriesController.SeriesNotFoundWithSeriesID);
+            if (!user.AllowedSeries(series))
+                return Forbid(SeriesController.SeriesForbiddenForUser);
+
+            var episode = series.GetNextUnwatchedEpisode(user.JMMUserID);
+            if (episode == null)
+                return null;
+            
+            return new Episode(HttpContext, episode);
+        }
+
         #endregion
         #region Episode
 

--- a/Shoko.Server/API/v3/Controllers/TreeController.cs
+++ b/Shoko.Server/API/v3/Controllers/TreeController.cs
@@ -282,9 +282,10 @@ namespace Shoko.Server.API.v3.Controllers
         /// </remarks>
         /// <param name="seriesID">Series ID</param>
         /// <param name="onlyUnwatched">Only show the next unwatched episode.</param>
+        /// <param name="includeSpecials">Include specials in the search.</param>
         /// <returns></returns>
         [HttpGet("Series/{seriesID}/Episode/NextUp")]
-        public ActionResult<Episode> GetNextUnwatchedEpisode([FromRoute] int seriesID, [FromQuery] bool onlyUnwatched = false)
+        public ActionResult<Episode> GetNextUnwatchedEpisode([FromRoute] int seriesID, [FromQuery] bool onlyUnwatched = true, [FromQuery] bool includeSpecials = true)
         {
             var user = User;
             var series = RepoFactory.AnimeSeries.GetByID(seriesID);

--- a/Shoko.Server/Databases/DatabaseFixes.cs
+++ b/Shoko.Server/Databases/DatabaseFixes.cs
@@ -783,5 +783,81 @@ namespace Shoko.Server.Databases
                 }
             }
         }
+
+        public static void FixWatchDates()
+        {
+            // Reset incorrectly parsed watch dates for anidb file.
+            var anidbFilesToSave = new List<SVR_AniDB_File>();
+            foreach (var anidbFile in RepoFactory.AniDB_File.GetAll())
+            {
+                if (anidbFile.WatchedDate.HasValue && anidbFile.WatchedDate.Value.ToUniversalTime().Equals(DateTime.UnixEpoch))
+                {
+                    anidbFile.WatchedDate = null;
+                    anidbFile.IsWatched = 0;
+                    anidbFilesToSave.Add(anidbFile);
+                }
+            }
+            RepoFactory.AniDB_File.Save(anidbFilesToSave);
+            anidbFilesToSave.Clear();
+            // Fetch every episode user record stored to both remove orphaned records and to make sure the watch date is correct.
+            var episodeDict = RepoFactory.AnimeEpisode.GetAll().ToDictionary(episode => episode.AnimeEpisodeID, episode => episode.GetVideoLocals());
+            var episodesURsToSave = new List<SVR_AnimeEpisode_User>();
+            var episodeURsToRemove = new List<SVR_AnimeEpisode_User>();
+            foreach (var episodeUserRecord in RepoFactory.AnimeEpisode_User.GetAll())
+            {
+                // Remove any unkown episode user records.
+                if (!episodeDict.ContainsKey(episodeUserRecord.AnimeEpisodeID))
+                {
+                    episodeURsToRemove.Add(episodeUserRecord);
+                    continue;
+                }
+                // Fetch the file user record for when a file for the episode was last watched.
+                var fileUserRecord = episodeDict[episodeUserRecord.AnimeEpisodeID]
+                    .Select(file => file.GetUserRecord(episodeUserRecord.JMMUserID))
+                    .Where(record => record != null)
+                    .OrderByDescending(record => record.LastUpdated)
+                    .FirstOrDefault(record => record.WatchedDate.HasValue);
+                if (fileUserRecord != null)
+                {
+                    // Check if the episode user record contains the same date and only update it if it does not.
+                    if (!episodeUserRecord.WatchedDate.HasValue || !episodeUserRecord.WatchedDate.Value.Equals(fileUserRecord.WatchedDate.Value))
+                    {
+                        episodeUserRecord.WatchedDate = fileUserRecord.WatchedDate;
+                        if (episodeUserRecord.WatchedCount == 0)
+                            episodeUserRecord.WatchedCount++;
+                        episodesURsToSave.Add(episodeUserRecord);
+                    }
+                }
+                // We couldn't find a watched date for any of the files, so make sure the episode user record is also marked as unwatched.
+                else if (episodeUserRecord.WatchedDate.HasValue)
+                {
+                    episodeUserRecord.WatchedDate = null;
+                    episodesURsToSave.Add(episodeUserRecord);
+                }
+            }
+            // Update the client contracts and save the changes to the database.
+            RepoFactory.AnimeEpisode_User.Delete(episodeURsToRemove);
+            foreach (var episodeUserRecord in episodesURsToSave)
+                RepoFactory.AnimeEpisode_User.Save(episodeUserRecord);
+            // Update all the series and groups to use the new watch dates.
+            var seriesList = episodesURsToSave
+                .GroupBy(record => record.AnimeSeriesID)
+                .Select(records => (RepoFactory.AnimeSeries.GetByID(records.Key), records.Select(record => record.JMMUserID).Distinct()));
+            foreach (var (series, userIDs) in seriesList)
+            {
+                // No idea why we would have episode entries for a deleted series, but just in case.
+                if (series == null)
+                    continue;
+                // Update the timestamp for when an episode for the series was last partially or fully watched.
+                foreach (var userID in userIDs)
+                {
+                    var seriesUserRecord = series.GetOrCreateUserRecord(userID);
+                    seriesUserRecord.LastEpisodeUpdate = DateTime.Now;
+                    RepoFactory.AnimeSeries_User.Save(seriesUserRecord);
+                }
+                // Update the rest of the stats for the series.
+                series.UpdateStats(true, true, true);
+            }
+        }
     }
 }

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -20,7 +20,7 @@ namespace Shoko.Server.Databases
     public class MySQL : BaseDatabase<MySqlConnection>, IDatabase
     {
         public string Name { get; } = "MySQL";
-        public int RequiredVersion { get; } = 95;
+        public int RequiredVersion { get; } = 96;
 
 
         private List<DatabaseCommand> createVersionTable = new List<DatabaseCommand>
@@ -639,6 +639,7 @@ namespace Shoko.Server.Databases
             new DatabaseCommand(95, 2, "ALTER TABLE VideoLocal_User ADD WatchedCount INT NOT NULL DEFAULT 0;"),
             new DatabaseCommand(95, 3, "ALTER TABLE VideoLocal_User ADD LastUpdated datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;"),
             new DatabaseCommand(95, 4, "UPDATE VideoLocal_User SET WatchedCount = 1, LastUpdated = WatchedDate WHERE WatchedDate IS NOT NULL;"),
+            new DatabaseCommand(96, 1, "ALTER TABLE AnimeSeries_User ADD LastUpdated datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;"),
         };
 
         private DatabaseCommand linuxTableVersionsFix = new DatabaseCommand("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -640,6 +640,7 @@ namespace Shoko.Server.Databases
             new DatabaseCommand(95, 3, "ALTER TABLE VideoLocal_User ADD LastUpdated datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;"),
             new DatabaseCommand(95, 4, "UPDATE VideoLocal_User SET WatchedCount = 1, LastUpdated = WatchedDate WHERE WatchedDate IS NOT NULL;"),
             new DatabaseCommand(96, 1, "ALTER TABLE AnimeSeries_User ADD LastEpisodeUpdate datetime DEFAULT NULL;"),
+            new DatabaseCommand(96, 2, DatabaseFixes.FixWatchDates),
         };
 
         private DatabaseCommand linuxTableVersionsFix = new DatabaseCommand("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -639,7 +639,7 @@ namespace Shoko.Server.Databases
             new DatabaseCommand(95, 2, "ALTER TABLE VideoLocal_User ADD WatchedCount INT NOT NULL DEFAULT 0;"),
             new DatabaseCommand(95, 3, "ALTER TABLE VideoLocal_User ADD LastUpdated datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;"),
             new DatabaseCommand(95, 4, "UPDATE VideoLocal_User SET WatchedCount = 1, LastUpdated = WatchedDate WHERE WatchedDate IS NOT NULL;"),
-            new DatabaseCommand(96, 1, "ALTER TABLE AnimeSeries_User ADD LastUpdated datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;"),
+            new DatabaseCommand(96, 1, "ALTER TABLE AnimeSeries_User ADD LastEpisodeUpdate datetime DEFAULT NULL;"),
         };
 
         private DatabaseCommand linuxTableVersionsFix = new DatabaseCommand("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -617,7 +617,7 @@ namespace Shoko.Server.Databases
             new DatabaseCommand(88, 2, "ALTER TABLE VideoLocal_User ADD WatchedCount INT NOT NULL DEFAULT 0;"),
             new DatabaseCommand(88, 3, "ALTER TABLE VideoLocal_User ADD LastUpdated datetime NOT NULL DEFAULT CURRENT_TIMESTAMP;"),
             new DatabaseCommand(88, 4, "UPDATE VideoLocal_User SET WatchedCount = 1, LastUpdated = WatchedDate WHERE WatchedDate IS NOT NULL;"),
-            new DatabaseCommand(89, 1, "ALTER TABLE AnimeSeries_User ADD LastUpdated datetime NOT NULL DEFAULT CURRENT_TIMESTAMP;"),
+            new DatabaseCommand(89, 1, "ALTER TABLE AnimeSeries_User ADD LastEpisodeUpdate datetime DEFAULT NULL;"),
         };
 
         private List<DatabaseCommand> updateVersionTable = new List<DatabaseCommand>

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -26,7 +26,7 @@ namespace Shoko.Server.Databases
     public class SQLServer : BaseDatabase<SqlConnection>, IDatabase
     {
         public string Name { get; } = "SQLServer";
-        public int RequiredVersion { get; } = 88;
+        public int RequiredVersion { get; } = 89;
 
         public void BackupDatabase(string fullfilename)
         {
@@ -617,6 +617,7 @@ namespace Shoko.Server.Databases
             new DatabaseCommand(88, 2, "ALTER TABLE VideoLocal_User ADD WatchedCount INT NOT NULL DEFAULT 0;"),
             new DatabaseCommand(88, 3, "ALTER TABLE VideoLocal_User ADD LastUpdated datetime NOT NULL DEFAULT CURRENT_TIMESTAMP;"),
             new DatabaseCommand(88, 4, "UPDATE VideoLocal_User SET WatchedCount = 1, LastUpdated = WatchedDate WHERE WatchedDate IS NOT NULL;"),
+            new DatabaseCommand(89, 1, "ALTER TABLE AnimeSeries_User ADD LastUpdated datetime NOT NULL DEFAULT CURRENT_TIMESTAMP;"),
         };
 
         private List<DatabaseCommand> updateVersionTable = new List<DatabaseCommand>

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -618,6 +618,7 @@ namespace Shoko.Server.Databases
             new DatabaseCommand(88, 3, "ALTER TABLE VideoLocal_User ADD LastUpdated datetime NOT NULL DEFAULT CURRENT_TIMESTAMP;"),
             new DatabaseCommand(88, 4, "UPDATE VideoLocal_User SET WatchedCount = 1, LastUpdated = WatchedDate WHERE WatchedDate IS NOT NULL;"),
             new DatabaseCommand(89, 1, "ALTER TABLE AnimeSeries_User ADD LastEpisodeUpdate datetime DEFAULT NULL;"),
+            new DatabaseCommand(89, 2, DatabaseFixes.FixWatchDates),
         };
 
         private List<DatabaseCommand> updateVersionTable = new List<DatabaseCommand>

--- a/Shoko.Server/Databases/SQLite.cs
+++ b/Shoko.Server/Databases/SQLite.cs
@@ -557,6 +557,7 @@ namespace Shoko.Server.Databases
             new DatabaseCommand(83, 3, "ALTER TABLE VideoLocal_User ADD LastUpdated timestamp NOT NULL DEFAULT '2000-01-01 00:00:00';"),
             new DatabaseCommand(83, 4, "UPDATE VideoLocal_User SET WatchedCount = 1, LastUpdated = WatchedDate WHERE WatchedDate IS NOT NULL;"),
             new DatabaseCommand(84, 1, "ALTER TABLE AnimeSeries_User ADD LastEpisodeUpdate timestamp DEFAULT NULL;"),
+            new DatabaseCommand(84, 2, DatabaseFixes.FixWatchDates),
         };
 
         private static Tuple<bool, string> DropVideoLocal_Media(object connection)

--- a/Shoko.Server/Databases/SQLite.cs
+++ b/Shoko.Server/Databases/SQLite.cs
@@ -22,7 +22,7 @@ namespace Shoko.Server.Databases
 
         public string Name { get; } = "SQLite";
 
-        public int RequiredVersion { get; } = 83;
+        public int RequiredVersion { get; } = 84;
 
 
         public void BackupDatabase(string fullfilename)
@@ -556,6 +556,7 @@ namespace Shoko.Server.Databases
             new DatabaseCommand(83, 2, "ALTER TABLE VideoLocal_User ADD WatchedCount INT NOT NULL DEFAULT 0;"),
             new DatabaseCommand(83, 3, "ALTER TABLE VideoLocal_User ADD LastUpdated timestamp NOT NULL DEFAULT '2000-01-01 00:00:00';"),
             new DatabaseCommand(83, 4, "UPDATE VideoLocal_User SET WatchedCount = 1, LastUpdated = WatchedDate WHERE WatchedDate IS NOT NULL;"),
+            new DatabaseCommand(84, 1, "ALTER TABLE AnimeSeries_User ADD LastUpdated timestamp NOT NULL DEFAULT '2000-01-01 00:00:00';"),
         };
 
         private static Tuple<bool, string> DropVideoLocal_Media(object connection)

--- a/Shoko.Server/Databases/SQLite.cs
+++ b/Shoko.Server/Databases/SQLite.cs
@@ -556,7 +556,7 @@ namespace Shoko.Server.Databases
             new DatabaseCommand(83, 2, "ALTER TABLE VideoLocal_User ADD WatchedCount INT NOT NULL DEFAULT 0;"),
             new DatabaseCommand(83, 3, "ALTER TABLE VideoLocal_User ADD LastUpdated timestamp NOT NULL DEFAULT '2000-01-01 00:00:00';"),
             new DatabaseCommand(83, 4, "UPDATE VideoLocal_User SET WatchedCount = 1, LastUpdated = WatchedDate WHERE WatchedDate IS NOT NULL;"),
-            new DatabaseCommand(84, 1, "ALTER TABLE AnimeSeries_User ADD LastUpdated timestamp NOT NULL DEFAULT '2000-01-01 00:00:00';"),
+            new DatabaseCommand(84, 1, "ALTER TABLE AnimeSeries_User ADD LastEpisodeUpdate timestamp DEFAULT NULL;"),
         };
 
         private static Tuple<bool, string> DropVideoLocal_Media(object connection)

--- a/Shoko.Server/Extensions/ModelDatabase.cs
+++ b/Shoko.Server/Extensions/ModelDatabase.cs
@@ -69,7 +69,7 @@ namespace Shoko.Server.Extensions
             RepoFactory.AnimeEpisode.Save(existingEp);
 
             // We might have removed our AnimeEpisode_User records when wiping out AnimeEpisodes, recreate them if there's watched files
-            var vlUsers = existingEp?.GetVideoLocals()
+            var vlUsers = existingEp.GetVideoLocals()
                 .SelectMany(a => RepoFactory.VideoLocalUser.GetByVideoLocalID(a.VideoLocalID)).ToList();
             
             // get the list of unique users
@@ -84,17 +84,14 @@ namespace Shoko.Server.Extensions
                     var vlUser = vlUsers.Where(a => a.JMMUserID == uid && a.WatchedDate != null)
                         .MaxBy(a => a.WatchedDate).FirstOrDefault();
                     // create or update the record
-                    var epUser = RepoFactory.AnimeEpisode_User.GetByUserIDAndEpisodeID(uid, existingEp.AnimeEpisodeID);
+                    var epUser = existingEp.GetUserRecord(uid);
                     if (epUser == null)
                     {
-                        epUser = new SVR_AnimeEpisode_User
+                        epUser = new SVR_AnimeEpisode_User(uid, existingEp.AnimeEpisodeID, animeSeriesID)
                         {
-                            JMMUserID = uid,
                             WatchedDate = vlUser?.WatchedDate,
                             PlayedCount = vlUser != null ? 1 : 0,
                             WatchedCount = vlUser != null ? 1 : 0,
-                            AnimeSeriesID = animeSeriesID,
-                            AnimeEpisodeID = existingEp.AnimeEpisodeID
                         };
                         RepoFactory.AnimeEpisode_User.Save(epUser);
                     }

--- a/Shoko.Server/Mappings/AnimeSeries_UserMap.cs
+++ b/Shoko.Server/Mappings/AnimeSeries_UserMap.cs
@@ -19,7 +19,7 @@ namespace Shoko.Server.Mappings
             Map(x => x.WatchedCount).Not.Nullable();
             Map(x => x.WatchedDate);
             Map(x => x.WatchedEpisodeCount).Not.Nullable();
-            Map(x => x.LastUpdated).Not.Nullable();
+            Map(x => x.LastEpisodeUpdate).Not.Nullable();
         }
     }
 }

--- a/Shoko.Server/Mappings/AnimeSeries_UserMap.cs
+++ b/Shoko.Server/Mappings/AnimeSeries_UserMap.cs
@@ -19,6 +19,7 @@ namespace Shoko.Server.Mappings
             Map(x => x.WatchedCount).Not.Nullable();
             Map(x => x.WatchedDate);
             Map(x => x.WatchedEpisodeCount).Not.Nullable();
+            Map(x => x.LastUpdated).Not.Nullable();
         }
     }
 }

--- a/Shoko.Server/Models/SVR_AnimeEpisode_User.cs
+++ b/Shoko.Server/Models/SVR_AnimeEpisode_User.cs
@@ -11,6 +11,20 @@ namespace Shoko.Server.Models
         public byte[] ContractBlob { get; set; }
         public int ContractSize { get; set; }
 
+        public SVR_AnimeEpisode_User() {}
+
+        public SVR_AnimeEpisode_User(int userID, int episodeID, int seriesID)
+        {
+            JMMUserID = userID;
+            AnimeEpisodeID = episodeID;
+            AnimeSeriesID = seriesID;
+            PlayedCount = 0;
+            StoppedCount = 0;
+            WatchedCount = 0;
+            WatchedDate = null;
+            _contract = null;
+        }
+
 
         public const int CONTRACT_VERSION = 3;
 

--- a/Shoko.Server/Models/SVR_AnimeSeries.cs
+++ b/Shoko.Server/Models/SVR_AnimeSeries.cs
@@ -356,13 +356,14 @@ namespace Shoko.Server.Models
         /// </summary>
         /// <param name="userID">User ID</param>
         /// <param name="onlyUnwatched">Only check for unwatched episodes.</param>
+        /// <param name="includeSpecials">Include specials when searching.</param>
         /// <returns></returns>
-        public SVR_AnimeEpisode GetNextEpisode(int userID, bool onlyUnwatched)
+        public SVR_AnimeEpisode GetNextEpisode(int userID, bool onlyUnwatched, bool includeSpecials = true)
         {
             // Filter the episodes to only normal or special episodes and order them in rising order.
             var episodes = GetAnimeEpisodes()
                 .Select(episode => (episode, episode.AniDB_Episode))
-                .Where(tuple => tuple.AniDB_Episode.EpisodeType  == (int) EpisodeType.Episode || tuple.AniDB_Episode.EpisodeType == (int) EpisodeType.Special)
+                .Where(tuple => tuple.AniDB_Episode.EpisodeType  == (int) EpisodeType.Episode || (includeSpecials && tuple.AniDB_Episode.EpisodeType == (int) EpisodeType.Special))
                 .OrderBy(tuple => tuple.AniDB_Episode.EpisodeType)
                 .ThenBy(tuple => tuple.AniDB_Episode.EpisodeNumber)
                 .Select(tuple => tuple.episode)

--- a/Shoko.Server/Models/SVR_AnimeSeries.cs
+++ b/Shoko.Server/Models/SVR_AnimeSeries.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -321,7 +321,7 @@ namespace Shoko.Server.Models
         public void TouchUserRecord(int userID)
         {
             var serUserRecord = GetOrCreateUserRecord(userID);
-            serUserRecord.LastUpdated = DateTime.Now;
+            serUserRecord.LastEpisodeUpdate = DateTime.Now;
             RepoFactory.AnimeSeries_User.Save(serUserRecord);
         }
 

--- a/Shoko.Server/Models/SVR_AnimeSeries_User.cs
+++ b/Shoko.Server/Models/SVR_AnimeSeries_User.cs
@@ -14,6 +14,22 @@ namespace Shoko.Server.Models
         {
         }
 
+        public SVR_AnimeSeries_User(int userID, int seriesID)
+        {
+            JMMUserID = userID;
+            AnimeSeriesID = seriesID;
+            UnwatchedEpisodeCount = 0;
+            WatchedEpisodeCount = 0;
+            WatchedDate = null;
+            PlayedCount = 0;
+            WatchedCount = 0;
+            StoppedCount = 0;
+            LastUpdated = DateTime.Now;
+        }
+
+        public virtual SVR_AnimeSeries AnimeSeries
+            => RepoFactory.AnimeSeries.GetByID(AnimeSeriesID);
+
         private DateTime _lastPlexRegen = DateTime.MinValue;
         private Video _plexContract;
 
@@ -81,19 +97,6 @@ namespace Shoko.Server.Models
                 if (change)
                     RepoFactory.GroupFilter.Save(gf);
             }
-        }
-
-
-        public SVR_AnimeSeries_User(int userID, int seriesID)
-        {
-            JMMUserID = userID;
-            AnimeSeriesID = seriesID;
-            UnwatchedEpisodeCount = 0;
-            WatchedEpisodeCount = 0;
-            WatchedDate = null;
-            PlayedCount = 0;
-            WatchedCount = 0;
-            StoppedCount = 0;
         }
     }
 }

--- a/Shoko.Server/Models/SVR_AnimeSeries_User.cs
+++ b/Shoko.Server/Models/SVR_AnimeSeries_User.cs
@@ -24,7 +24,7 @@ namespace Shoko.Server.Models
             PlayedCount = 0;
             WatchedCount = 0;
             StoppedCount = 0;
-            LastUpdated = DateTime.Now;
+            LastEpisodeUpdate = null;
         }
 
         public virtual SVR_AnimeSeries AnimeSeries

--- a/Shoko.Server/Models/SVR_VideoLocal.cs
+++ b/Shoko.Server/Models/SVR_VideoLocal.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -252,7 +252,7 @@ namespace Shoko.Server.Models
 
         public void ToggleWatchedStatus(bool watched, int userID)
         {
-            ToggleWatchedStatus(watched, true, null, true, userID, true, true);
+            ToggleWatchedStatus(watched, true, watched ? DateTime.Now : null, true, userID, true, true);
         }
 
         public void ToggleWatchedStatus(bool watched, bool updateOnline, DateTime? watchedDate, bool updateStats, int userID,

--- a/Shoko.Server/Models/SVR_VideoLocal.cs
+++ b/Shoko.Server/Models/SVR_VideoLocal.cs
@@ -448,8 +448,8 @@ namespace Shoko.Server.Models
             {
                 cl.IsWatched = 1;
                 cl.WatchedDate = userRecord.WatchedDate;
-                cl.ResumePosition = userRecord.ResumePosition;
             }
+            cl.ResumePosition = userRecord?.ResumePosition ?? 0;
 
             try
             {
@@ -507,15 +507,13 @@ namespace Shoko.Server.Models
             {
                 cl.VideoLocal_IsWatched = 0;
                 cl.VideoLocal_WatchedDate = null;
-                cl.VideoLocal_ResumePosition = 0;
             }
             else
             {
                 cl.VideoLocal_IsWatched = 1;
                 cl.VideoLocal_WatchedDate = userRecord.WatchedDate;
             }
-            if (userRecord != null)
-                cl.VideoLocal_ResumePosition = userRecord.ResumePosition;
+            cl.VideoLocal_ResumePosition = userRecord?.ResumePosition ?? 0;
             cl.VideoInfo_AudioBitrate = Media?.AudioStreams.FirstOrDefault()?.BitRate.ToString();
             cl.VideoInfo_AudioCodec =
                 LegacyMediaUtils.TranslateCodec(Media?.AudioStreams.FirstOrDefault());
@@ -607,15 +605,13 @@ namespace Shoko.Server.Models
             {
                 cl.IsWatched = 0;
                 cl.WatchedDate = null;
-                cl.ResumePosition = 0;
             }
             else
             {
                 cl.IsWatched = 1;
                 cl.WatchedDate = userRecord.WatchedDate;
             }
-            if (userRecord != null)
-                cl.ResumePosition = userRecord.ResumePosition;
+            cl.ResumePosition = userRecord?.ResumePosition ?? 0;
             return cl;
         }
 


### PR DESCRIPTION
Need to fix up the series endpoint so it shows either the active episode or the next if no active. The dashboard endpoints have been tested (in my local copy of the web ui).

Also, blocked by https://github.com/ShokoAnime/Shoko.Models/pull/6 and https://github.com/ShokoAnime/Shoko.Commons/pull/7