### PR TITLE
feature: add DateTimeImported to VideoLocal

### DIFF
--- a/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation_Entities.cs
+++ b/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation_Entities.cs
@@ -628,6 +628,13 @@ public partial class ShokoServiceImplementation : IShokoServer
                 }
             }
 
+            if (vid.DateTimeImported.HasValue)
+            {
+                // Reset the import date.
+                vid.DateTimeImported = null;
+                RepoFactory.VideoLocal.Save(vid);
+            }
+
             if (animeSeriesID.HasValue)
             {
                 var ser = RepoFactory.AnimeSeries.GetByID(animeSeriesID.Value);
@@ -699,6 +706,13 @@ public partial class ShokoServiceImplementation : IShokoServer
         foreach (var fileEp in fileEps)
         {
             RepoFactory.CrossRef_File_Episode.Delete(fileEp.CrossRef_File_EpisodeID);
+        }
+
+        if (vlocal.DateTimeImported.HasValue)
+        {
+            // Reset the import date.
+            vlocal.DateTimeImported = null;
+            RepoFactory.VideoLocal.Save(vlocal);
         }
     }
 

--- a/Shoko.Server/API/v3/Controllers/DashboardController.cs
+++ b/Shoko.Server/API/v3/Controllers/DashboardController.cs
@@ -244,7 +244,8 @@ public class DashboardController : BaseController
     {
         var user = HttpContext.GetUser();
         var episodeList = RepoFactory.VideoLocal.GetAll()
-            .OrderByDescending(f => f.DateTimeCreated)
+            .Where(f => f.DateTimeImported.HasValue)
+            .OrderByDescending(f => f.DateTimeImported)
             .SelectMany(file => file.GetAnimeEpisodes().Select(episode => (file, episode)));
         var seriesDict = episodeList
             .DistinctBy(tuple => tuple.episode.AnimeSeriesID)
@@ -287,7 +288,8 @@ public class DashboardController : BaseController
     {
         var user = HttpContext.GetUser();
         var seriesList = RepoFactory.VideoLocal.GetAll()
-            .OrderByDescending(f => f.DateTimeCreated)
+            .Where(f => f.DateTimeImported.HasValue)
+            .OrderByDescending(f => f.DateTimeImported)
             .SelectMany(file => file.GetAnimeEpisodes().Select(episode => episode.AnimeSeriesID))
             .Distinct()
             .Select(seriesID => RepoFactory.AnimeSeries.GetByID(seriesID))

--- a/Shoko.Server/API/v3/Models/Shoko/File.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/File.cs
@@ -67,6 +67,12 @@ public class File
     public DateTime? Watched { get; set; }
 
     /// <summary>
+    /// When the file was last imported. Usually is a file only imported once,
+    /// but there may be exceptions.
+    /// </summary>
+    public DateTime? Imported { get; set; }
+
+    /// <summary>
     /// The file creation date of this file
     /// </summary>
     [JsonConverter(typeof(IsoDateTimeConverter))]
@@ -102,6 +108,7 @@ public class File
         Duration = file.DurationTimeSpan;
         ResumePosition = userRecord?.ResumePositionTimeSpan;
         Watched = userRecord?.WatchedDate;
+        Imported = file.DateTimeImported;
         Created = file.DateTimeCreated;
         Updated = file.DateTimeUpdated;
         if (withXRefs)

--- a/Shoko.Server/Commands/Import/CommandRequest_LinkFileManually.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_LinkFileManually.cs
@@ -73,13 +73,16 @@ public class CommandRequest_LinkFileManually : CommandRequestImplementation
 
         _vlocal.Places.ForEach(a => { a.RenameAndMoveAsRequired(); });
 
+        // Set the import date.
+        _vlocal.DateTimeImported = DateTime.Now;
+        RepoFactory.VideoLocal.Save(_vlocal);
+
         var ser = _episode.GetAnimeSeries();
         ser.EpisodeAddedDate = DateTime.Now;
         RepoFactory.AnimeSeries.Save(ser, false, true);
 
         //Update will re-save
         ser.QueueUpdateStats();
-
 
         foreach (var grp in ser.AllGroupsAbove)
         {

--- a/Shoko.Server/Commands/Import/CommandRequest_ProcessFile.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_ProcessFile.cs
@@ -77,6 +77,10 @@ public class CommandRequest_ProcessFile : CommandRequestImplementation
 
             if (aniFile != null)
             {
+                // Set the import date.
+                vlocal.DateTimeImported = DateTime.Now;
+                RepoFactory.VideoLocal.Save(vlocal);
+
                 ShokoEventHandler.Instance.OnFileMatched(vlocal.GetBestVideoLocalPlace());
             }
         }

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -19,7 +19,7 @@ namespace Shoko.Server.Databases;
 public class MySQL : BaseDatabase<MySqlConnection>, IDatabase
 {
     public string Name { get; } = "MySQL";
-    public int RequiredVersion { get; } = 105;
+    public int RequiredVersion { get; } = 106;
 
 
     private List<DatabaseCommand> createVersionTable = new()
@@ -701,7 +701,9 @@ public class MySQL : BaseDatabase<MySqlConnection>, IDatabase
         new(102, 1, "UPDATE AniDB_File SET File_Source = 'Web' WHERE File_Source = 'www'; UPDATE AniDB_File SET File_Source = 'BluRay' WHERE File_Source = 'Blu-ray'; UPDATE AniDB_File SET File_Source = 'LaserDisc' WHERE File_Source = 'LD'; UPDATE AniDB_File SET File_Source = 'Unknown' WHERE File_Source = 'unknown';"),
         new (103, 1, "ALTER TABLE AniDB_GroupStatus MODIFY GroupName LONGTEXT NULL; ALTER TABLE AniDB_GroupStatus MODIFY EpisodeRange LONGTEXT NULL;"),
         new(104, 1, "ALTER TABLE AniDB_Episode ADD INDEX IX_AniDB_Episode_EpisodeType (EpisodeType);"),
-        new(105, 1, "ALTER TABLE AniDB_Episode_Title MODIFY Title TEXT NOT NULL")
+        new(105, 1, "ALTER TABLE AniDB_Episode_Title MODIFY Title TEXT NOT NULL"),
+        new(106, 1, "ALTER TABLE VideoLocal ADD DateTimeImported datetime DEFAULT NULL;"),
+        new(106, 2, "UPDATE VideoLocal v INNER JOIN CrossRef_File_Episode CRFE on v.Hash = CRFE.Hash SET DateImported = DateTimeCreated;")
     };
 
     private DatabaseCommand linuxTableVersionsFix = new("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -22,7 +22,7 @@ namespace Shoko.Server.Databases;
 public class SQLServer : BaseDatabase<SqlConnection>, IDatabase
 {
     public string Name { get; } = "SQLServer";
-    public int RequiredVersion { get; } = 98;
+    public int RequiredVersion { get; } = 99;
 
     public void BackupDatabase(string fullfilename)
     {
@@ -647,7 +647,9 @@ public class SQLServer : BaseDatabase<SqlConnection>, IDatabase
         new DatabaseCommand(95, 1, "UPDATE AniDB_File SET File_Source = 'Web' WHERE File_Source = 'www'; UPDATE AniDB_File SET File_Source = 'BluRay' WHERE File_Source = 'Blu-ray'; UPDATE AniDB_File SET File_Source = 'LaserDisc' WHERE File_Source = 'LD'; UPDATE AniDB_File SET File_Source = 'Unknown' WHERE File_Source = 'unknown';"),
         new DatabaseCommand(96, 1, "ALTER TABLE AniDB_GroupStatus ALTER COLUMN GroupName nvarchar(max); ALTER TABLE AniDB_GroupStatus ALTER COLUMN EpisodeRange nvarchar(max);"),
         new DatabaseCommand(97, 1, "CREATE INDEX IX_AniDB_Episode_EpisodeType ON AniDB_Episode(EpisodeType);"),
-        new DatabaseCommand(98, 1, "ALTER TABLE AniDB_Episode_Title ALTER COLUMN Title nvarchar(max) NOT NULL;")
+        new DatabaseCommand(98, 1, "ALTER TABLE AniDB_Episode_Title ALTER COLUMN Title nvarchar(max) NOT NULL;"),
+        new DatabaseCommand(99, 1, "ALTER TABLE VideoLocal ADD DateTimeImported datetime DEFAULT NULL;"),
+        new DatabaseCommand(99, 2, "UPDATE v SET DateImported = DateTimeCreated FROM VideoLocal v INNER JOIN CrossRef_File_Episode CRFE on v.Hash = CRFE.Hash;")
     };
 
     private static Tuple<bool, string> DropDefaultsOnAnimeEpisode_User(object connection)

--- a/Shoko.Server/Databases/SQLite.cs
+++ b/Shoko.Server/Databases/SQLite.cs
@@ -21,7 +21,7 @@ public class SQLite : BaseDatabase<SqliteConnection>, IDatabase
 {
     public string Name { get; } = "SQLite";
 
-    public int RequiredVersion { get; } = 91;
+    public int RequiredVersion { get; } = 92;
 
 
     public void BackupDatabase(string fullfilename)
@@ -616,7 +616,9 @@ public class SQLite : BaseDatabase<SqliteConnection>, IDatabase
             "DROP INDEX UIX2_VideoLocal_User_User_VideoLocalID; CREATE UNIQUE INDEX UIX_VideoLocal_User_User_VideoLocalID ON VideoLocal_User(JMMUserID, VideoLocalID);"),
         new(89, 19, "DROP INDEX \"UIX_VideoLocal_ VideoLocal_Place_ID\";"),
         new(90, 1, "UPDATE AniDB_File SET File_Source = 'Web' WHERE File_Source = 'www'; UPDATE AniDB_File SET File_Source = 'BluRay' WHERE File_Source = 'Blu-ray'; UPDATE AniDB_File SET File_Source = 'LaserDisc' WHERE File_Source = 'LD'; UPDATE AniDB_File SET File_Source = 'Unknown' WHERE File_Source = 'unknown';"),
-        new(91, 1, "CREATE INDEX IX_AniDB_Episode_EpisodeType ON AniDB_Episode(EpisodeType);")
+        new(91, 1, "CREATE INDEX IX_AniDB_Episode_EpisodeType ON AniDB_Episode(EpisodeType);"),
+        new(92, 1, "ALTER TABLE VideoLocal ADD DateTimeImported timestamp DEFAULT NULL;"),
+        new(92, 2, "UPDATE v SET DateImported = DateTimeCreated FROM VideoLocal v INNER JOIN CrossRef_File_Episode CRFE on v.Hash = CRFE.Hash;")
     };
 
     private static Tuple<bool, string> DropLanguage(object connection)

--- a/Shoko.Server/Mappings/VideoLocalMap.cs
+++ b/Shoko.Server/Mappings/VideoLocalMap.cs
@@ -12,6 +12,7 @@ public class VideoLocalMap : ClassMap<SVR_VideoLocal>
         Id(x => x.VideoLocalID);
         Map(x => x.DateTimeUpdated).Not.Nullable();
         Map(x => x.DateTimeCreated).Not.Nullable();
+        Map(x => x.DateTimeImported);
         Map(x => x.FileName).Not.Nullable();
         Map(x => x.FileSize).Not.Nullable();
         Map(x => x.Hash).Not.Nullable();


### PR DESCRIPTION
We're currently not tracking when a file was imported. This makes ordering the "Recently Imported" panel on the dashboard difficult to do correctly, so this PR adds a nullable date that's set when a file is either automatically imported by the system or manually imported by the user. It also unsets the date if a manual link is removed by the user, since it is no longer considered as _imported_.

### Changes in this PR

- Added `DateTime? DateTimeImported` to `VideoLocal`. The naming is to make it consistent with the existing dates present on the model. (We should probably consolidate on a common naming scheme when moving to EF Core, but for now I'm adding this as-is).

- Added a migration path for each of the database types. This will simply set the import date to the file creation date if the file is currently imported.

- Updated the `CommandRequest_ProcessFile` and `CommandRequest_LinkFileManually` to set the import date.

- Updated the manually link endpoints in both v1 and v3 to reset the import date once all cross-references have been removed from the file.

- Updated the recently episode/series endpoints (in the v3 api) to use the new field to sort the results.

- Made sure cross-references are removed _before_ queuing the new manual link command in the v3 api.

- Exposed the import date on the file model in the v3 api.

- Removed one extra white-space. :slightly_smiling_face: 