### PR TITLE
Downgrade Dependencies - Fix "Failed to load API definition" on v2 swagger

### DIFF
--- a/Shoko.Server/Shoko.Server.csproj
+++ b/Shoko.Server/Shoko.Server.csproj
@@ -90,9 +90,9 @@
     <PackageReference Include="Sentry.NLog" Version="3.21.0"/>
     <PackageReference Include="SharpCompress" Version="0.32.2"/>
     <PackageReference Include="SharpZipLib" Version="1.4.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.4.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0"/>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3"/>
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.2.3"/>
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.2.3"/>
     <!-- This needs to be explicit because of dep BS -->
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1"/>
     <PackageReference Include="System.Data.SqlClient" Version="4.8.3"/>


### PR DESCRIPTION
Possible Problems with >6.3.0+ cause this issue. 
Downgrading to working version as mentioned in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2368 fixes this.
Dunno if other things were broken by this also.