### PR TITLE
refactor: update image commands

### DIFF
--- a/Shoko.Server/Commands/Import/CommandRequest_DownloadAniDBImages.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_DownloadAniDBImages.cs
@@ -1,23 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Net;
-using System.Threading;
 using System.Xml;
 using Microsoft.Extensions.Logging;
 using Shoko.Commons.Properties;
 using Shoko.Commons.Queue;
-using Shoko.Commons.Utils;
-using Shoko.Models.Enums;
 using Shoko.Models.Queue;
 using Shoko.Models.Server;
 using Shoko.Server.Commands.Attributes;
 using Shoko.Server.Commands.Generic;
-using Shoko.Server.Extensions;
 using Shoko.Server.ImageDownload;
-using Shoko.Server.Providers.AniDB;
 using Shoko.Server.Providers.AniDB.Interfaces;
 using Shoko.Server.Repositories;
 using Shoko.Server.Server;
@@ -28,30 +21,37 @@ namespace Shoko.Server.Commands.Import;
 [Command(CommandRequestType.DownloadAniDBImages)]
 public class CommandRequest_DownloadAniDBImages : CommandRequestImplementation
 {
+    private const string DownloadImage = "Downloading Image {0}: {1}";
+
+    private const string FailedToDownloadNoID = "Images failed to download: Can\'t find {EntityType} with ID: {AnimeID}";
+
     private readonly IUDPConnectionHandler _handler;
+
     private readonly ISettingsProvider _settingsProvider;
+
     public int AnimeID { get; set; }
+
     public bool ForceDownload { get; set; }
 
     public override CommandRequestPriority DefaultPriority => CommandRequestPriority.Priority1;
 
     public override QueueStateStruct PrettyDescription => new()
     {
-        message = "Downloading Image {0}: {1}",
+        message = DownloadImage,
         queueState = QueueStateEnum.DownloadImage,
         extraParams = new[] { Resources.Command_ValidateAllImages_AniDBPosters, AnimeID.ToString() }
     };
 
     public QueueStateStruct PrettyDescriptionCharacters => new()
     {
-        message = "Downloading Image {0}: {1}",
+        message = DownloadImage,
         queueState = QueueStateEnum.DownloadImage,
         extraParams = new[] { Resources.Command_ValidateAllImages_AniDBCharacters, AnimeID.ToString() }
     };
 
     public QueueStateStruct PrettyDescriptionCreators => new()
     {
-        message = "Downloading Image {0}: {1}",
+        message = DownloadImage,
         queueState = QueueStateEnum.DownloadImage,
         extraParams = new[] { Resources.Command_ValidateAllImages_AniDBSeiyuus, AnimeID.ToString() }
     };
@@ -63,260 +63,101 @@ public class CommandRequest_DownloadAniDBImages : CommandRequestImplementation
         try
         {
             var settings = _settingsProvider.GetSettings();
-            var types = new List<ImageEntityType>
+            var anime = RepoFactory.AniDB_Anime.GetByAnimeID(AnimeID);
+            if (anime == null)
             {
-                ImageEntityType.AniDB_Cover, ImageEntityType.AniDB_Character, ImageEntityType.AniDB_Creator
+                Logger.LogWarning(FailedToDownloadNoID, "anime", AnimeID);
+                return;
+            }
+
+            var requests = new List<ImageDownloadRequest>()
+            {
+                new ImageDownloadRequest(anime, ForceDownload, _handler.ImageServerUrl),
             };
 
-            foreach (var entityTypeEnum in types)
+            var characterOffset = requests.Count;
+            if (settings.AniDb.DownloadCharacters)
             {
-                var downloadUrls = new List<string>();
-                var fileNames = new List<string>();
-                switch (entityTypeEnum)
+                var characters = RepoFactory.AniDB_Anime_Character.GetByAnimeID(AnimeID)
+                    .Select(xref => RepoFactory.AniDB_Character.GetByCharID(xref.CharID))
+                    .Where(a => !string.IsNullOrEmpty(a?.PicName))
+                    .DistinctBy(a => a.CharID)
+                    .ToList();
+                if (characters == null || characters.Count == 0)
                 {
-                    case ImageEntityType.AniDB_Cover:
-                        var anime = RepoFactory.AniDB_Anime.GetByAnimeID(AnimeID);
-                        if (anime == null)
-                        {
-                            Logger.LogWarning(
-                                "AniDB poster image failed to download: Can\'t find AniDB_Anime with ID: {AnimeID}",
-                                AnimeID);
-                            return;
-                        }
-
-                        downloadUrls.Add(string.Format(_handler.ImageServerUrl, anime.Picname));
-                        fileNames.Add(anime.PosterPath);
-                        break;
-
-                    case ImageEntityType.AniDB_Character:
-                        if (!settings.AniDb.DownloadCharacters)
-                        {
-                            continue;
-                        }
-
-                        var chrs = (from xref1 in RepoFactory.AniDB_Anime_Character.GetByAnimeID(AnimeID)
-                                select RepoFactory.AniDB_Character.GetByCharID(xref1.CharID))
-                            .Where(a => !string.IsNullOrEmpty(a?.PicName))
-                            .DistinctBy(a => a.CharID)
-                            .ToList();
-                        if (chrs == null || chrs.Count == 0)
-                        {
-                            Logger.LogWarning(
-                                "AniDB Character image failed to download: Can\'t find Character for anime: {AnimeID}",
-                                AnimeID
-                            );
-                            return;
-                        }
-
-                        foreach (var chr in chrs)
-                        {
-                            downloadUrls.Add(string.Format(_handler.ImageServerUrl, chr.PicName));
-                            fileNames.Add(chr.GetPosterPath());
-                        }
-
-                        ShokoService.CmdProcessorImages.QueueState = PrettyDescriptionCharacters;
-                        break;
-
-                    case ImageEntityType.AniDB_Creator:
-                        if (!settings.AniDb.DownloadCreators)
-                        {
-                            continue;
-                        }
-
-                        var creators = (from xref1 in RepoFactory.AniDB_Anime_Character.GetByAnimeID(AnimeID)
-                                from xref2 in RepoFactory.AniDB_Character_Seiyuu.GetByCharID(xref1.CharID)
-                                select RepoFactory.AniDB_Seiyuu.GetBySeiyuuID(xref2.SeiyuuID))
-                            .Where(a => !string.IsNullOrEmpty(a?.PicName))
-                            .DistinctBy(a => a.SeiyuuID)
-                            .ToList();
-                        if (creators == null || creators.Count == 0)
-                        {
-                            Logger.LogWarning(
-                                "AniDB Seiyuu image failed to download: Can\'t find Seiyuus for anime: {AnimeID}",
-                                AnimeID
-                            );
-                            return;
-                        }
-
-                        foreach (var creator in creators)
-                        {
-                            downloadUrls.Add(string.Format(_handler.ImageServerUrl, creator.PicName));
-                            fileNames.Add(creator.GetPosterPath());
-                        }
-
-                        ShokoService.CmdProcessorImages.QueueState = PrettyDescriptionCreators;
-                        break;
-                }
-
-                if (downloadUrls.Count == 0 || fileNames.All(string.IsNullOrEmpty))
-                {
-                    Logger.LogWarning("Image failed to download: No URLs were generated. This should never happen");
+                    Logger.LogWarning(FailedToDownloadNoID, "characters for anime", AnimeID);
                     return;
                 }
 
+                requests.AddRange(characters.Select(character => new ImageDownloadRequest(character, ForceDownload, _handler.ImageServerUrl)));
+            }
 
-                for (var i = 0; i < downloadUrls.Count; i++)
+            var creatorOffset = requests.Count;
+            if (settings.AniDb.DownloadCreators)
+            {
+                // Get all voice-actors working on this anime.
+                var voiceActors =  RepoFactory.AniDB_Anime_Character.GetByAnimeID(AnimeID)
+                    .SelectMany(xref => RepoFactory.AniDB_Character_Seiyuu.GetByCharID(xref.CharID))
+                    .Select(xref => RepoFactory.AniDB_Seiyuu.GetBySeiyuuID(xref.SeiyuuID))
+                    .Where(va => !string.IsNullOrEmpty(va?.PicName));
+                // Get all staff members working on this anime.
+                var staffMembers = RepoFactory.AniDB_Anime_Staff.GetByAnimeID(AnimeID)
+                    .Select(xref => RepoFactory.AniDB_Seiyuu.GetBySeiyuuID(xref.CreatorID))
+                    .Where(staff => !string.IsNullOrEmpty(staff?.PicName));
+                // Concatenate the streams into a single list.
+                var creators = voiceActors
+                    .Concat(staffMembers)
+                    .DistinctBy(creator => creator.SeiyuuID)
+                    .ToList();
+
+                if (creators == null || creators.Count == 0)
                 {
-                    try
-                    {
-                        if (string.IsNullOrEmpty(fileNames[i]))
-                        {
-                            continue;
-                        }
+                    Logger.LogWarning(FailedToDownloadNoID, "creators for anime", AnimeID);
+                    return;
+                }
 
-                        var downloadImage = true;
-                        var fileExists = File.Exists(fileNames[i]);
-                        var imageValid = fileExists && Misc.IsImageValid(fileNames[i]);
+                requests.AddRange(creators.Select(va => new ImageDownloadRequest(va, ForceDownload, _handler.ImageServerUrl)));
+            }
 
-                        if (imageValid && !ForceDownload)
-                        {
-                            downloadImage = false;
-                        }
+            for (var index = 0; index < requests.Count; index++)
+            {
+                // Update the queue state.
+                if (index == characterOffset)
+                    ShokoService.CmdProcessorImages.QueueState = PrettyDescriptionCharacters;
+                else if (index == creatorOffset)
+                    ShokoService.CmdProcessorImages.QueueState = PrettyDescriptionCreators;
 
-                        if (!downloadImage)
-                        {
-                            continue;
-                        }
-
-                        var tempName = Path.Combine(ImageUtils.GetImagesTempFolder(),
-                            Path.GetFileName(fileNames[i]));
-
-                        try
-                        {
-                            if (fileExists)
-                            {
-                                File.Delete(fileNames[i]);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.LogWarning(Resources.Command_DeleteError, fileNames, ex.Message);
-                            return;
-                        }
-
-                        // If this has any issues, it will throw an exception, so the catch below will handle it
-                        RecursivelyRetryDownload(downloadUrls[i], ref tempName, 0, 5);
-
-                        // move the file to it's final location
-                        // check that the final folder exists
-                        var fullPath = Path.GetDirectoryName(fileNames[i]);
-                        if (!Directory.Exists(fullPath))
-                        {
-                            Directory.CreateDirectory(fullPath);
-                        }
-
-                        File.Move(tempName, fileNames[i]);
-                        Logger.LogInformation("Image downloaded: {FileName} from {DownloadUrl}", fileNames[i],
-                            downloadUrls[i]);
-                    }
-                    catch (WebException e)
-                    {
-                        Logger.LogWarning(
-                            "Error processing CommandRequest_DownloadAniDBImages: {Url} ({AnimeID}) - {Ex}",
-                            downloadUrls[i],
-                            AnimeID,
-                            e.Message);
-                    }
-                    catch (Exception e)
-                    {
-                        Logger.LogError(e,
-                            "Error processing CommandRequest_DownloadAniDBImages: {Url} ({AnimeID}) - {Ex}",
-                            downloadUrls[i],
-                            AnimeID,
-                            e);
-                    }
+                // Process the
+                var req = requests[index];
+                try
+                {
+                    // If this has any issues, it will throw an exception, so the catch below will handle it.
+                    if (req.DownloadNow())
+                        Logger.LogInformation("Image downloaded: {FilePath} from {DownloadUrl}", req.FilePath, req.DownloadUrl);
+                    else
+                        Logger.LogWarning("Image failed to download; FilePath from {DownloadUrl}", req.FilePath, req.DownloadUrl);
+                }
+                catch (WebException e)
+                {
+                    Logger.LogWarning(
+                        "Error processing CommandRequest_DownloadAniDBImages: {Url} ({AnimeID}) - {Ex}",
+                        req.DownloadUrl,
+                        AnimeID,
+                        e.Message);
+                }
+                catch (Exception e)
+                {
+                    Logger.LogError(e,
+                        "Error processing CommandRequest_DownloadAniDBImages: {Url} ({AnimeID}) - {Ex}",
+                        req.DownloadUrl,
+                        AnimeID,
+                        e);
                 }
             }
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error processing CommandRequest_DownloadAniDBImages: {AnimeID}", AnimeID);
-        }
-    }
-
-    private static void RecursivelyRetryDownload(string downloadURL, ref string tempFilePath, int count, int maxretry)
-    {
-        try
-        {
-            // download image
-            if (downloadURL.Length <= 0)
-            {
-                return;
-            }
-
-            // Ignore all certificate failures.
-            ServicePointManager.Expect100Continue = true;
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
-
-            using var client = new WebClient();
-            client.Headers.Add("user-agent", "JMM");
-            //OnImageDownloadEvent(new ImageDownloadEventArgs("", req, ImageDownloadEventType.Started));
-            //BaseConfig.MyAnimeLog.Write("ProcessImages: Download: {0}  *** to ***  {1}", req.URL, fullName);
-
-            AniDbImageRateLimiter.Instance.EnsureRate();
-            var bytes = client.DownloadData(downloadURL);
-            AniDbImageRateLimiter.Instance.Reset();
-            if (bytes.Length < 4)
-            {
-                throw new WebException(
-                    "The image download stream returned less than 4 bytes (a valid image has 2-4 bytes in the header)");
-            }
-
-            var imageFormat = Misc.GetImageFormat(bytes);
-            string extension;
-            switch (imageFormat)
-            {
-                case ImageFormatEnum.bmp:
-                    extension = ".bmp";
-                    break;
-                case ImageFormatEnum.gif:
-                    extension = ".gif";
-                    break;
-                case ImageFormatEnum.jpeg:
-                    extension = ".jpeg";
-                    break;
-                case ImageFormatEnum.png:
-                    extension = ".png";
-                    break;
-                case ImageFormatEnum.tiff:
-                    extension = ".tiff";
-                    break;
-                default: throw new WebException("The image download stream returned an invalid image");
-            }
-
-            if (extension.Length <= 0)
-            {
-                return;
-            }
-
-            var newFile = Path.ChangeExtension(tempFilePath, extension);
-            if (newFile == null)
-            {
-                return;
-            }
-
-            if (File.Exists(newFile))
-            {
-                File.Delete(newFile);
-            }
-
-            using (var fs = new FileStream(newFile, FileMode.Create, FileAccess.Write))
-            {
-                fs.Write(bytes, 0, bytes.Length);
-            }
-
-            tempFilePath = newFile;
-        }
-        catch (WebException)
-        {
-            if (count + 1 >= maxretry)
-            {
-                throw;
-            }
-
-            Thread.Sleep(500);
-            RecursivelyRetryDownload(downloadURL, ref tempFilePath, count + 1, maxretry);
         }
     }
 

--- a/Shoko.Server/Commands/Import/CommandRequest_DownloadImage.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_DownloadImage.cs
@@ -1,21 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Net;
-using System.Threading;
 using System.Xml;
+using System.Xml.Serialization;
 using Microsoft.Extensions.Logging;
 using Shoko.Commons.Properties;
 using Shoko.Commons.Queue;
-using Shoko.Commons.Utils;
 using Shoko.Models.Enums;
 using Shoko.Models.Queue;
 using Shoko.Models.Server;
 using Shoko.Server.Commands.Attributes;
 using Shoko.Server.Commands.Generic;
-using Shoko.Server.Extensions;
 using Shoko.Server.ImageDownload;
-using Shoko.Server.Models;
 using Shoko.Server.Providers.AniDB;
 using Shoko.Server.Providers.AniDB.Interfaces;
 using Shoko.Server.Repositories;
@@ -26,13 +21,25 @@ namespace Shoko.Server.Commands;
 [Command(CommandRequestType.ImageDownload)]
 public class CommandRequest_DownloadImage : CommandRequestImplementation
 {
+    private const string FailedToDownloadNoID = "Image failed to download: Can\'t find valid {EntityType} with ID: {EntityID}";
+
+    private const string FailedToDownloadNoImpl = "Image failed to download: No implementation found for {EntityType}";
+
+    [XmlIgnore]
     private readonly IUDPConnectionHandler _handler;
 
     public int EntityID { get; set; }
+
     public int EntityType { get; set; }
+
     public bool ForceDownload { get; set; }
 
-    public ImageEntityType EntityTypeEnum => (ImageEntityType)EntityType;
+    [XmlIgnore]
+    public ImageEntityType EntityTypeEnum
+    {
+        get => (ImageEntityType)EntityType;
+        set => EntityType = (int)value;
+    }
 
     public override CommandRequestPriority DefaultPriority => CommandRequestPriority.Priority2;
 
@@ -40,40 +47,19 @@ public class CommandRequest_DownloadImage : CommandRequestImplementation
     {
         get
         {
-            string type;
-            switch (EntityTypeEnum)
+            string type = EntityTypeEnum switch
             {
-                case ImageEntityType.TvDB_Episode:
-                    type = Resources.Command_ValidateAllImages_TvDBEpisodes;
-                    break;
-                case ImageEntityType.TvDB_FanArt:
-                    type = Resources.Command_ValidateAllImages_TvDBFanarts;
-                    break;
-                case ImageEntityType.TvDB_Cover:
-                    type = Resources.Command_ValidateAllImages_TvDBPosters;
-                    break;
-                case ImageEntityType.TvDB_Banner:
-                    type = Resources.Command_ValidateAllImages_TvDBBanners;
-                    break;
-                case ImageEntityType.MovieDB_Poster:
-                    type = Resources.Command_ValidateAllImages_MovieDBPosters;
-                    break;
-                case ImageEntityType.MovieDB_FanArt:
-                    type = Resources.Command_ValidateAllImages_MovieDBFanarts;
-                    break;
-                case ImageEntityType.AniDB_Cover:
-                    type = Resources.Command_ValidateAllImages_AniDBPosters;
-                    break;
-                case ImageEntityType.AniDB_Character:
-                    type = Resources.Command_ValidateAllImages_AniDBCharacters;
-                    break;
-                case ImageEntityType.AniDB_Creator:
-                    type = Resources.Command_ValidateAllImages_AniDBSeiyuus;
-                    break;
-                default:
-                    type = string.Empty;
-                    break;
-            }
+                ImageEntityType.TvDB_Episode => Resources.Command_ValidateAllImages_TvDBEpisodes,
+                ImageEntityType.TvDB_FanArt => Resources.Command_ValidateAllImages_TvDBFanarts,
+                ImageEntityType.TvDB_Cover => Resources.Command_ValidateAllImages_TvDBPosters,
+                ImageEntityType.TvDB_Banner => Resources.Command_ValidateAllImages_TvDBBanners,
+                ImageEntityType.MovieDB_Poster => Resources.Command_ValidateAllImages_MovieDBPosters,
+                ImageEntityType.MovieDB_FanArt => Resources.Command_ValidateAllImages_MovieDBFanarts,
+                ImageEntityType.AniDB_Cover => Resources.Command_ValidateAllImages_AniDBPosters,
+                ImageEntityType.AniDB_Character => Resources.Command_ValidateAllImages_AniDBCharacters,
+                ImageEntityType.AniDB_Creator => Resources.Command_ValidateAllImages_AniDBSeiyuus,
+                _ => string.Empty
+            };
 
             return new QueueStateStruct
             {
@@ -87,216 +73,146 @@ public class CommandRequest_DownloadImage : CommandRequestImplementation
     protected override void Process()
     {
         Logger.LogInformation("Processing CommandRequest_DownloadImage: {EntityID}", EntityID);
-        var downloadURL = string.Empty;
-
+        ImageDownloadRequest req = null;
         try
         {
-            ImageDownloadRequest req = null;
             switch (EntityTypeEnum)
             {
                 case ImageEntityType.TvDB_Episode:
                     var ep = RepoFactory.TvDB_Episode.GetByID(EntityID);
                     if (string.IsNullOrEmpty(ep?.Filename))
                     {
-                        Logger.LogWarning(
-                            "TvDB Episode image failed to download: Can\'t get episode with ID: {EntityID}", EntityID);
+                        Logger.LogWarning(FailedToDownloadNoID, "TvDB episode", EntityID);
                         return;
                     }
 
-                    req = new ImageDownloadRequest(EntityTypeEnum, ep, ForceDownload);
+                    req = new ImageDownloadRequest(ep, ForceDownload);
                     break;
 
                 case ImageEntityType.TvDB_FanArt:
                     var fanart = RepoFactory.TvDB_ImageFanart.GetByID(EntityID);
                     if (string.IsNullOrEmpty(fanart?.BannerPath))
                     {
-                        Logger.LogWarning(
-                            "TvDB Fanart image failed to download: Can\'t find valid fanart with ID: {EntityID}",
-                            EntityID);
+                        Logger.LogWarning(FailedToDownloadNoID, "TvDB fanart", EntityID);
                         RemoveImageRecord();
                         return;
                     }
 
-                    req = new ImageDownloadRequest(EntityTypeEnum, fanart, ForceDownload);
+                    req = new ImageDownloadRequest(fanart, ForceDownload);
                     break;
 
                 case ImageEntityType.TvDB_Cover:
                     var poster = RepoFactory.TvDB_ImagePoster.GetByID(EntityID);
                     if (string.IsNullOrEmpty(poster?.BannerPath))
                     {
-                        Logger.LogWarning(
-                            "TvDB Poster image failed to download: Can\'t find valid poster with ID: {EntityID}",
-                            EntityID);
+                        Logger.LogWarning(FailedToDownloadNoID, "TvDB poster", EntityID);
                         RemoveImageRecord();
                         return;
                     }
 
-                    req = new ImageDownloadRequest(EntityTypeEnum, poster, ForceDownload);
+                    req = new ImageDownloadRequest(poster, ForceDownload);
                     break;
 
                 case ImageEntityType.TvDB_Banner:
                     var wideBanner = RepoFactory.TvDB_ImageWideBanner.GetByID(EntityID);
                     if (string.IsNullOrEmpty(wideBanner?.BannerPath))
                     {
-                        Logger.LogWarning(
-                            "TvDB Banner image failed to download: Can\'t find valid banner with ID: {EntityID}",
-                            EntityID);
+                        Logger.LogWarning(FailedToDownloadNoID, "TvDB banner", EntityID);
                         RemoveImageRecord();
                         return;
                     }
 
-                    req = new ImageDownloadRequest(EntityTypeEnum, wideBanner, ForceDownload);
+                    req = new ImageDownloadRequest(wideBanner, ForceDownload);
                     break;
 
                 case ImageEntityType.MovieDB_Poster:
                     var moviePoster = RepoFactory.MovieDB_Poster.GetByID(EntityID);
                     if (string.IsNullOrEmpty(moviePoster?.URL))
                     {
-                        Logger.LogWarning(
-                            "MovieDB Poster image failed to download: Can\'t find valid poster with ID: {EntityID}",
-                            EntityID);
+                        Logger.LogWarning(FailedToDownloadNoID, "TMDB poster", EntityID);
                         RemoveImageRecord();
                         return;
                     }
 
-                    req = new ImageDownloadRequest(EntityTypeEnum, moviePoster, ForceDownload);
+                    req = new ImageDownloadRequest(moviePoster, ForceDownload);
                     break;
 
                 case ImageEntityType.MovieDB_FanArt:
                     var movieFanart = RepoFactory.MovieDB_Fanart.GetByID(EntityID);
                     if (string.IsNullOrEmpty(movieFanart?.URL))
                     {
-                        Logger.LogWarning(
-                            "MovieDB Fanart image failed to download: Can\'t find valid fanart with ID: {EntityID}",
-                            EntityID);
+                        Logger.LogWarning(FailedToDownloadNoID, "TMDB fanart", EntityID);
+                        RemoveImageRecord();
                         return;
                     }
 
-                    req = new ImageDownloadRequest(EntityTypeEnum, movieFanart, ForceDownload);
+                    req = new ImageDownloadRequest(movieFanart, ForceDownload);
                     break;
 
                 case ImageEntityType.AniDB_Cover:
                     var anime = RepoFactory.AniDB_Anime.GetByAnimeID(EntityID);
                     if (anime == null)
                     {
-                        Logger.LogWarning(
-                            "AniDB poster image failed to download: Can\'t find AniDB_Anime with ID: {EntityID}",
-                            EntityID);
+                        Logger.LogWarning(FailedToDownloadNoID, "AniDB anime poster", EntityID);
                         return;
                     }
 
                     AniDbImageRateLimiter.Instance.EnsureRate();
-                    req = new ImageDownloadRequest(EntityTypeEnum, anime, ForceDownload);
+                    req = new ImageDownloadRequest(anime, ForceDownload, _handler.ImageServerUrl);
                     break;
 
                 case ImageEntityType.AniDB_Character:
                     var chr = RepoFactory.AniDB_Character.GetByCharID(EntityID);
                     if (chr == null)
                     {
-                        Logger.LogWarning(
-                            "AniDB Character image failed to download: Can\'t find AniDB Character with ID: {EntityID}",
-                            EntityID);
+                        Logger.LogWarning(FailedToDownloadNoID, "AniDB character", EntityID);
                         return;
                     }
 
                     AniDbImageRateLimiter.Instance.EnsureRate();
-                    req = new ImageDownloadRequest(EntityTypeEnum, chr, ForceDownload);
+                    req = new ImageDownloadRequest(chr, ForceDownload, _handler.ImageServerUrl);
                     break;
 
                 case ImageEntityType.AniDB_Creator:
-                    var creator = RepoFactory.AniDB_Seiyuu.GetBySeiyuuID(EntityID);
-                    if (creator == null)
+                    var va = RepoFactory.AniDB_Seiyuu.GetBySeiyuuID(EntityID);
+                    if (va == null)
                     {
-                        Logger.LogWarning(
-                            "AniDB Seiyuu image failed to download: Can\'t find Seiyuu with ID: {EntityID}", EntityID);
+                        Logger.LogWarning(FailedToDownloadNoID, "AniDB Seiyuu", EntityID);
                         return;
                     }
 
                     AniDbImageRateLimiter.Instance.EnsureRate();
-                    req = new ImageDownloadRequest(EntityTypeEnum, creator, ForceDownload);
+                    req = new ImageDownloadRequest(va, ForceDownload, _handler.ImageServerUrl);
                     break;
             }
 
             if (req == null)
             {
-                Logger.LogWarning("Image failed to download: No implementation found for {EntityTypeEnum}",
-                    EntityTypeEnum);
+                Logger.LogWarning(FailedToDownloadNoImpl, EntityTypeEnum.ToString());
                 return;
             }
 
-            var fileNames = new List<string>();
-            var downloadUrls = new List<string>();
-
-            var fileNameTemp = GetFileName(req);
-            var downloadURLTemp = GetFileURL(req);
-
-            fileNames.Add(fileNameTemp);
-            downloadUrls.Add(downloadURLTemp);
-
-            for (var i = 0; i < fileNames.Count; i++)
+            try
             {
-                try
-                {
-                    var fileName = fileNames[i];
-                    downloadURL = downloadUrls[i];
-
-                    var downloadImage = true;
-                    var fileExists = File.Exists(fileName);
-                    var imageValid = fileExists && Misc.IsImageValid(fileName);
-
-                    if (imageValid && !req.ForceDownload)
-                    {
-                        downloadImage = false;
-                    }
-
-                    if (!downloadImage)
-                    {
-                        continue;
-                    }
-
-                    var tempName = Path.Combine(ImageUtils.GetImagesTempFolder(), Path.GetFileName(fileName));
-
-                    try
-                    {
-                        if (fileExists)
-                        {
-                            File.Delete(fileName);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogWarning(Resources.Command_DeleteError, fileName, ex.Message);
-                        return;
-                    }
-
-                    // If this has any issues, it will throw an exception, so the catch below will handle it
-                    RecursivelyRetryDownload(downloadURL, ref tempName, 0, 5);
-
-                    // move the file to it's final location
-                    // check that the final folder exists
-                    var fullPath = Path.GetDirectoryName(fileName);
-                    if (!Directory.Exists(fullPath))
-                    {
-                        Directory.CreateDirectory(fullPath);
-                    }
-
-                    File.Move(tempName, fileName);
-                    Logger.LogInformation("Image downloaded: {FileName} from {DownloadUrl}", fileName, downloadURL);
-                }
-                catch (WebException e)
-                {
-                    Logger.LogWarning("Error processing CommandRequest_DownloadImage: {Url} ({EntityID}) - {Message}",
-                        downloadURL,
-                        EntityID,
-                        e.Message);
-                    // Remove the record if the image doesn't exist or can't download
-                    RemoveImageRecord();
-                }
+                // If this has any issues, it will throw an exception, so the catch below will handle it.
+                if (req.DownloadNow())
+                    Logger.LogInformation("Image downloaded: {FilePath} from {DownloadUrl}", req.FilePath, req.DownloadUrl);
+                else
+                    Logger.LogWarning("Image failed to download; FilePath from {DownloadUrl}", req.FilePath, req.DownloadUrl);
+            }
+            catch (WebException e)
+            {
+                Logger.LogWarning("Error processing CommandRequest_DownloadImage: {Url} ({EntityID}) - {Message}",
+                    req.DownloadUrl,
+                    EntityID,
+                    e.Message);
+                // Remove the record if the image doesn't exist or can't download
+                RemoveImageRecord();
             }
         }
         catch (Exception ex)
         {
-            Logger.LogWarning("Error processing CommandRequest_DownloadImage: {Url} ({EntityID}) - {Ex}", downloadURL,
+            Logger.LogWarning("Error processing CommandRequest_DownloadImage: {Url} ({EntityID}) - {Ex}", req?.DownloadUrl,
                 EntityID, ex);
         }
     }
@@ -308,9 +224,7 @@ public class CommandRequest_DownloadImage : CommandRequestImplementation
             case ImageEntityType.TvDB_FanArt:
                 var fanart = RepoFactory.TvDB_ImageFanart.GetByID(EntityID);
                 if (fanart == null)
-                {
                     return;
-                }
 
                 RepoFactory.TvDB_ImageFanart.Delete(fanart);
                 break;
@@ -318,9 +232,7 @@ public class CommandRequest_DownloadImage : CommandRequestImplementation
             case ImageEntityType.TvDB_Cover:
                 var poster = RepoFactory.TvDB_ImagePoster.GetByID(EntityID);
                 if (poster == null)
-                {
                     return;
-                }
 
                 RepoFactory.TvDB_ImagePoster.Delete(poster);
                 break;
@@ -328,9 +240,7 @@ public class CommandRequest_DownloadImage : CommandRequestImplementation
             case ImageEntityType.TvDB_Banner:
                 var wideBanner = RepoFactory.TvDB_ImageWideBanner.GetByID(EntityID);
                 if (wideBanner == null)
-                {
                     return;
-                }
 
                 RepoFactory.TvDB_ImageWideBanner.Delete(wideBanner);
                 break;
@@ -338,9 +248,7 @@ public class CommandRequest_DownloadImage : CommandRequestImplementation
             case ImageEntityType.MovieDB_Poster:
                 var moviePoster = RepoFactory.MovieDB_Poster.GetByID(EntityID);
                 if (moviePoster == null)
-                {
                     return;
-                }
 
                 RepoFactory.MovieDB_Poster.Delete(moviePoster);
                 break;
@@ -348,188 +256,10 @@ public class CommandRequest_DownloadImage : CommandRequestImplementation
             case ImageEntityType.MovieDB_FanArt:
                 var movieFanart = RepoFactory.MovieDB_Fanart.GetByID(EntityID);
                 if (movieFanart == null)
-                {
                     return;
-                }
 
                 RepoFactory.MovieDB_Fanart.Delete(movieFanart);
                 break;
-        }
-    }
-
-    private void RecursivelyRetryDownload(string downloadURL, ref string tempFilePath, int count, int maxretry)
-    {
-        try
-        {
-            // download image
-            if (downloadURL.Length <= 0)
-            {
-                return;
-            }
-
-            // Ignore all certificate failures.
-            ServicePointManager.Expect100Continue = true;
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-            ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
-
-            using (var client = new WebClient())
-            {
-                client.Headers.Add("user-agent", "JMM");
-                //OnImageDownloadEvent(new ImageDownloadEventArgs("", req, ImageDownloadEventType.Started));
-                //BaseConfig.MyAnimeLog.Write("ProcessImages: Download: {0}  *** to ***  {1}", req.URL, fullName);
-
-                var bytes = client.DownloadData(downloadURL);
-                if (bytes.Length < 4)
-                {
-                    throw new WebException(
-                        "The image download stream returned less than 4 bytes (a valid image has 2-4 bytes in the header)");
-                }
-
-                var imageFormat = Misc.GetImageFormat(bytes);
-                string extension;
-                switch (imageFormat)
-                {
-                    case ImageFormatEnum.bmp:
-                        extension = ".bmp";
-                        break;
-                    case ImageFormatEnum.gif:
-                        extension = ".gif";
-                        break;
-                    case ImageFormatEnum.jpeg:
-                        extension = ".jpeg";
-                        break;
-                    case ImageFormatEnum.png:
-                        extension = ".png";
-                        break;
-                    case ImageFormatEnum.tiff:
-                        extension = ".tiff";
-                        break;
-                    default: throw new WebException("The image download stream returned an invalid image");
-                }
-
-                if (extension.Length <= 0)
-                {
-                    return;
-                }
-
-                var newFile = Path.ChangeExtension(tempFilePath, extension);
-                if (newFile == null)
-                {
-                    return;
-                }
-
-                if (File.Exists(newFile))
-                {
-                    File.Delete(newFile);
-                }
-
-                using (var fs = new FileStream(newFile, FileMode.Create, FileAccess.Write))
-                {
-                    fs.Write(bytes, 0, bytes.Length);
-                }
-
-                tempFilePath = newFile;
-            }
-        }
-        catch (WebException)
-        {
-            if (count + 1 >= maxretry)
-            {
-                throw;
-            }
-
-            Thread.Sleep(500);
-            RecursivelyRetryDownload(downloadURL, ref tempFilePath, count + 1, maxretry);
-        }
-    }
-
-    public string GetFileURL(ImageDownloadRequest req)
-    {
-        switch (req.ImageType)
-        {
-            case ImageEntityType.TvDB_Episode:
-                var ep = req.ImageData as TvDB_Episode;
-                return string.Format(Constants.URLS.TvDB_Episode_Images, ep!.Filename);
-
-            case ImageEntityType.TvDB_FanArt:
-                var fanart = req.ImageData as TvDB_ImageFanart;
-                return string.Format(Constants.URLS.TvDB_Images, fanart!.BannerPath);
-
-            case ImageEntityType.TvDB_Cover:
-                var poster = req.ImageData as TvDB_ImagePoster;
-                return string.Format(Constants.URLS.TvDB_Images, poster!.BannerPath);
-
-            case ImageEntityType.TvDB_Banner:
-                var wideBanner = req.ImageData as TvDB_ImageWideBanner;
-                return string.Format(Constants.URLS.TvDB_Images, wideBanner!.BannerPath);
-
-            case ImageEntityType.MovieDB_Poster:
-                var moviePoster = req.ImageData as MovieDB_Poster;
-                return string.Format(Constants.URLS.MovieDB_Images, moviePoster!.URL);
-
-            case ImageEntityType.MovieDB_FanArt:
-                var movieFanart = req.ImageData as MovieDB_Fanart;
-                return string.Format(Constants.URLS.MovieDB_Images, movieFanart!.URL);
-
-            case ImageEntityType.AniDB_Cover:
-                var anime = req.ImageData as SVR_AniDB_Anime;
-                return string.Format(_handler.ImageServerUrl, anime!.Picname);
-
-            case ImageEntityType.AniDB_Character:
-                var chr = req.ImageData as AniDB_Character;
-                return string.Format(_handler.ImageServerUrl, chr!.PicName);
-
-            case ImageEntityType.AniDB_Creator:
-                var creator = req.ImageData as AniDB_Seiyuu;
-                return string.Format(_handler.ImageServerUrl, creator!.PicName);
-
-            default:
-                return string.Empty;
-        }
-    }
-
-    private string GetFileName(ImageDownloadRequest req)
-    {
-        switch (req.ImageType)
-        {
-            case ImageEntityType.AniDB_Cover:
-                var anime = req.ImageData as SVR_AniDB_Anime;
-                return anime!.PosterPath;
-
-            case ImageEntityType.TvDB_Episode:
-                var ep = req.ImageData as TvDB_Episode;
-                return ep.GetFullImagePath();
-
-            case ImageEntityType.TvDB_FanArt:
-                var fanart = req.ImageData as TvDB_ImageFanart;
-                return fanart.GetFullImagePath();
-
-            case ImageEntityType.TvDB_Cover:
-                var poster = req.ImageData as TvDB_ImagePoster;
-                return poster.GetFullImagePath();
-
-            case ImageEntityType.TvDB_Banner:
-                var wideBanner = req.ImageData as TvDB_ImageWideBanner;
-                return wideBanner.GetFullImagePath();
-
-            case ImageEntityType.MovieDB_Poster:
-                var moviePoster = req.ImageData as MovieDB_Poster;
-                return moviePoster.GetFullImagePath();
-
-            case ImageEntityType.MovieDB_FanArt:
-                var movieFanart = req.ImageData as MovieDB_Fanart;
-                return movieFanart.GetFullImagePath();
-
-            case ImageEntityType.AniDB_Character:
-                var chr = req.ImageData as AniDB_Character;
-                return chr.GetPosterPath();
-
-            case ImageEntityType.AniDB_Creator:
-                var creator = req.ImageData as AniDB_Seiyuu;
-                return creator.GetPosterPath();
-
-            default:
-                return string.Empty;
         }
     }
 

--- a/Shoko.Server/ImageDownload/ImageDownloadRequest.cs
+++ b/Shoko.Server/ImageDownload/ImageDownloadRequest.cs
@@ -1,17 +1,134 @@
-﻿using Shoko.Models.Enums;
+﻿using System.Net;
+using System.IO;
+using Shoko.Models.Server;
+using Shoko.Server.Extensions;
+using Shoko.Server.Models;
+using Shoko.Server.Server;
+using Shoko.Commons.Utils;
+using System.Threading;
+using System.Net.Http;
 
+#nullable enable
 namespace Shoko.Server.ImageDownload;
 
 public class ImageDownloadRequest
 {
-    public ImageEntityType ImageType { get; set; }
-    public object ImageData { get; set; }
-    public bool ForceDownload { get; set; }
 
-    public ImageDownloadRequest(ImageEntityType imageType, object data, bool forceDownload)
+    private object ImageData { get; }
+
+    public bool ForceDownload { get; }
+
+    private string ImageServerUrl { get; }
+
+    private string? _filePath { get; set; } = null;
+
+    public string FilePath
+        => _filePath != null ? _filePath : _filePath = ImageData switch
+        {
+            AniDB_Character character => character.GetPosterPath(),
+            AniDB_Seiyuu creator => creator.GetPosterPath(),
+            MovieDB_Fanart image => image.GetFullImagePath(),
+            MovieDB_Poster image => image.GetFullImagePath(),
+            SVR_AniDB_Anime anime => anime.PosterPath,
+            TvDB_Episode episode => episode.GetFullImagePath(),
+            TvDB_ImageFanart image => image.GetFullImagePath(),
+            TvDB_ImagePoster image => image.GetFullImagePath(),
+            TvDB_ImageWideBanner image => image.GetFullImagePath(),
+            _ => string.Empty,
+        };
+
+    private string? _downloadUrl { get; set; } = null;
+
+    public string DownloadUrl
+        => _downloadUrl != null ? _downloadUrl : _downloadUrl = ImageData switch
+        {
+            AniDB_Character character => string.Format(ImageServerUrl, character.PicName),
+            AniDB_Seiyuu creator => string.Format(ImageServerUrl, creator.PicName),
+            MovieDB_Fanart movieFanart => string.Format(Constants.URLS.MovieDB_Images, movieFanart.URL),
+            MovieDB_Poster moviePoster => string.Format(Constants.URLS.MovieDB_Images, moviePoster.URL),
+            SVR_AniDB_Anime anime => string.Format(ImageServerUrl, anime.Picname),
+            TvDB_Episode ep => string.Format(Constants.URLS.TvDB_Episode_Images, ep.Filename),
+            TvDB_ImageFanart fanart => string.Format(Constants.URLS.TvDB_Images, fanart.BannerPath),
+            TvDB_ImagePoster poster => string.Format(Constants.URLS.TvDB_Images, poster.BannerPath),
+            TvDB_ImageWideBanner wideBanner => string.Format(Constants.URLS.TvDB_Images, wideBanner.BannerPath),
+            _ => string.Empty
+        };
+
+    public ImageDownloadRequest(object data, bool forceDownload, string? imageServerUrl = null)
     {
-        ImageType = imageType;
         ImageData = data;
         ForceDownload = forceDownload;
+        ImageServerUrl = imageServerUrl ?? "";
+    }
+
+    public bool DownloadNow(int maxRetries = 5)
+        => RecursivelyRetryDownload(0, maxRetries);
+
+    private bool RecursivelyRetryDownload(int count, int maxRetries)
+    {
+        // Abort if the download url or final destination is not available.
+        if (string.IsNullOrEmpty(DownloadUrl) || string.IsNullOrEmpty(FilePath))
+            return false;
+
+        var imageValid = File.Exists(FilePath) && Misc.IsImageValid(FilePath);
+        if (imageValid && !ForceDownload)
+            return false;
+
+        var tempPath = Path.Combine(ImageUtils.GetImagesTempFolder(), Path.GetFileName(FilePath));
+        try
+        {
+            // Ignore all certificate failures.
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+
+            // Download the image.
+            using (var client = new HttpClient())
+            {
+                // Download the image data.
+                client.DefaultRequestHeaders.Add("user-agent", "JMM");
+                var bytes = client.GetByteArrayAsync(DownloadUrl)
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+                if (bytes.Length < 4)
+                    throw new WebException(
+                        "The image download stream returned less than 4 bytes (a valid image has 2-4 bytes in the header)");
+
+                // Check if the image format is valid.
+                if (Misc.GetImageFormat(bytes) == null)
+                    throw new WebException("The image download stream returned an invalid image");
+
+                // Delete the existing (failed?) temporary file.
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+
+                // Write the image data to the temp file.
+                using (var fs = new FileStream(tempPath, FileMode.Create, FileAccess.Write))
+                    fs.Write(bytes, 0, bytes.Length);
+
+                // Make sure the directory structure exists.
+                var dirPath = Path.GetDirectoryName(tempPath);
+                if (!string.IsNullOrEmpty(dirPath) && !Directory.Exists(dirPath))
+                    Directory.CreateDirectory(dirPath);
+
+                // Delete the existing file if we're re-downloading.
+                if (File.Exists(FilePath))
+                    File.Delete(FilePath);
+
+                // Move the temp file to it's final destination.
+                File.Move(tempPath, FilePath);
+
+                return true;
+            }
+        }
+        catch (WebException)
+        {
+            if (count + 1 >= maxRetries)
+                throw;
+
+            Thread.Sleep(1000);
+            return RecursivelyRetryDownload(count + 1, maxRetries);
+        }
     }
 }


### PR DESCRIPTION
Modernize the image commands. A second PR to add staff data and staff images
are incoming.

 ### Changes in this commit/PR

- Modernized and simplified the image commands (by my standards if that is
  anything to go by man_shrugging).

- Tried to reduce duplicate code where possible, without rewriting the whole
  system.

- **Updated Shoko.Commons** to modify the get image format helper function
  used in this PR. The master branch for Shoko.Commons needs to be moved
  accordingly afterwards.