### PR TITLE
refactor: update tags

### DIFF
--- a/Shoko.Server/API/v3/Controllers/SeriesController.cs
+++ b/Shoko.Server/API/v3/Controllers/SeriesController.cs
@@ -1177,10 +1177,12 @@ public class SeriesController : BaseController
     /// <param name="filter"></param>
     /// <param name="excludeDescriptions"></param>
     /// <param name="orderByName">Order tags by name (and source) only. Don't use the tag weights for ordering.</param>
+    /// <param name="onlyVerified">Only show verified tags.</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/Tags")]
     public ActionResult<List<Tag>> GetSeriesTags([FromRoute] int seriesID, [FromQuery] TagFilter.Filter filter = 0,
-        [FromQuery] bool excludeDescriptions = false, [FromQuery] bool orderByName = false)
+        [FromQuery] bool excludeDescriptions = false, [FromQuery] bool orderByName = false,
+        [FromQuery] bool onlyVerified = true)
     {
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
@@ -1199,7 +1201,7 @@ public class SeriesController : BaseController
             return new List<Tag>();
         }
 
-        return Series.GetTags(HttpContext, anidb, filter, excludeDescriptions, orderByName);
+        return Series.GetTags(HttpContext, anidb, filter, excludeDescriptions, orderByName, onlyVerified);
     }
 
     /// <summary>

--- a/Shoko.Server/API/v3/Models/Common/Tag.cs
+++ b/Shoko.Server/API/v3/Models/Common/Tag.cs
@@ -1,3 +1,4 @@
+using System;
 using Newtonsoft.Json;
 using Shoko.Models.Server;
 
@@ -20,15 +21,20 @@ public class Tag
         if (!excludeDescriptions)
             Description = tag.TagDescription;
         Source = "User";
+        IsSpoiler = false;
     }
 
     public Tag(AniDB_Tag tag, bool excludeDescriptions = false)
     {
         ID = tag.TagID;
+        ParentID = tag.ParentTagID;
         Name = tag.TagName;
         if (!excludeDescriptions)
             Description = tag.TagDescription;
         Source = "AniDB";
+        IsVerified = tag.Verified;
+        IsSpoiler = tag.GlobalSpoiler;
+        LastUpdated = tag.LastUpdated;
     }
 
     /// <summary>
@@ -38,21 +44,55 @@ public class Tag
     public int ID { get; set; }
 
     /// <summary>
-    /// The tag itself
+    /// The parent tag id, if any. Relative to it's source for now.
+    /// </summary>
+    public int? ParentID { get; set; }
+
+    /// <summary>
+    /// The tag itself.
     /// </summary>
     public string Name { get; set; }
 
     /// <summary>
-    /// What does the tag mean/what's it for
+    /// What does the tag mean/what's it for.
     /// </summary>
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public string? Description { get; set; }
+
+    /// <summary>
+    /// True if the tag has been verified.
+    /// </summary>
+    /// <remarks>
+    /// For anidb does this mean the tag has been verified for use, and is not
+    /// an unsorted tag. Also, anidb hides unverified tags from appearing in
+    /// their UI except when the tags are edited.
+    /// </remarks>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public bool? IsVerified { get; set; }
+
+    /// <summary>
+    /// True if the tag is considered a spoiler for all series it appears on.
+    /// </summary>
+    public bool IsSpoiler { get; set; }
+
+    /// <summary>
+    /// True if the tag is considered a spoiler for that particular series it is
+    /// set on.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public bool? IsLocalSpoiler { get; set; }
 
     /// <summary>
     /// How relevant is it to the series
     /// </summary>
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public int? Weight { get; set; }
+
+    /// <summary>
+    /// When the tag info was last updated.
+    /// </summary>
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public DateTime? LastUpdated { get; set; }
     
     /// <summary>
     /// Source. Anidb, User, etc.

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -706,7 +706,7 @@ public class MySQL : BaseDatabase<MySqlConnection>, IDatabase
         new(106, 2, "UPDATE VideoLocal v INNER JOIN CrossRef_File_Episode CRFE on v.Hash = CRFE.Hash SET DateTimeImported = DateTimeCreated;"),
         new(107, 1, "ALTER TABLE AniDB_Tag ADD Verified integer NOT NULL DEFAULT 0;"),
         new(107, 2, "ALTER TABLE AniDB_Tag ADD ParentTagID integer DEFAULT NULL;"),
-        new(107, 3, "ALTER TABLE AniDB_Tag ADD TagNameOverride text DEFAULT NULL;"),
+        new(107, 3, "ALTER TABLE AniDB_Tag ADD TagNameOverride varchar(150) DEFAULT NULL;"),
         new(107, 4, "ALTER TABLE AniDB_Tag ADD LastUpdated datetime NOT NULL DEFAULT '1970-01-01 00:00:00';"),
         new(107, 5, "ALTER TABLE AniDB_Tag DROP COLUMN Spoiler;"),
         new(107, 6, "ALTER TABLE AniDB_Tag DROP COLUMN LocalSpoiler;"),

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -19,7 +19,7 @@ namespace Shoko.Server.Databases;
 public class MySQL : BaseDatabase<MySqlConnection>, IDatabase
 {
     public string Name { get; } = "MySQL";
-    public int RequiredVersion { get; } = 106;
+    public int RequiredVersion { get; } = 107;
 
 
     private List<DatabaseCommand> createVersionTable = new()
@@ -703,7 +703,17 @@ public class MySQL : BaseDatabase<MySqlConnection>, IDatabase
         new(104, 1, "ALTER TABLE AniDB_Episode ADD INDEX IX_AniDB_Episode_EpisodeType (EpisodeType);"),
         new(105, 1, "ALTER TABLE AniDB_Episode_Title MODIFY Title TEXT NOT NULL"),
         new(106, 1, "ALTER TABLE VideoLocal ADD DateTimeImported datetime DEFAULT NULL;"),
-        new(106, 2, "UPDATE VideoLocal v INNER JOIN CrossRef_File_Episode CRFE on v.Hash = CRFE.Hash SET DateTimeImported = DateTimeCreated;")
+        new(106, 2, "UPDATE VideoLocal v INNER JOIN CrossRef_File_Episode CRFE on v.Hash = CRFE.Hash SET DateTimeImported = DateTimeCreated;"),
+        new(107, 1, "ALTER TABLE AniDB_Tag ADD Verified integer NOT NULL DEFAULT 0;"),
+        new(107, 2, "ALTER TABLE AniDB_Tag ADD ParentTagID integer DEFAULT NULL;"),
+        new(107, 3, "ALTER TABLE AniDB_Tag ADD TagNameOverride text DEFAULT NULL;"),
+        new(107, 4, "ALTER TABLE AniDB_Tag ADD LastUpdated datetime NOT NULL DEFAULT '1970-01-01 00:00:00';"),
+        new(107, 5, "ALTER TABLE AniDB_Tag DROP COLUMN Spoiler;"),
+        new(107, 6, "ALTER TABLE AniDB_Tag DROP COLUMN LocalSpoiler;"),
+        new(107, 7, "ALTER TABLE AniDB_Tag DROP COLUMN TagCount;"),
+        new(107, 8, "ALTER TABLE AniDB_Anime_Tag ADD LocalSpoiler integer NOT NULL DEFAULT 0;"),
+        new(107, 9, "ALTER TABLE AniDB_Anime_Tag DROP COLUMN Approval;"),
+        new(107, 10, DatabaseFixes.FixTagParentIDsAndNameOverrides),
     };
 
     private DatabaseCommand linuxTableVersionsFix = new("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -22,7 +22,7 @@ namespace Shoko.Server.Databases;
 public class SQLServer : BaseDatabase<SqlConnection>, IDatabase
 {
     public string Name { get; } = "SQLServer";
-    public int RequiredVersion { get; } = 99;
+    public int RequiredVersion { get; } = 100;
 
     public void BackupDatabase(string fullfilename)
     {
@@ -649,7 +649,17 @@ public class SQLServer : BaseDatabase<SqlConnection>, IDatabase
         new DatabaseCommand(97, 1, "CREATE INDEX IX_AniDB_Episode_EpisodeType ON AniDB_Episode(EpisodeType);"),
         new DatabaseCommand(98, 1, "ALTER TABLE AniDB_Episode_Title ALTER COLUMN Title nvarchar(max) NOT NULL;"),
         new DatabaseCommand(99, 1, "ALTER TABLE VideoLocal ADD DateTimeImported datetime DEFAULT NULL;"),
-        new DatabaseCommand(99, 2, "UPDATE v SET DateTimeImported = DateTimeCreated FROM VideoLocal v INNER JOIN CrossRef_File_Episode CRFE on v.Hash = CRFE.Hash;")
+        new DatabaseCommand(99, 2, "UPDATE v SET DateTimeImported = DateTimeCreated FROM VideoLocal v INNER JOIN CrossRef_File_Episode CRFE on v.Hash = CRFE.Hash;"),
+        new DatabaseCommand(100, 1, "ALTER TABLE AniDB_Tag ADD Verified integer NOT NULL DEFAULT 0;"),
+        new DatabaseCommand(100, 2, "ALTER TABLE AniDB_Tag ADD ParentTagID integer DEFAULT NULL;"),
+        new DatabaseCommand(100, 3, "ALTER TABLE AniDB_Tag ADD TagNameOverride text DEFAULT NULL;"),
+        new DatabaseCommand(100, 4, "ALTER TABLE AniDB_Tag ADD LastUpdated datetime NOT NULL DEFAULT '1970-01-01 00:00:00';"),
+        new DatabaseCommand(100, 5, "ALTER TABLE AniDB_Tag DROP COLUMN Spoiler;"),
+        new DatabaseCommand(100, 6, "ALTER TABLE AniDB_Tag DROP COLUMN LocalSpoiler;"),
+        new DatabaseCommand(100, 7, "ALTER TABLE AniDB_Tag DROP COLUMN TagCount;"),
+        new DatabaseCommand(100, 8, "ALTER TABLE AniDB_Anime_Tag ADD LocalSpoiler integer NOT NULL DEFAULT 0;"),
+        new DatabaseCommand(100, 9, "ALTER TABLE AniDB_Anime_Tag DROP COLUMN Approval;"),
+        new DatabaseCommand(100, 10, DatabaseFixes.FixTagParentIDsAndNameOverrides),
     };
 
     private static Tuple<bool, string> DropDefaultsOnAnimeEpisode_User(object connection)

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -652,7 +652,7 @@ public class SQLServer : BaseDatabase<SqlConnection>, IDatabase
         new DatabaseCommand(99, 2, "UPDATE v SET DateTimeImported = DateTimeCreated FROM VideoLocal v INNER JOIN CrossRef_File_Episode CRFE on v.Hash = CRFE.Hash;"),
         new DatabaseCommand(100, 1, "ALTER TABLE AniDB_Tag ADD Verified integer NOT NULL DEFAULT 0;"),
         new DatabaseCommand(100, 2, "ALTER TABLE AniDB_Tag ADD ParentTagID integer DEFAULT NULL;"),
-        new DatabaseCommand(100, 3, "ALTER TABLE AniDB_Tag ADD TagNameOverride text DEFAULT NULL;"),
+        new DatabaseCommand(100, 3, "ALTER TABLE AniDB_Tag ADD TagNameOverride varchar(150) DEFAULT NULL;"),
         new DatabaseCommand(100, 4, "ALTER TABLE AniDB_Tag ADD LastUpdated datetime NOT NULL DEFAULT '1970-01-01 00:00:00';"),
         new DatabaseCommand(100, 5, "ALTER TABLE AniDB_Tag DROP COLUMN Spoiler;"),
         new DatabaseCommand(100, 6, "ALTER TABLE AniDB_Tag DROP COLUMN LocalSpoiler;"),

--- a/Shoko.Server/Databases/SQLite.cs
+++ b/Shoko.Server/Databases/SQLite.cs
@@ -21,7 +21,7 @@ public class SQLite : BaseDatabase<SqliteConnection>, IDatabase
 {
     public string Name { get; } = "SQLite";
 
-    public int RequiredVersion { get; } = 92;
+    public int RequiredVersion { get; } = 93;
 
 
     public void BackupDatabase(string fullfilename)
@@ -618,7 +618,17 @@ public class SQLite : BaseDatabase<SqliteConnection>, IDatabase
         new(90, 1, "UPDATE AniDB_File SET File_Source = 'Web' WHERE File_Source = 'www'; UPDATE AniDB_File SET File_Source = 'BluRay' WHERE File_Source = 'Blu-ray'; UPDATE AniDB_File SET File_Source = 'LaserDisc' WHERE File_Source = 'LD'; UPDATE AniDB_File SET File_Source = 'Unknown' WHERE File_Source = 'unknown';"),
         new(91, 1, "CREATE INDEX IX_AniDB_Episode_EpisodeType ON AniDB_Episode(EpisodeType);"),
         new(92, 1, "ALTER TABLE VideoLocal ADD DateTimeImported timestamp DEFAULT NULL;"),
-        new(92, 2, "UPDATE VideoLocal SET DateTimeImported = DateTimeCreated WHERE EXISTS(SELECT Hash FROM CrossRef_File_Episode xref WHERE xref.Hash = VideoLocal.Hash)")
+        new(92, 2, "UPDATE VideoLocal SET DateTimeImported = DateTimeCreated WHERE EXISTS(SELECT Hash FROM CrossRef_File_Episode xref WHERE xref.Hash = VideoLocal.Hash)"),
+        new(93, 1, "ALTER TABLE AniDB_Tag ADD Verified integer NOT NULL DEFAULT 0;"),
+        new(93, 2, "ALTER TABLE AniDB_Tag ADD ParentTagID integer DEFAULT NULL;"),
+        new(93, 3, "ALTER TABLE AniDB_Tag ADD TagNameOverride text DEFAULT NULL;"),
+        new(93, 4, "ALTER TABLE AniDB_Tag ADD LastUpdated timestamp NOT NULL DEFAULT '1970-01-01 00:00:00';"),
+        new(93, 5, "ALTER TABLE AniDB_Tag DROP COLUMN Spoiler;"),
+        new(93, 6, "ALTER TABLE AniDB_Tag DROP COLUMN LocalSpoiler;"),
+        new(93, 7, "ALTER TABLE AniDB_Tag DROP COLUMN TagCount;"),
+        new(93, 8, "ALTER TABLE AniDB_Anime_Tag ADD LocalSpoiler integer NOT NULL DEFAULT 0;"),
+        new(93, 9, "ALTER TABLE AniDB_Anime_Tag DROP COLUMN Approval;"),
+        new(93, 10, DatabaseFixes.FixTagParentIDsAndNameOverrides),
     };
 
     private static Tuple<bool, string> DropLanguage(object connection)

--- a/Shoko.Server/Mappings/AniDB_Anime_TagMap.cs
+++ b/Shoko.Server/Mappings/AniDB_Anime_TagMap.cs
@@ -12,7 +12,7 @@ public class AniDB_Anime_TagMap : ClassMap<AniDB_Anime_Tag>
         Id(x => x.AniDB_Anime_TagID);
 
         Map(x => x.AnimeID).Not.Nullable();
-        Map(x => x.Approval).Not.Nullable();
+        Map(x => x.LocalSpoiler).Not.Nullable();
         Map(x => x.Weight).Not.Nullable();
         Map(x => x.TagID).Not.Nullable();
     }

--- a/Shoko.Server/Mappings/AniDB_TagMap.cs
+++ b/Shoko.Server/Mappings/AniDB_TagMap.cs
@@ -11,12 +11,13 @@ public class AniDB_TagMap : ClassMap<AniDB_Tag>
         Not.LazyLoad();
         Id(x => x.AniDB_TagID);
 
-        Map(x => x.GlobalSpoiler).Not.Nullable();
-        Map(x => x.LocalSpoiler).Not.Nullable();
-        Map(x => x.Spoiler).Not.Nullable();
-        Map(x => x.TagCount).Not.Nullable();
-        Map(x => x.TagDescription).Not.Nullable().CustomType("StringClob");
         Map(x => x.TagID).Not.Nullable();
-        Map(x => x.TagName).Not.Nullable();
+        Map(x => x.ParentTagID);
+        Map(x => x.TagNameSource).Column("TagName").Not.Nullable();
+        Map(x => x.TagNameOverride);
+        Map(x => x.TagDescription).Not.Nullable().CustomType("StringClob");
+        Map(x => x.GlobalSpoiler).Not.Nullable();
+        Map(x => x.Verified).Not.Nullable();
+        Map(x => x.LastUpdated);
     }
 }

--- a/Shoko.Server/Providers/AniDB/HTTP/AnimeCreator.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/AnimeCreator.cs
@@ -273,7 +273,84 @@ public class AnimeCreator
         RepoFactory.AniDB_Anime_Title.Save(titlesToSave);
     }
 
-    private void CreateTags(List<ResponseTag> tags, SVR_AniDB_Anime anime)
+    /// <summary>
+    /// A dictionary containing the name overrides for tags whose name either
+    /// doesn't makes much sense or is otherwise confusing.
+    /// </summary>
+    /// <remarks>
+    /// We use the tag name since the id _can_ change sometimes.
+    /// </remarks>
+    internal static Dictionary<string, string> TagNameOverrideDict = new()
+    {
+        {"new", "original work"},
+        {"original work", "source material"},
+    };
+
+    private AniDB_Tag FindOrCreate(ResponseTag rawTag)
+    {
+        var tag = RepoFactory.AniDB_Tag.GetByTagID(rawTag.TagID);
+
+        // We're trying to add older details to an existing tag,
+        // so skip updating the tag but still create the cross-reference.
+        if (tag != null && tag.LastUpdated != DateTime.UnixEpoch && tag.LastUpdated >= rawTag.LastUpdated)
+            return tag;
+
+        if (tag == null)
+        {
+            // There are situations in which an ID may have changed, this is
+            // usually due to it being moved, but may be for other reasons.
+            var existingTags = RepoFactory.AniDB_Tag.GetBySourceName(rawTag.TagName);
+            var lastUpdatedTag = existingTags
+                .OrderByDescending(existingTag => existingTag.LastUpdated)
+                .FirstOrDefault();
+
+            // One (or more, but idc) of the existing tags are more recently
+            // updated than the tag we're trying to create, so skip creating
+            // the tag and instead use more recent tag.
+            if (lastUpdatedTag != null && lastUpdatedTag.LastUpdated >= rawTag.LastUpdated)
+                return lastUpdatedTag;
+
+            var xrefsToRemap = existingTags
+                .SelectMany(t => RepoFactory.AniDB_Anime_Tag.GetByTagID(t.TagID))
+                .ToList();
+            foreach (var xref in xrefsToRemap)
+            {
+                xref.TagID = rawTag.TagID;
+                RepoFactory.AniDB_Anime_Tag.Save(xref);
+            }
+
+            // Delete the obsolete tag(s).
+            RepoFactory.AniDB_Tag.Delete(existingTags);
+
+            // While we're at it, clean up other unreferenced tags.
+            RepoFactory.AniDB_Tag.Delete(RepoFactory.AniDB_Tag.GetAll()
+                .Where(a => !RepoFactory.AniDB_Anime_Tag.GetByTagID(a.TagID).Any()).ToList());
+
+            // Also clean up dead cross-references. They shouldn't exist,
+            // but they sometime does for whatever reason. ¯\_(ツ)_/¯
+            var orphanedXRefs = RepoFactory.AniDB_Anime_Tag.GetAll().Where(a =>
+                RepoFactory.AniDB_Tag.GetByTagID(a.TagID) == null ||
+                RepoFactory.AniDB_Anime.GetByAnimeID(a.AnimeID) == null).ToList();
+
+            RepoFactory.AniDB_Anime_Tag.Delete(orphanedXRefs);
+
+            tag = new AniDB_Tag();
+        }
+
+        TagNameOverrideDict.TryGetValue(rawTag.TagName, out var nameOverride);
+        tag.TagID = rawTag.TagID;
+        tag.ParentTagID = rawTag.ParentTagID;
+        tag.TagNameSource = rawTag.TagName;
+        tag.TagNameOverride = nameOverride;
+        tag.TagDescription = rawTag.TagDescription ?? string.Empty;
+        tag.GlobalSpoiler = rawTag.GlobalSpoiler;
+        tag.Verified = rawTag.Verified;
+        tag.LastUpdated = rawTag.LastUpdated;
+
+        return tag;
+    }
+
+    public void CreateTags(List<ResponseTag> tags, SVR_AniDB_Anime anime)
     {
         if (tags == null)
         {
@@ -287,76 +364,36 @@ public class AnimeCreator
 
         // find all the current links, and then later remove the ones that are no longer relevant
         var currentTags = RepoFactory.AniDB_Anime_Tag.GetByAnimeID(anime.AnimeID);
-        var newTagIDs = new List<int>();
+        var newTagIDs = new HashSet<int>();
 
         foreach (var rawtag in tags)
         {
-            var tag = RepoFactory.AniDB_Tag.GetByTagID(rawtag.TagID);
-
-            if (tag == null)
-            {
-                // There are situations in which an ID may have changed, this is usually due to it being moved
-                var existingTags = RepoFactory.AniDB_Tag.GetByName(rawtag.TagName).ToList();
-                var xrefsToRemap = existingTags.SelectMany(a => RepoFactory.AniDB_Anime_Tag.GetByTagID(a.TagID))
-                    .ToList();
-                foreach (var xref in xrefsToRemap)
-                {
-                    xref.TagID = rawtag.TagID;
-                    RepoFactory.AniDB_Anime_Tag.Save(xref);
-                }
-
-                // Delete the obsolete tag(s)
-                RepoFactory.AniDB_Tag.Delete(existingTags);
-
-                // While we're at it, clean up other unreferenced tags
-                RepoFactory.AniDB_Tag.Delete(RepoFactory.AniDB_Tag.GetAll()
-                    .Where(a => !RepoFactory.AniDB_Anime_Tag.GetByTagID(a.TagID).Any()).ToList());
-
-                // Also clean up dead xrefs (shouldn't happen, but sometimes does)
-                var orphanedXRefs = RepoFactory.AniDB_Anime_Tag.GetAll().Where(a =>
-                    RepoFactory.AniDB_Tag.GetByTagID(a.TagID) == null ||
-                    RepoFactory.AniDB_Anime.GetByAnimeID(a.AnimeID) == null).ToList();
-
-                RepoFactory.AniDB_Anime_Tag.Delete(orphanedXRefs);
-
-                tag = new AniDB_Tag();
-            }
-
-            if (string.IsNullOrEmpty(rawtag.TagName))
-            {
+            if (rawtag.TagID <= 0 || string.IsNullOrEmpty(rawtag.TagName))
                 continue;
-            }
 
-            if (rawtag.TagID <= 0)
-            {
-                continue;
-            }
-
-            tag.TagID = rawtag.TagID;
-            tag.GlobalSpoiler = rawtag.GlobalSpoiler ? 1 : 0;
-            tag.LocalSpoiler = rawtag.LocalSpoiler ? 1 : 0;
-            tag.Spoiler = 0;
-            tag.TagCount = 0;
-            tag.TagDescription = rawtag.TagDescription ?? string.Empty;
-            tag.TagName = rawtag.TagName;
+            var tag = FindOrCreate(rawtag);
             tagsToSave.Add(tag);
 
             newTagIDs.Add(tag.TagID);
 
-            var animeTag = RepoFactory.AniDB_Anime_Tag.GetByAnimeIDAndTagID(rawtag.AnimeID, rawtag.TagID) ??
-                           new AniDB_Anime_Tag();
-            animeTag.AnimeID = rawtag.AnimeID;
-            animeTag.TagID = rawtag.TagID;
-            animeTag.Approval = 100;
-            animeTag.Weight = rawtag.Weight;
-            xrefsToSave.Add(animeTag);
+            var xref = RepoFactory.AniDB_Anime_Tag.GetByAnimeIDAndTagID(rawtag.AnimeID, tag.TagID) ?? new();
+            xref.AnimeID = rawtag.AnimeID;
+            xref.TagID = tag.TagID;
+            xref.LocalSpoiler = rawtag.LocalSpoiler;
+            xref.Weight = rawtag.Weight;
+            xrefsToSave.Add(xref);
 
-            if (allTags.Length > 0)
+            // Only add it to the cached array if the tag is verified. This
+            // ensures the v1 and v2 api is only displaying verified tags.
+            if (tag.Verified)
             {
-                allTags += "|";
-            }
+                if (allTags.Length > 0)
+                {
+                    allTags += "|";
+                }
 
-            allTags += tag.TagName;
+                allTags += tag.TagName;
+            }
         }
 
         anime.AllTags = allTags;

--- a/Shoko.Server/Providers/AniDB/HTTP/AnimeCreator.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/AnimeCreator.cs
@@ -286,7 +286,7 @@ public class AnimeCreator
         {"original work", "source material"},
     };
 
-    private AniDB_Tag FindOrCreate(ResponseTag rawTag)
+    private AniDB_Tag FindOrCreateTag(ResponseTag rawTag)
     {
         var tag = RepoFactory.AniDB_Tag.GetByTagID(rawTag.TagID);
 
@@ -371,7 +371,7 @@ public class AnimeCreator
             if (rawtag.TagID <= 0 || string.IsNullOrEmpty(rawtag.TagName))
                 continue;
 
-            var tag = FindOrCreate(rawtag);
+            var tag = FindOrCreateTag(rawtag);
             tagsToSave.Add(tag);
 
             newTagIDs.Add(tag.TagID);

--- a/Shoko.Server/Providers/AniDB/HTTP/GetAnime/ResponseTag.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/GetAnime/ResponseTag.cs
@@ -1,13 +1,17 @@
-﻿namespace Shoko.Server.Providers.AniDB.HTTP.GetAnime;
+﻿using System;
+
+namespace Shoko.Server.Providers.AniDB.HTTP.GetAnime;
 
 public class ResponseTag
 {
     public int AnimeID { get; set; }
     public int TagID { get; set; }
-    public bool Spoiler { get; set; }
+    public int? ParentTagID { get; set; }
+    public bool Verified { get; set; }
     public bool LocalSpoiler { get; set; }
     public bool GlobalSpoiler { get; set; }
     public string TagName { get; set; }
     public string TagDescription { get; set; }
     public int Weight { get; set; }
+    public DateTime LastUpdated { get; set; }
 }

--- a/Shoko.Server/Providers/AniDB/HTTP/HttpAnimeParser.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/HttpAnimeParser.cs
@@ -473,20 +473,26 @@ public class HttpAnimeParser
         }
 
         var tagDescription = TryGetProperty(node, "description")?.Replace('`', '\'');
+        int.TryParse(TryGetAttribute(node, "parentid"), out var parentTagID);
         int.TryParse(TryGetAttribute(node, "weight"), out var weight);
+        bool.TryParse(TryGetAttribute(node, "verified"), out var verified);
         bool.TryParse(TryGetAttribute(node, "localspoiler"), out var lsp);
         bool.TryParse(TryGetAttribute(node, "globalspoiler"), out var gsp);
+        if (!DateTime.TryParse(TryGetAttribute(node, "update"), out var lastUpdated))
+            lastUpdated = DateTime.UnixEpoch;
 
         return new ResponseTag
         {
             AnimeID = animeID,
             TagID = tagID,
+            ParentTagID = parentTagID > 0 ? parentTagID : null,
             TagName = tagName,
             TagDescription = tagDescription,
             Weight = weight,
+            Verified = verified,
             LocalSpoiler = lsp,
             GlobalSpoiler = gsp,
-            Spoiler = lsp || gsp
+            LastUpdated = lastUpdated,
         };
     }
 

--- a/Shoko.Server/Repositories/Cached/AniDB_TagRepository.cs
+++ b/Shoko.Server/Repositories/Cached/AniDB_TagRepository.cs
@@ -11,11 +11,13 @@ public class AniDB_TagRepository : BaseCachedRepository<AniDB_Tag, int>
 {
     private PocoIndex<int, AniDB_Tag, int> Tags;
     private PocoIndex<int, AniDB_Tag, string> Names;
+    private PocoIndex<int, AniDB_Tag, string> SourceNames;
 
     public override void PopulateIndexes()
     {
         Tags = new PocoIndex<int, AniDB_Tag, int>(Cache, a => a.TagID);
         Names = new PocoIndex<int, AniDB_Tag, string>(Cache, a => a.TagName);
+        SourceNames = new PocoIndex<int, AniDB_Tag, string>(Cache, a => a.TagNameSource);
     }
 
     protected override int SelectKey(AniDB_Tag entity)
@@ -30,7 +32,8 @@ public class AniDB_TagRepository : BaseCachedRepository<AniDB_Tag, int>
         foreach (var tag in tags)
         {
             tag.TagDescription = tag.TagDescription?.Replace('`', '\'');
-            tag.TagName = tag.TagName.Replace('`', '\'');
+            tag.TagNameOverride = tag.TagNameOverride?.Replace('`', '\'');
+            tag.TagNameSource = tag.TagNameSource.Replace('`', '\'');
             Save(tag);
         }
     }
@@ -69,6 +72,11 @@ public class AniDB_TagRepository : BaseCachedRepository<AniDB_Tag, int>
     public List<AniDB_Tag> GetByName(string name)
     {
         return ReadLock(() => Names.GetMultiple(name));
+    }
+
+    public List<AniDB_Tag> GetBySourceName(string sourceName)
+    {
+        return ReadLock(() => SourceNames.GetMultiple(sourceName));
     }
 
 

--- a/Shoko.Server/Utilities/TagFilter.cs
+++ b/Shoko.Server/Utilities/TagFilter.cs
@@ -591,7 +591,7 @@ public class TagFilter<T> where T : class
                    (typeof(T) == typeof(string) ? name as T : (T)Activator.CreateInstance(typeof(T), name));
         }
 
-        originalWorkTag = GetTag("new");
+        originalWorkTag = GetTag("original work");
     }
 
     /// <summary>

--- a/Shoko.Server/Utilities/TagFilter.cs
+++ b/Shoko.Server/Utilities/TagFilter.cs
@@ -422,6 +422,15 @@ public static class TagFilter
     {
         tag = tag.Trim().ToLowerInvariant();
         var inverted = flags.HasFlag(Filter.Invert);
+
+        // Always remove the "original work" tag. It will be added back if it's
+        // not supposed to be filtered out and there are no other source
+        // material tags.
+        if (tag.Equals("original work"))
+        {
+            return true;
+        }
+
         if (flags.HasFlag(Filter.ArtStyle))
         {
             if (TagBlackListArtStyle.Contains(tag))

--- a/Shoko.Server/Utilities/TagFilter.cs
+++ b/Shoko.Server/Utilities/TagFilter.cs
@@ -632,14 +632,13 @@ public class TagFilter<T> where T : class
                 break;
         }
 
+        foreach (var tag in toRemove)
+            while (tags.Remove(tag)) { }
+
         // Add the _original work_ tag if no source tags are present and we either want to only include the source tags or want to not exclude the source tags.
         // evaluates like an xor because of how invert works
         var includeSource = flags.HasFlag(TagFilter.Filter.Source) == flags.HasFlag(TagFilter.Filter.Invert);
         var addOriginal = includeSource && !tags.Select(_nameSelector).Any(tag => TagFilter.TagBlackListSource.Contains(tag));
-
-        foreach (var tag in toRemove)
-            while (tags.Remove(tag)) { }
-
         if (addOriginal) tags.Add(originalWorkTag);
     }
 

--- a/Shoko.Tests/Shoko.Tests/TagFilterTest.cs
+++ b/Shoko.Tests/Shoko.Tests/TagFilterTest.cs
@@ -22,7 +22,7 @@ namespace Shoko.Tests
         private static IEnumerable<string> Input =>
             new[]
             {
-                "comedy", "Comedy", "horror", "18 restricted", "large breasts", "japan", "violence", "original work", "manga", "fantasy", "shounen", "earth", "asia", "noitamina", "cgi", "long episodes",
+                "comedy", "Comedy", "horror", "18 restricted", "large breasts", "japan", "violence", "source material", "manga", "fantasy", "shounen", "earth", "asia", "noitamina", "cgi", "long episodes",
                 "first girl wins", "alternative past", "past",
             };
 
@@ -37,31 +37,7 @@ namespace Shoko.Tests
             {
                 "large breasts",
                 "japan",
-                "original work",
-                "manga",
-                "earth",
-                "asia",
-                "noitamina",
-                "cgi",
-                "long episodes",
-                "first girl wins",
-                "alternative past"
-            };
-            
-            _console.WriteLine("Expected: [{0}]", string.Join(", ", expected));
-            _console.WriteLine("Actual: [{0}]", string.Join(", ", actual));
-            Assert.Equal(expected, actual);
-        }
-
-        [Fact(DisplayName = "Full Test w/ 'new'")]
-        public void TestFullListWithNew()
-        {
-            var actual = TagFilter.String.ProcessTags(TagFilter.Filter.Genre, Input.Concat(new[] { "new" }));
-            var expected = new List<string>
-            {
-                "large breasts",
-                "japan",
-                "original work",
+                "source material",
                 "manga",
                 "earth",
                 "asia",
@@ -70,6 +46,32 @@ namespace Shoko.Tests
                 "long episodes",
                 "first girl wins",
                 "alternative past",
+                "past",
+            };
+            
+            _console.WriteLine("Expected: [{0}]", string.Join(", ", expected));
+            _console.WriteLine("Actual: [{0}]", string.Join(", ", actual));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact(DisplayName = "Full Test w/ 'original work'")]
+        public void TestFullListWithNew()
+        {
+            var actual = TagFilter.String.ProcessTags(TagFilter.Filter.Genre, Input.Concat(new[] { "original work" }));
+            var expected = new List<string>
+            {
+                "large breasts",
+                "japan",
+                "source material",
+                "manga",
+                "earth",
+                "asia",
+                "noitamina",
+                "cgi",
+                "long episodes",
+                "first girl wins",
+                "alternative past",
+                "past",
             };
 
             _console.WriteLine("Expected: [{0}]", string.Join(", ", expected));
@@ -115,6 +117,7 @@ namespace Shoko.Tests
                 "fantasy",
                 "shounen",
                 "alternative past",
+                "past",
             };
 
             _console.WriteLine(
@@ -139,6 +142,7 @@ namespace Shoko.Tests
                 "large breasts",
                 "japan",
                 "violence",
+                "source material",
                 "fantasy",
                 "shounen",
                 "earth",
@@ -148,6 +152,7 @@ namespace Shoko.Tests
                 "long episodes",
                 "first girl wins",
                 "alternative past",
+                "past",
             };
 
             _console.WriteLine("Expected: [{0}]", string.Join(", ", expected));
@@ -181,16 +186,10 @@ namespace Shoko.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Fact(DisplayName = "Source Replacement")]
-        public void TestSourceReplacement()
-        {
-            Assert.Equal(new List<string> { "original work" }, TagFilter.String.ProcessTags(TagFilter.Filter.Genre, new[] { "new" }));
-        }
-         
         [Fact(DisplayName = "Source Exclusion")]
         public void TestSource()
         {
-            Assert.Equal(new List<string>(), TagFilter.String.ProcessTags(TagFilter.Filter.Source, new[] { "new" }));
+            Assert.Equal(new List<string>(), TagFilter.String.ProcessTags(TagFilter.Filter.Source, new[] { "original work" }));
         }
 
         [Fact(DisplayName = "Source Exclusion with No Source")]
@@ -220,13 +219,13 @@ namespace Shoko.Tests
         [Fact(DisplayName = "AniDB Internal with Replacement Source")]
         public void TestAniDBInternalWithSource()
         {
-            Assert.Equal(new List<string> { "original work" }, TagFilter.String.ProcessTags(TagFilter.Filter.AnidbInternal, new[] { "new", "original work" }));
+            Assert.Equal(new List<string> { "original work" }, TagFilter.String.ProcessTags(TagFilter.Filter.AnidbInternal, new[] { "source material", "original work" }));
         }
 
         [Fact(DisplayName = "AniDB Internal with Source")]
         public void TestAniDBInternalWithTag()
         {
-            Assert.Equal(new List<string>(), TagFilter.String.ProcessTags(TagFilter.Filter.AnidbInternal | TagFilter.Filter.Source, new[] { "original work", "new" }));
+            Assert.Equal(new List<string>(), TagFilter.String.ProcessTags(TagFilter.Filter.AnidbInternal | TagFilter.Filter.Source, new[] { "source material", "original work" }));
         }
 
         [Fact(DisplayName = "AniDB Internal with Overlapping Source")]

--- a/Shoko.Tests/Shoko.Tests/TagFilterTest.cs
+++ b/Shoko.Tests/Shoko.Tests/TagFilterTest.cs
@@ -22,12 +22,12 @@ namespace Shoko.Tests
         private static IEnumerable<string> Input =>
             new[]
             {
-                "comedy", "Comedy", "horror", "18 restricted", "large breasts", "japan", "violence", "source material", "manga", "fantasy", "shounen", "earth", "asia", "noitamina", "cgi", "long episodes",
+                "comedy", "Comedy", "horror", "18 restricted", "large breasts", "japan", "violence", "source material", "manga", "fantasy", "shounen", "Earth", "Asia", "noitamina", "cgi", "long episodes",
                 "first girl wins", "alternative past", "past",
             };
 
         private static IEnumerable<string> InputNoSource =>
-            new[] { "horror", "Horror", "18 restricted", "large breasts", "japan", "violence", "fantasy", "shounen", "earth", "asia", "noitamina", "cgi", "long episodes", "first girl wins", };
+            new[] { "horror", "Horror", "18 restricted", "large breasts", "japan", "violence", "fantasy", "shounen", "Earth", "Asia", "noitamina", "cgi", "long episodes", "first girl wins", };
 
         [Fact(DisplayName = "Full Test")]
         public void TestFullList()
@@ -39,8 +39,8 @@ namespace Shoko.Tests
                 "japan",
                 "source material",
                 "manga",
-                "earth",
-                "asia",
+                "Earth",
+                "Asia",
                 "noitamina",
                 "cgi",
                 "long episodes",
@@ -64,8 +64,8 @@ namespace Shoko.Tests
                 "japan",
                 "source material",
                 "manga",
-                "earth",
-                "asia",
+                "Earth",
+                "Asia",
                 "noitamina",
                 "cgi",
                 "long episodes",
@@ -87,8 +87,8 @@ namespace Shoko.Tests
             {
                 "large breasts",
                 "japan",
-                "earth",
-                "asia",
+                "Earth",
+                "Asia",
                 "noitamina",
                 "cgi",
                 "long episodes",
@@ -145,8 +145,8 @@ namespace Shoko.Tests
                 "source material",
                 "fantasy",
                 "shounen",
-                "earth",
-                "asia",
+                "Earth",
+                "Asia",
                 "noitamina",
                 "cgi",
                 "long episodes",
@@ -173,8 +173,8 @@ namespace Shoko.Tests
                 "violence",
                 "fantasy",
                 "shounen",
-                "earth",
-                "asia",
+                "Earth",
+                "Asia",
                 "noitamina",
                 "cgi",
                 "long episodes",

--- a/Shoko.Tests/Shoko.Tests/TagFilterTest.cs
+++ b/Shoko.Tests/Shoko.Tests/TagFilterTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -22,12 +21,47 @@ namespace Shoko.Tests
         private static IEnumerable<string> Input =>
             new[]
             {
-                "comedy", "Comedy", "horror", "18 restricted", "large breasts", "japan", "violence", "source material", "manga", "fantasy", "shounen", "Earth", "Asia", "noitamina", "cgi", "long episodes",
-                "first girl wins", "alternative past", "past",
+                "comedy",
+                "Comedy",
+                "horror",
+                "18 restricted",
+                "large breasts",
+                "japan",
+                "violence",
+                "source material",
+                "manga",
+                "fantasy",
+                "shounen",
+                "Earth",
+                "Asia",
+                "noitamina",
+                "cgi",
+                "3DCG",
+                "long episodes",
+                "first girl wins",
+                "alternative past",
+                "past",
             };
 
         private static IEnumerable<string> InputNoSource =>
-            new[] { "horror", "Horror", "18 restricted", "large breasts", "japan", "violence", "fantasy", "shounen", "Earth", "Asia", "noitamina", "cgi", "long episodes", "first girl wins", };
+            new[]
+            {
+                "horror",
+                "Horror",
+                "18 restricted",
+                "large breasts",
+                "japan",
+                "violence",
+                "fantasy",
+                "shounen",
+                "Earth",
+                "Asia",
+                "noitamina",
+                "cgi",
+                "3DCG",
+                "long episodes",
+                "first girl wins",
+            };
 
         [Fact(DisplayName = "Full Test")]
         public void TestFullList()
@@ -43,6 +77,7 @@ namespace Shoko.Tests
                 "Asia",
                 "noitamina",
                 "cgi",
+                "3DCG",
                 "long episodes",
                 "first girl wins",
                 "alternative past",
@@ -68,6 +103,7 @@ namespace Shoko.Tests
                 "Asia",
                 "noitamina",
                 "cgi",
+                "3DCG",
                 "long episodes",
                 "first girl wins",
                 "alternative past",
@@ -91,6 +127,7 @@ namespace Shoko.Tests
                 "Asia",
                 "noitamina",
                 "cgi",
+                "3DCG",
                 "long episodes",
                 "first girl wins",
                 "original work",
@@ -104,7 +141,7 @@ namespace Shoko.Tests
         [Fact(DisplayName = "Full Test Inverted")]
         public void TestFullListInverted()
         {
-            TagFilter.Filter filter = TagFilter.Filter.Invert | TagFilter.Filter.Source | TagFilter.Filter.Genre | TagFilter.Filter.Setting;
+            var filter = TagFilter.Filter.Invert | TagFilter.Filter.Source | TagFilter.Filter.Genre | TagFilter.Filter.Setting;
             var actual = TagFilter.String.ProcessTags(filter, Input);
             var expected = new List<string>
             {
@@ -149,6 +186,7 @@ namespace Shoko.Tests
                 "Asia",
                 "noitamina",
                 "cgi",
+                "3DCG",
                 "long episodes",
                 "first girl wins",
                 "alternative past",
@@ -177,6 +215,7 @@ namespace Shoko.Tests
                 "Asia",
                 "noitamina",
                 "cgi",
+                "3DCG",
                 "long episodes",
                 "first girl wins",
             };
@@ -245,7 +284,7 @@ namespace Shoko.Tests
         {
             Assert.Equal(new List<string>(), TagFilter.String.ProcessTags(TagFilter.Filter.Plot | TagFilter.Filter.Source, new[] { "everybody dies", "first girl wins" }));
         }
-        
+
         [Fact(DisplayName = "Settings Exclusion")]
         public void TestSettings()
         {
@@ -257,7 +296,7 @@ namespace Shoko.Tests
         {
             Assert.Equal(new List<string>(), TagFilter.String.ProcessTags(TagFilter.Filter.Misc | TagFilter.Filter.Source, new[] { "previews suck" }));
         }
-        
+
         [Fact(DisplayName = "AniDB Internal Exclusion")]
         public void TestAniDBInternal()
         {
@@ -273,15 +312,15 @@ namespace Shoko.Tests
                 )
             );
         }
-        
+
         [Fact(DisplayName = "Speed Test (Ideally <600ms on a good CPU)")]
         public void TestSpeed()
         {
-            int count = 4;
-            long[] times = new long[count];
-            for (int i = 0; i < count; i++)
+            const int Count = 4;
+            var times = new long[Count];
+            for (var i = 0; i < Count; i++)
             {
-                Stopwatch stopwatch = Stopwatch.StartNew();
+                var stopwatch = Stopwatch.StartNew();
                 Parallel.ForEach(
                     Enumerable.Range(0, 100000), new ParallelOptions() { MaxDegreeOfParallelism = 2 },
                     _ => TagFilter.String.ProcessTags(TagFilter.Filter.Genre | TagFilter.Filter.AnidbInternal | TagFilter.Filter.Programming | TagFilter.Filter.Misc, Input)


### PR DESCRIPTION
This commit/PR changes some of the data we store about tags, update how we handle tag renaming and exposes some new data in the api. I've tested that it works with a SQLite database, but have not tried for MySQL or SQL Server.

### Changes in this PR

- Updated the Anidb_Tag and Anidb_Anime_Tag tables to better align with the data present in the anime http xml dumps. This is mostly for adding some missing-but-useful information like the verified status of the tag, parent tag id for parsing the tag hierarchy, the last updated timestamp for comparing if we want to update the tag details and to prevent older tag details from overwriting newer details. These changes also involve converting int booleans to booleans in code, moving the local spoiler boolean from the tag to the anime↔tag cross-reference where it belongs, and removes some old and now unused fields from both tables.

- Added a name override for some anidb tags, mainly "original work" → "source material" and "new" → "original work" for now. These overrides are used both internally and externally to be backwards compatible with v1 and v2, but are stored separately in the database so we can still use the source name when updating the tags.

- Tweaked (and simplified) the tag filter. Removed the logic to replace and rename tags, but kept the logic for adding the "original work" tag if no source material tag is set.

- Database migrations and a database fix to fix up the tags after the migration.

- Updated the v1 and v2 api so they only display verified tags, since unverified tags are still pending approval by a moderator on anidb. If a tag later becomes verified then it will be reflected in the apis once we've downloaded an anime http xml dump containing the updated tags.

- Updated the v3 api to only show verified tags by default, but have the ability to also show unverified tags. Also updated the v3 api model to display the new data for the anidb tags.

- Upated the tests for the tag filter.