### PR TITLE
feat(series): Make search not coerce strings to ascii when using non-latin languages in settings

### DIFF
--- a/Shoko.Server/API/v2/Modules/Common.cs
+++ b/Shoko.Server/API/v2/Modules/Common.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Dynamic;
@@ -2686,9 +2686,12 @@ namespace Shoko.Server.API.v2.Modules
             double dist = double.MaxValue;
 
             if (string.IsNullOrEmpty(a.GroupName)) return;
+
+            bool forceAscii = Languages.PreferredNamingLanguages.ContainsOnlyLatin();
+
             int k = Math.Max(Math.Min((int)(a.GroupName.Length / 6D), (int)(query.Length / 6D)), 1);
             if (query.Length <= 4 || a.GroupName.Length <= 4) k = 0;
-            var result = Misc.DiceFuzzySearch(a.GroupName, query, k, a);
+            var result = Misc.DiceFuzzySearch(a.GroupName, query, k, a, forceAscii);
             if (result.Index == -1) return;
             if (result.Distance < dist)
             {

--- a/Shoko.Server/Models/SVR_AnimeSeries.cs
+++ b/Shoko.Server/Models/SVR_AnimeSeries.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -21,6 +21,7 @@ using Shoko.Server.LZ4;
 using Shoko.Server.Repositories;
 using Shoko.Server.Repositories.NHibernate;
 using Shoko.Server.Settings;
+using Shoko.Server.Utilities;
 
 namespace Shoko.Server.Models
 {
@@ -1313,6 +1314,8 @@ namespace Shoko.Server.Models
 
             foreach (SVR_AnimeSeries series in allseries)
             {
+                bool forceAscii = Languages.PreferredNamingLanguages.ContainsOnlyLatin();
+
                 List<(CrossRef_Anime_Staff, AnimeStaff)> staff = RepoFactory.CrossRef_Anime_Staff
                     .GetByAnimeID(series.AniDB_ID).Select(a => (a, RepoFactory.AnimeStaff.GetByID(a.StaffID))).ToList();
 
@@ -1321,7 +1324,7 @@ namespace Shoko.Server.Models
                     {
                         if (fuzzy)
                         {
-                            if (!animeStaff.Item2.Name.FuzzyMatches(search)) continue;
+                            if (!animeStaff.Item2.Name.FuzzyMatches(search, forceAscii)) continue;
                         }
                         else
                         {

--- a/Shoko.Server/Providers/TvDB/TvDBLinkingHelper.cs
+++ b/Shoko.Server/Providers/TvDB/TvDBLinkingHelper.cs
@@ -10,6 +10,7 @@ using Shoko.Models.Server;
 using Shoko.Server.Extensions;
 using Shoko.Server.Models;
 using Shoko.Server.Repositories;
+using Shoko.Server.Utilities;
 
 namespace Shoko.Server
 {
@@ -593,6 +594,7 @@ namespace Shoko.Server
         {
             // Will try to compare the Titles for the first and last episodes of the series
             // This is very inacurrate, but may fix the situations with pre-screenings
+            bool forceAscii = Languages.PreferredNamingLanguages.ContainsOnlyLatin();
 
             // first ep
             var aniepstart = aniepsNormal.FirstOrDefault();
@@ -611,7 +613,7 @@ namespace Shoko.Server
                 string tvstart = epsInSeason.FirstOrDefault()?.EpisodeName;
                 if (string.IsNullOrEmpty(tvstart)) continue;
                 // fuzzy match
-                if (anistart.FuzzyMatches(tvstart))
+                if (anistart.FuzzyMatches(tvstart, forceAscii))
                 {
                     temp.AddRange(epsInSeason);
                     continue;
@@ -620,7 +622,7 @@ namespace Shoko.Server
                 string tvend = epsInSeason.LastOrDefault()?.EpisodeName;
                 if (string.IsNullOrEmpty(tvend)) continue;
                 // fuzzy match
-                if (aniend.FuzzyMatches(tvend))
+                if (aniend.FuzzyMatches(tvend, forceAscii))
                 {
                     temp.AddRange(epsInSeason);
                 }
@@ -655,6 +657,8 @@ namespace Shoko.Server
             ref List<TvDB_Episode> tvepsNormal,
             ref List<(AniDB_Episode, TvDB_Episode, MatchRating)> matches, bool fuzzy)
         {
+            bool forceAscii = Languages.PreferredNamingLanguages.ContainsOnlyLatin();
+
             foreach (var aniep in aniepsNormal.ToList())
             {
                 string anititle = aniep.GetEnglishTitle();
@@ -668,7 +672,7 @@ namespace Shoko.Server
                     // fuzzy match
                     if (fuzzy)
                     {
-                        if (!anititle.FuzzyMatches(tvtitle)) continue;
+                        if (!anititle.FuzzyMatches(tvtitle, forceAscii)) continue;
                     }
                     else
                     {
@@ -685,6 +689,8 @@ namespace Shoko.Server
 
         private static void CorrectMatchRatings(ref List<(AniDB_Episode, TvDB_Episode, MatchRating)> matches)
         {
+            bool forceAscii = Languages.PreferredNamingLanguages.ContainsOnlyLatin();
+
             for (int index = 0; index < matches.Count; index++)
             {
                 var match = matches[index];
@@ -707,7 +713,7 @@ namespace Shoko.Server
                 var aniTitle = match.Item1.GetEnglishTitle();
                 var tvTitle = match.Item2.EpisodeName;
                 // this method returns false if either is null
-                bool titlesMatch = aniTitle.FuzzyMatches(tvTitle);
+                bool titlesMatch = aniTitle.FuzzyMatches(tvTitle, forceAscii);
 
                 matches[index] = titlesMatch
                     ? (match.Item1, match.Item2, MatchRating.Good)

--- a/Shoko.Server/Repositories/Cached/VideoLocalRepository.cs
+++ b/Shoko.Server/Repositories/Cached/VideoLocalRepository.cs
@@ -15,6 +15,7 @@ using Shoko.Server.Databases;
 using Shoko.Server.Extensions;
 using Shoko.Server.Models;
 using Shoko.Server.Server;
+using Shoko.Server.Utilities;
 
 namespace Shoko.Server.Repositories.Cached
 {
@@ -276,10 +277,12 @@ namespace Shoko.Server.Repositories.Cached
 
         public List<SVR_VideoLocal> GetByName(string fileName)
         {
+            bool forceAscii = Languages.PreferredNamingLanguages.ContainsOnlyLatin();
+
             lock (Cache)
             {
                 return Cache.Values.Where(p => p.Places.Any(
-                        a => a.FilePath.FuzzyMatches(fileName)))
+                        a => a.FilePath.FuzzyMatches(fileName, forceAscii)))
                     .ToList();
             }
         }

--- a/Shoko.Server/Utilities/LanguageExtensions.cs
+++ b/Shoko.Server/Utilities/LanguageExtensions.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace Shoko.Server.Utilities
+{
+    public static class LanguageExtensions
+    {
+        public static bool ContainsOnlyLatin(this List<NamingLanguage> languages)
+        {
+            foreach (NamingLanguage nlan in languages)
+            {
+                if (!nlan.IsLatin)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+    }
+}

--- a/Shoko.Server/Utilities/Languages.cs
+++ b/Shoko.Server/Utilities/Languages.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Shoko.Server.Settings;
 
 namespace Shoko.Server.Utilities
@@ -242,6 +242,35 @@ namespace Shoko.Server.Utilities
                     return "Chinese (zh-hant)";
                 default:
                     return language;
+            }
+        }
+        public static bool IsLatinLanguage(string language)
+        {
+            switch (language.Trim().ToUpper())
+            {
+                case "JA":
+                case "AR":
+                case "BD":
+                case "BG":
+                case "EL":
+                case "GR":
+                case "HE":
+                case "HU":
+                case "IL":
+                case "KO":
+                case "MN":
+                case "RU":
+                case "SR":
+                case "TH":
+                case "UK":
+                case "UA":
+                case "ZH":
+                case "ZH-HANS":
+                case "ZH-HANT":
+                    return false;
+                default:
+                    return true;
+
             }
         }
 

--- a/Shoko.Server/Utilities/NamingLanguage.cs
+++ b/Shoko.Server/Utilities/NamingLanguage.cs
@@ -1,4 +1,4 @@
-﻿namespace Shoko.Server.Utilities
+namespace Shoko.Server.Utilities
 {
     public class NamingLanguage
     {
@@ -7,6 +7,11 @@
         public string LanguageDescription
         {
             get { return Languages.GetLanguageDescription(Language.Trim().ToUpper()); }
+        }
+
+        public bool IsLatin
+        {
+            get { return Languages.IsLatinLanguage(Language.Trim().ToUpper()); }
         }
 
         public NamingLanguage()
@@ -22,5 +27,7 @@
         {
             return string.Format("{0} - ({1})", Language, LanguageDescription);
         }
+
+
     }
 }


### PR DESCRIPTION
With these changes, when at least one non-latin language is selected in the list, search features won't coerce the characters to ASCII. 

Please comment on any further change or improvement that should be made. It's my first time with C# so there are probably a few