### PR TITLE
feature: add user tags to series tags,

### DIFF
--- a/Shoko.Server/API/v3/Controllers/SeriesController.cs
+++ b/Shoko.Server/API/v3/Controllers/SeriesController.cs
@@ -1176,10 +1176,11 @@ public class SeriesController : BaseController
     /// <param name="seriesID">Shoko ID</param>
     /// <param name="filter"></param>
     /// <param name="excludeDescriptions"></param>
+    /// <param name="orderByName">Order tags by name (and source) only. Don't use the tag weights for ordering.</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/Tags")]
     public ActionResult<List<Tag>> GetSeriesTags([FromRoute] int seriesID, [FromQuery] TagFilter.Filter filter = 0,
-        [FromQuery] bool excludeDescriptions = false)
+        [FromQuery] bool excludeDescriptions = false, [FromQuery] bool orderByName = false)
     {
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
@@ -1198,7 +1199,7 @@ public class SeriesController : BaseController
             return new List<Tag>();
         }
 
-        return Series.GetTags(HttpContext, anidb, filter, excludeDescriptions);
+        return Series.GetTags(HttpContext, anidb, filter, excludeDescriptions, orderByName);
     }
 
     /// <summary>

--- a/Shoko.Server/API/v3/Controllers/WebUIController.cs
+++ b/Shoko.Server/API/v3/Controllers/WebUIController.cs
@@ -41,7 +41,8 @@ public class WebUIController : BaseController
                     return null;
                 }
 
-                return new WebUI.WebUIGroupExtra(HttpContext, group, series, anime);
+                return new WebUI.WebUIGroupExtra(HttpContext, group, series, anime, body.TagFilter, body.OrderByName,
+                    body.TagLimit);
             })
             .ToList();
     }

--- a/Shoko.Server/API/v3/Models/Shoko/WebUI.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/WebUI.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -15,7 +16,7 @@ public class WebUI
     public class WebUIGroupExtra
     {
         public WebUIGroupExtra(HttpContext context, SVR_AnimeGroup group, SVR_AnimeSeries series, SVR_AniDB_Anime anime,
-            TagFilter.Filter filter = TagFilter.Filter.None)
+            TagFilter.Filter filter = TagFilter.Filter.None, bool orderByName = false, int tagLimit = 30)
         {
             ID = group.AnimeGroupID;
             Type = Series.GetAniDBSeriesType(anime.AnimeType);
@@ -38,7 +39,9 @@ public class WebUI
                 }
             }
 
-            Tags = Series.GetTags(context, anime, filter, true);
+            Tags = Series.GetTags(context, anime, filter, excludeDescriptions: true, orderByName)
+                .Take(tagLimit)
+                .ToList();
         }
 
         /// <summary>
@@ -95,6 +98,18 @@ public class WebUI
             /// </summary>
             /// <value></value>
             public TagFilter.Filter TagFilter { get; set; } = 0;
+
+            /// <summary>
+            /// Limits the number of returned tags.
+            /// </summary>
+            /// <value></value>
+            public int TagLimit { get; set; } = 30;
+
+            /// <summary>
+            /// Order tags by name (and source) only. Don't use the tag weights.
+            /// </summary>
+            /// <value></value>
+            public bool OrderByName { get; set; } = false;
         }
     }
 }

--- a/Shoko.Server/Utilities/TagFilter.cs
+++ b/Shoko.Server/Utilities/TagFilter.cs
@@ -25,6 +25,10 @@ public static class TagFilter
         Programming = 1 << 6,
         Genre = 1 << 7,
 
+        // User tags. won't actually be used in the filter, but having it in this
+        // enum makes it easier to send from the clients.
+        User = 1L << 30,
+
         // This should always be last, if we get that many categories, then we should redesign this
         Invert = 1L << 31 // without L Invert is still intiger and it returns after bitshift -2147483648
     }


### PR DESCRIPTION
Some changes to the series tags requested by @hidden4003 and @ElementalCrisis. Mainly to send the user tags, allow switching between ordering by name or ordering by tag weight and to limit the number of tags sent with the web ui group view data (and making it configurable in case the requirements for the number of visible tags change in the future).

If there are no comments within the next 12 hours then I'm merging it when I get back home.

### Changes in this PR

- add user tags to series tags,

- add a sort order to the tags, and

- limit the number of tags sent with the web ui data.