### PR TITLE
Implement TraktTV Ratelimiter - MK-II

### DIFF
--- a/Shoko.Server/Providers/TraktTV/TraktRateLimiter.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktRateLimiter.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using NLog;
+
+namespace Shoko.Server.Providers.TraktTV;
+
+public sealed class TraktTVRateLimiter
+{
+    private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+    private static readonly TraktTVRateLimiter instance = new();
+
+    private static int ShortDelay = 1000;
+    private static int LongDelay = 1500;
+
+    // Switch to longer delay after 1 hour
+    private static long shortPeriod = 60 * 60 * 1000;
+
+    // Switch to shorter delay after 30 minutes of inactivity
+    private static long resetPeriod = 30 * 60 * 1000;
+
+    private static Stopwatch _requestWatch = new();
+
+    private static Stopwatch _activeTimeWatch = new();
+
+    public Guid InstanceID { get; private set; }
+
+    // Explicit static constructor to tell C# compiler
+    // not to mark type as beforefieldinit
+    static TraktTVRateLimiter()
+    {
+        _requestWatch.Start();
+        _activeTimeWatch.Start();
+    }
+
+    public static TraktTVRateLimiter Instance => instance;
+
+    private TraktTVRateLimiter()
+    {
+        InstanceID = Guid.NewGuid();
+    }
+
+    public void ResetRate()
+    {
+        var elapsedTime = _activeTimeWatch.ElapsedMilliseconds;
+        _activeTimeWatch.Restart();
+        logger.Trace($"TraktTVRateLimiter#{InstanceID}: Rate is reset. Active time was {elapsedTime} ms.");
+    }
+
+    public void EnsureRate()
+    {
+        lock (instance)
+        {
+            var delay = _requestWatch.ElapsedMilliseconds;
+
+            if (delay > resetPeriod)
+            {
+                ResetRate();
+            }
+
+            var currentDelay = _activeTimeWatch.ElapsedMilliseconds > shortPeriod ? LongDelay : ShortDelay;
+
+            if (delay > currentDelay)
+            {
+                logger.Trace($"TraktTVRateLimiter#{InstanceID}: Time since last request is {delay} ms, not throttling.");
+                _requestWatch.Restart();
+                return;
+            }
+
+            logger.Trace(
+                $"TraktTVRateLimiter#{InstanceID}: Time since last request is {delay} ms, throttling for {currentDelay} ms.");
+            Thread.Sleep(currentDelay);
+
+            logger.Trace($"TraktTVRateLimiter#{InstanceID}: Sending TraktTV command.");
+            _requestWatch.Restart();
+        }
+    }
+}

--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -243,6 +243,7 @@ public class TraktTVHelper
             var headers = new Dictionary<string, string>();
 
             var retData = string.Empty;
+            TraktTVRateLimiter.Instance.EnsureRate();
             var response = SendData(TraktURIs.Oauth, json, "POST", headers, ref retData);
             if (response is TraktStatusCodes.Success or TraktStatusCodes.Success_Post)
             {
@@ -316,6 +317,7 @@ public class TraktTVHelper
             var headers = new Dictionary<string, string>();
 
             var retData = string.Empty;
+            TraktTVRateLimiter.Instance.EnsureRate();
             var response = SendData(TraktURIs.OAuthDeviceCode, json, "POST", headers, ref retData);
             if (response != TraktStatusCodes.Success && response != TraktStatusCodes.Success_Post)
             {
@@ -364,6 +366,7 @@ public class TraktTVHelper
                 headers.Clear();
 
                 var retData = string.Empty;
+                TraktTVRateLimiter.Instance.EnsureRate();
                 var response = SendData(TraktURIs.OAuthDeviceToken, json, "POST", headers, ref retData);
                 if (response == TraktStatusCodes.Success)
                 {
@@ -774,6 +777,7 @@ public class TraktTVHelper
 
 
             var retData = string.Empty;
+            TraktTVRateLimiter.Instance.EnsureRate();
             var response = SendData(TraktURIs.PostComment, json, "POST", BuildRequestHeaders(), ref retData);
             if (response == TraktStatusCodes.Success || response == TraktStatusCodes.Success_Post ||
                 response == TraktStatusCodes.Success_Delete)
@@ -891,6 +895,7 @@ public class TraktTVHelper
             }
 
             var epDate = GetEpisodeDateForSync(ep, syncType);
+            TraktTVRateLimiter.Instance.EnsureRate();
 
             //SyncEpisodeToTrakt(syncType, traktEpisodeId.Value, secondaryAction);
             SyncEpisodeToTrakt(syncType, traktShowID, season, epNumber, epDate);
@@ -945,6 +950,7 @@ public class TraktTVHelper
             }
 
             var retData = string.Empty;
+            TraktTVRateLimiter.Instance.EnsureRate();
             SendData(url, json, "POST", BuildRequestHeaders(), ref retData);
         }
         catch (Exception ex)
@@ -1015,6 +1021,7 @@ public class TraktTVHelper
 
                 //3. send Json
                 var retData = string.Empty;
+                TraktTVRateLimiter.Instance.EnsureRate();
                 SendData(url, json, "POST", BuildRequestHeaders(), ref retData);
             }
             else
@@ -1768,6 +1775,7 @@ public class TraktTVHelper
                 json = JSONHelper.Serialize(syncCollectionAdd);
                 url = TraktURIs.SyncCollectionAdd;
                 retData = string.Empty;
+                TraktTVRateLimiter.Instance.EnsureRate();
                 SendData(url, json, "POST", BuildRequestHeaders(), ref retData);
             }
 
@@ -1776,6 +1784,7 @@ public class TraktTVHelper
                 json = JSONHelper.Serialize(syncCollectionRemove);
                 url = TraktURIs.SyncCollectionRemove;
                 retData = string.Empty;
+                TraktTVRateLimiter.Instance.EnsureRate();
                 SendData(url, json, "POST", BuildRequestHeaders(), ref retData);
             }
 
@@ -1784,6 +1793,7 @@ public class TraktTVHelper
                 json = JSONHelper.Serialize(syncHistoryAdd);
                 url = TraktURIs.SyncHistoryAdd;
                 retData = string.Empty;
+                TraktTVRateLimiter.Instance.EnsureRate();
                 SendData(url, json, "POST", BuildRequestHeaders(), ref retData);
             }
 
@@ -1792,6 +1802,7 @@ public class TraktTVHelper
                 json = JSONHelper.Serialize(syncHistoryRemove);
                 url = TraktURIs.SyncHistoryRemove;
                 retData = string.Empty;
+                TraktTVRateLimiter.Instance.EnsureRate();
                 SendData(url, json, "POST", BuildRequestHeaders(), ref retData);
             }
 


### PR DESCRIPTION
Same as #1011  - but with a fresh repo.. I could not fix it.

Tried implementing a rate limiter to get rid of http 429 errors on syncing to Trakt. I took the limiter from TVDB and altered it a bit.
TraktTV wants 1 Second delay on POST according to Apiary: https://trakt.docs.apiary.io/#introduction/rate-limiting

Maybe someone can have a look at what I did there - I guess there is room for improvement, lol