### PR TITLE
Force docker image to use packaged WebUI

### DIFF
--- a/dockerentry.sh
+++ b/dockerentry.sh
@@ -64,5 +64,9 @@ UMASK set:    $(umask)
 -------------------------------------
 "
 
+# Make sure we use the packaged WebUI
+rm -rf /home/shoko/.shoko/Shoko.CLI/webui
+ln -s /usr/src/app/build/webui /home/shoko/.shoko/Shoko.CLI/webui
+
 # Go and run the server 
 exec gosu $USER:$GROUP /usr/src/app/build/Shoko.CLI


### PR DESCRIPTION
#989

This will have a side effect where if an existing docker container is updated, any old WebUI will be forcibly removed and replaced with a symlink.