### PR TITLE
cleanup: remove episode user record contracts from the db

### DIFF
--- a/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation_Entities.cs
+++ b/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation_Entities.cs
@@ -480,24 +480,7 @@ namespace Shoko.Server
         {
             try
             {
-                return RepoFactory.AnimeEpisode_User.GetLastWatchedEpisodeForSeries(animeSeriesID, jmmuserID)?.Contract;
-                /*
-                                using (var session = JMMService.SessionFactory.OpenSession())
-                                {
-                                    AnimeEpisodeRepository repEps = new AnimeEpisodeRepository();
-                                    JMMUserRepository repUsers = new JMMUserRepository();
-
-                                    JMMUser user = repUsers.GetByID(session, jmmuserID);
-                                    if (user == null) return null;
-
-                                    List<AnimeEpisode_User> userRecords = repEpUser.GetLastWatchedEpisodeForSeries(session, animeSeriesID, jmmuserID);
-                                    if (userRecords == null || userRecords.Count == 0) return null;
-
-                                    AnimeEpisode ep = repEps.GetByID(session, userRecords[0].AnimeEpisodeID);
-                                    if (ep == null) return null;
-
-                                    return ep.ToContract(session, jmmuserID);
-                                }*/
+                return RepoFactory.AnimeEpisode_User.GetLastWatchedEpisodeForSeries(animeSeriesID, jmmuserID)?.GetAnimeEpisode()?.GetUserContract(jmmuserID);
             }
             catch (Exception ex)
             {

--- a/Shoko.Server/API/v1/Implementations/ShokoServiceImplementationMetro.cs
+++ b/Shoko.Server/API/v1/Implementations/ShokoServiceImplementationMetro.cs
@@ -692,17 +692,11 @@ namespace Shoko.Server
                         if (dictAniEps.ContainsKey(ep.AniDB_EpisodeID))
                         {
                             AniDB_Episode anidbep = dictAniEps[ep.AniDB_EpisodeID];
-                            if (anidbep.EpisodeType == (int) EpisodeType.Episode ||
-                                anidbep.EpisodeType == (int) EpisodeType.Special)
+                            if (anidbep.EpisodeType == (int) EpisodeType.Episode || anidbep.EpisodeType == (int) EpisodeType.Special)
                             {
-                                SVR_AnimeEpisode_User userRecord = null;
-                                if (dictEpUsers.ContainsKey(ep.AnimeEpisodeID))
-                                {
-                                    userRecord = dictEpUsers[ep.AnimeEpisodeID];
-                                    CL_AnimeEpisode_User epContract = userRecord.Contract;
-                                    if (epContract != null)
-                                        candidateEps.Add(epContract);
-                                }
+                                // The episode list have already been filtered to only episodes with a user record
+                                // So just add the candidate to the list.
+                                candidateEps.Add(ep.GetUserContract(jmmuserID));
                             }
                         }
                     }

--- a/Shoko.Server/Databases/DatabaseFixes.cs
+++ b/Shoko.Server/Databases/DatabaseFixes.cs
@@ -840,13 +840,8 @@ namespace Shoko.Server.Databases
                 }
             }
             logger.Debug($"Found {episodesURsToSave.Count} episode user records to fix.");
-            // Update the client contracts and save the changes to the database.
             RepoFactory.AnimeEpisode_User.Delete(episodeURsToRemove);
-            foreach (var episodeUserRecord in episodesURsToSave)
-            {
-                logger.Debug($"Updating episode user contract for user \"{userDict[episodeUserRecord.JMMUserID].Username}\". (UserID={episodeUserRecord.JMMUserID},EpisodeID={episodeUserRecord.AnimeEpisodeID},SeriesID={episodeUserRecord.AnimeSeriesID})");
-                RepoFactory.AnimeEpisode_User.Save(episodeUserRecord);
-            }
+            RepoFactory.AnimeEpisode_User.Save(episodesURsToSave);
             logger.Debug($"Updating series user records and series stats.");
             // Update all the series and groups to use the new watch dates.
             var seriesList = episodesURsToSave

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -20,7 +20,7 @@ namespace Shoko.Server.Databases
     public class MySQL : BaseDatabase<MySqlConnection>, IDatabase
     {
         public string Name { get; } = "MySQL";
-        public int RequiredVersion { get; } = 97;
+        public int RequiredVersion { get; } = 98;
 
 
         private List<DatabaseCommand> createVersionTable = new List<DatabaseCommand>
@@ -642,6 +642,7 @@ namespace Shoko.Server.Databases
             new DatabaseCommand(96, 1, "ALTER TABLE AnimeSeries_User ADD LastEpisodeUpdate datetime DEFAULT NULL;"),
             new DatabaseCommand(96, 2, DatabaseFixes.FixWatchDates),
             new DatabaseCommand(97, 1, "ALTER TABLE AnimeGroup ADD MainAniDBAnimeID INT DEFAULT NULL;"),
+            new DatabaseCommand(98, 1, "ALTER TABLE AnimeEpisode_User DROP COLUMN ContractSize, DROP COLUMN ContractBlob, DROP COLUMN ContractVersion;"),
         };
 
         private DatabaseCommand linuxTableVersionsFix = new DatabaseCommand("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -620,6 +620,9 @@ namespace Shoko.Server.Databases
             new DatabaseCommand(89, 1, "ALTER TABLE AnimeSeries_User ADD LastEpisodeUpdate datetime DEFAULT NULL;"),
             new DatabaseCommand(89, 2, DatabaseFixes.FixWatchDates),
             new DatabaseCommand(90, 1, "ALTER TABLE AnimeGroup ADD MainAniDBAnimeID INT DEFAULT NULL;"),
+            new DatabaseCommand(91, 1, "ALTER TABLE AnimeEpisode_User DROP COLUMN ContractSize;"),
+            new DatabaseCommand(91, 2, "ALTER TABLE AnimeEpisode_User DROP COLUMN ContractBlob;"),
+            new DatabaseCommand(91, 3, "ALTER TABLE AnimeEpisode_User DROP COLUMN ContractVersion;"),
         };
 
         private List<DatabaseCommand> updateVersionTable = new List<DatabaseCommand>

--- a/Shoko.Server/Databases/SQLite.cs
+++ b/Shoko.Server/Databases/SQLite.cs
@@ -22,7 +22,7 @@ namespace Shoko.Server.Databases
 
         public string Name { get; } = "SQLite";
 
-        public int RequiredVersion { get; } = 85;
+        public int RequiredVersion { get; } = 86;
 
 
         public void BackupDatabase(string fullfilename)
@@ -559,6 +559,9 @@ namespace Shoko.Server.Databases
             new DatabaseCommand(84, 1, "ALTER TABLE AnimeSeries_User ADD LastEpisodeUpdate timestamp DEFAULT NULL;"),
             new DatabaseCommand(84, 2, DatabaseFixes.FixWatchDates),
             new DatabaseCommand(85, 1, "ALTER TABLE AnimeGroup ADD MainAniDBAnimeID INT DEFAULT NULL;"),
+            new DatabaseCommand(86, 1, "ALTER TABLE AnimeEpisode_User DROP COLUMN ContractSize;"),
+            new DatabaseCommand(86, 2, "ALTER TABLE AnimeEpisode_User DROP COLUMN ContractBlob;"),
+            new DatabaseCommand(86, 3, "ALTER TABLE AnimeEpisode_User DROP COLUMN ContractVersion;"),
         };
 
         private static Tuple<bool, string> DropVideoLocal_Media(object connection)

--- a/Shoko.Server/Mappings/AnimeEpisode_UserMap.cs
+++ b/Shoko.Server/Mappings/AnimeEpisode_UserMap.cs
@@ -18,9 +18,6 @@ namespace Shoko.Server.Mappings
             Map(x => x.StoppedCount).Not.Nullable();
             Map(x => x.WatchedCount).Not.Nullable();
             Map(x => x.WatchedDate);
-            Map(x => x.ContractVersion).Not.Nullable();
-            Map(x => x.ContractBlob).Nullable().CustomType("BinaryBlob");
-            Map(x => x.ContractSize).Not.Nullable();
         }
     }
 }

--- a/Shoko.Server/Models/SVR_AnimeEpisode.cs
+++ b/Shoko.Server/Models/SVR_AnimeEpisode.cs
@@ -143,7 +143,35 @@ namespace Shoko.Server.Models
 
         public CL_AnimeEpisode_User GetUserContract(int userID, ISessionWrapper session = null)
         {
-            return GetOrCreateUserRecord(userID, session).Contract;
+            var anidbEpisode = AniDB_Episode;
+            var seriesUserRecord = RepoFactory.AnimeSeries_User.GetByUserAndSeriesID(userID, AnimeSeriesID);
+            var episodeUserRecord = GetOrCreateUserRecord(userID, session);
+            var contract = new CL_AnimeEpisode_User
+            {
+                AniDB_EpisodeID = AniDB_EpisodeID,
+                AnimeEpisodeID = AnimeEpisodeID,
+                AnimeSeriesID = AnimeSeriesID,
+                DateTimeCreated = DateTimeCreated,
+                DateTimeUpdated = DateTimeUpdated,
+                PlayedCount = episodeUserRecord.PlayedCount,
+                StoppedCount = episodeUserRecord.StoppedCount,
+                WatchedCount = episodeUserRecord.WatchedCount,
+                WatchedDate = episodeUserRecord.WatchedDate,
+                AniDB_EnglishName = RepoFactory.AniDB_Episode_Title.GetByEpisodeIDAndLanguage(AniDB_EpisodeID, "EN")
+                    .FirstOrDefault()?.Title,
+                AniDB_RomajiName = RepoFactory.AniDB_Episode_Title.GetByEpisodeIDAndLanguage(AniDB_EpisodeID, "X-JAT")
+                    .FirstOrDefault()?.Title,
+                AniDB_AirDate = anidbEpisode.GetAirDateAsDate(),
+                AniDB_LengthSeconds = anidbEpisode.LengthSeconds,
+                AniDB_Rating = anidbEpisode.Rating,
+                AniDB_Votes = anidbEpisode.Votes,
+                EpisodeNumber = anidbEpisode.EpisodeNumber,
+                Description = anidbEpisode.Description,
+                EpisodeType = anidbEpisode.EpisodeType,
+                UnwatchedEpCountSeries = seriesUserRecord?.UnwatchedEpisodeCount ?? 0,
+                LocalFileCount = GetVideoLocals().Count,
+            };
+            return contract;
         }
 
         public void ToggleWatchedStatus(bool watched, bool updateOnline, DateTime? watchedDate, int userID,

--- a/Shoko.Server/Models/SVR_AnimeEpisode_User.cs
+++ b/Shoko.Server/Models/SVR_AnimeEpisode_User.cs
@@ -7,10 +7,6 @@ namespace Shoko.Server.Models
 {
     public class SVR_AnimeEpisode_User : AnimeEpisode_User
     {
-        public int ContractVersion { get; set; }
-        public byte[] ContractBlob { get; set; }
-        public int ContractSize { get; set; }
-
         public SVR_AnimeEpisode_User() {}
 
         public SVR_AnimeEpisode_User(int userID, int episodeID, int seriesID)

--- a/Shoko.Server/Models/SVR_AnimeEpisode_User.cs
+++ b/Shoko.Server/Models/SVR_AnimeEpisode_User.cs
@@ -22,43 +22,11 @@ namespace Shoko.Server.Models
             StoppedCount = 0;
             WatchedCount = 0;
             WatchedDate = null;
-            _contract = null;
         }
 
-
-        public const int CONTRACT_VERSION = 3;
-
-
-        internal CL_AnimeEpisode_User _contract;
-
-        internal virtual CL_AnimeEpisode_User Contract
+        public SVR_AnimeEpisode GetAnimeEpisode()
         {
-            get
-            {
-                if ((_contract == null) && (ContractBlob != null) && (ContractBlob.Length > 0) && (ContractSize > 0))
-                    _contract = CompressionHelper.DeserializeObject<CL_AnimeEpisode_User>(ContractBlob, ContractSize);
-                if (_contract != null)
-                {
-                    SVR_AnimeSeries_User seuse =
-                        RepoFactory.AnimeSeries_User.GetByUserAndSeriesID(JMMUserID, AnimeSeriesID);
-                    _contract.UnwatchedEpCountSeries = seuse?.UnwatchedEpisodeCount ?? 0;
-                    SVR_AnimeEpisode aep = RepoFactory.AnimeEpisode.GetByID(AnimeEpisodeID);
-                    _contract.LocalFileCount = aep?.GetVideoLocals().Count ?? 0;
-                }
-                return _contract;
-            }
-            set
-            {
-                _contract = value;
-                ContractBlob = CompressionHelper.SerializeObject(value, out int outsize);
-                ContractSize = outsize;
-                ContractVersion = CONTRACT_VERSION;
-            }
-        }
-
-        public void CollectContractMemory()
-        {
-            _contract = null;
+            return RepoFactory.AnimeEpisode.GetByID(AnimeEpisodeID);
         }
     }
 }

--- a/Shoko.Server/Repositories/RepoFactory.cs
+++ b/Shoko.Server/Repositories/RepoFactory.cs
@@ -156,7 +156,6 @@ namespace Shoko.Server.Repositories
         {
             AniDB_Anime.GetAll().ForEach(a => a.CollectContractMemory());
             VideoLocal.GetAll().ForEach(a => a.CollectContractMemory());
-            AnimeEpisode_User.GetAll().ForEach(a => a.CollectContractMemory());
             AnimeSeries.GetAll().ForEach(a => a.CollectContractMemory());
             AnimeSeries_User.GetAll().ForEach(a => a.CollectContractMemory());
             AnimeGroup.GetAll().ForEach(a => a.CollectContractMemory());

--- a/Shoko.Server/Shoko.Server.csproj
+++ b/Shoko.Server/Shoko.Server.csproj
@@ -88,7 +88,7 @@
     <!-- This needs to be explicit because of dep BS -->
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
-    <PackageReference Include="System.Data.Sqlite" Version="1.0.113.1" />
+    <PackageReference Include="System.Data.Sqlite" Version="1.0.116" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="5.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <!-- This needs to be explicit because of https://github.com/MySqlBackupNET/MySqlBackup.Net/issues/61 -->

--- a/Shoko.Server/Tasks/ContractExtractor.cs
+++ b/Shoko.Server/Tasks/ContractExtractor.cs
@@ -34,17 +34,6 @@ namespace Shoko.Server.Tasks
                     return pb;
                 });
             });
-            ContractExtractors.Add("AnimeEpisode_User", (sw, za) =>
-            {
-                ExtractContracts<SVR_AnimeEpisode_User, CL_AnimeEpisode_User>(sw, za, pb =>
-                {
-                    pb.Select(CreateEntryNameProjection<SVR_AnimeEpisode_User>("AnimeEpisode_User\\u", a => a.JMMUserID,
-                        "\\s", a => a.AnimeSeriesID, "_e", a => a.AnimeEpisodeID));
-                    pb.Select(s => s.ContractSize);
-                    pb.Select(s => s.ContractBlob);
-                    return pb;
-                });
-            });
             ContractExtractors.Add("AnimeGroup", (sw, za) =>
             {
                 ExtractContracts<SVR_AnimeGroup, CL_AnimeGroup_User>(sw, za, pb =>


### PR DESCRIPTION
remove episode user record contracts from the db and generate the client user contracts on the fly instead.