### PR TITLE
feature: add group letters endpoint

### DIFF
--- a/Shoko.Server/API/v3/Controllers/GroupController.cs
+++ b/Shoko.Server/API/v3/Controllers/GroupController.cs
@@ -76,10 +76,13 @@ public class GroupController : BaseController
     }
 
     /// <summary>
-    /// Get a dictionary with the count for each starting character in each of the group names.
+    /// Get a dictionary with the count for each starting character in each of
+    /// the group's name.
     /// </summary>
-    /// <param name="includeEmpty">Include <see cref="Series"/> with missing <see cref="Episode"/>s in the search.</param>
-    /// <param name="topLevelOnly">Only list the top level groups if set.</param>
+    /// <param name="includeEmpty">Include <see cref="Series"/> with missing
+    /// <see cref="Episode"/>s in the count.</param>
+    /// <param name="topLevelOnly">Only count top-level groups (groups with no
+    /// parent group).</param>
     /// <returns></returns>
     [HttpGet("Letters")]
     public ActionResult<Dictionary<char, int>> GetGroupNameLetters([FromQuery] bool includeEmpty = false, [FromQuery] bool topLevelOnly = true)

--- a/Shoko.Server/API/v3/Controllers/GroupController.cs
+++ b/Shoko.Server/API/v3/Controllers/GroupController.cs
@@ -71,8 +71,35 @@ public class GroupController : BaseController
                 return includeEmpty || group.GetAllSeries()
                     .Any(s => s.GetAnimeEpisodes().Any(e => e.GetVideoLocals().Count > 0));
             })
-            .OrderBy(group => group.GroupName)
+            .OrderBy(group => group.GetSortName())
             .ToListResult(group => new Group(HttpContext, group, randomImages), page, pageSize);
+    }
+
+    /// <summary>
+    /// Get a dictionary with the count for each starting character in each of the group names.
+    /// </summary>
+    /// <param name="includeEmpty">Include <see cref="Series"/> with missing <see cref="Episode"/>s in the search.</param>
+    /// <param name="topLevelOnly">Only list the top level groups if set.</param>
+    /// <returns></returns>
+    [HttpGet("Letters")]
+    public ActionResult<Dictionary<char, int>> GetGroupNameLetters([FromQuery] bool includeEmpty = false, [FromQuery] bool topLevelOnly = true)
+    {
+        var user = User;
+        return RepoFactory.AnimeGroup.GetAll()
+            .Where(group =>
+            {
+                if (topLevelOnly && group.AnimeGroupParentID.HasValue)
+                    return false;
+
+                if (!user.AllowedGroup(group))
+                    return false;
+
+                return includeEmpty || group.GetAllSeries()
+                    .Any(s => s.GetAnimeEpisodes().Any(e => e.GetVideoLocals().Count > 0));
+            })
+            .GroupBy(group => group.GetSortName()[0])
+            .OrderBy(groupList => groupList.Key)
+            .ToDictionary(groupList => groupList.Key, groupList => groupList.Count());
     }
 
     #endregion

--- a/Shoko.Server/API/v3/Controllers/TreeController.cs
+++ b/Shoko.Server/API/v3/Controllers/TreeController.cs
@@ -149,10 +149,13 @@ public class TreeController : BaseController
     }
 
     /// <summary>
-    /// Get a dictionary with the count for each starting character in each of the group names.
+    /// Get a dictionary with the count for each starting character in each of
+    /// the top-level group's name with the filter for the given
+    /// <paramref name="filterID"/> applied.
     /// </summary>
     /// <param name="filterID"><see cref="Filter"/> ID</param>
-    /// <param name="includeEmpty">Include <see cref="Series"/> with missing <see cref="Episode"/>s in the search.</param>
+    /// <param name="includeEmpty">Include <see cref="Series"/> with missing
+    /// <see cref="Episode"/>s in the count.</param>
     /// <returns></returns>
     [HttpGet("Filter/{filterID}/Group/Letters")]
     public ActionResult<Dictionary<char, int>> GetGroupNameLettersInFilter([FromRoute] int? filterID = null, [FromQuery] bool includeEmpty = false)

--- a/Shoko.Server/Models/SVR_AnimeGroup.cs
+++ b/Shoko.Server/Models/SVR_AnimeGroup.cs
@@ -37,6 +37,18 @@ public class SVR_AnimeGroup : AnimeGroup, IGroup
 
     private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
+    /// <summary>
+    /// Get a predictable sort name that stuffs everything that's not between
+    /// A-Z under #.
+    /// </summary>
+    public string GetSortName()
+    {
+        var sortName = !string.IsNullOrWhiteSpace(SortName) ? SortName.ToUpperInvariant() :
+                !string.IsNullOrWhiteSpace(GroupName) ? GroupName.ToUpperInvariant() : "";
+        var initialChar = (short)(sortName.Length > 0 ? sortName[0] : ' ');
+        return initialChar is >= 65 and <= 90 ? sortName : "#" + sortName;
+    }
+
 
     internal CL_AnimeGroup_User _contract;
 


### PR DESCRIPTION
Added an endpoint to get the count of each starting letter for each group, since @hidden4003 needs it for the collection view in web ui to calculate the letter offsets.

Will merge this tomorrow unless there are comments when I wake up tomorrow. (ETA 12h+)

### Changes in this PR

- Add an endpoint to get the count of each starting letter for every group. Characters between A to Z are grouped separately and all other starting characters are grouped under '#'.

- Add a new query parameter to forcefully order the groups in a group filter by name... in case we need it.... which we probably do.