### PR TITLE
TraktRateLimiter - higher ShortDelay for rare HTTP429

### DIFF
--- a/Shoko.Server/Providers/TraktTV/TraktRateLimiter.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktRateLimiter.cs
@@ -10,7 +10,7 @@ public sealed class TraktTVRateLimiter
     private static readonly Logger logger = LogManager.GetCurrentClassLogger();
     private static readonly TraktTVRateLimiter instance = new();
 
-    private static int ShortDelay = 1000;
+    private static int ShortDelay = 1500;
     private static int LongDelay = 1500;
 
     // Switch to longer delay after 1 hour


### PR DESCRIPTION
In rare cases the ShortDelay of 1000 causes the rate limiter to still trigger HTTP429 errors - thus increasing the value to 1.5s (same as LongDelay). 
It looks like it occurs if a video is scrobbled during watching while a TraktSync Job is running on the Server