### PR TITLE
Fix: Ensures temp image moves to valid location

### DIFF
--- a/Shoko.Server/ImageDownload/ImageDownloadRequest.cs
+++ b/Shoko.Server/ImageDownload/ImageDownloadRequest.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.IO;
 using Shoko.Models.Server;
 using Shoko.Server.Extensions;
@@ -114,7 +114,14 @@ public class ImageDownloadRequest
 
                 // Delete the existing file if we're re-downloading.
                 if (File.Exists(FilePath))
+                {
                     File.Delete(FilePath);
+                }
+                // Otherwise ensure that the target directory exists.
+                else
+                {
+                    new FileInfo(FilePath).Directory?.Create();
+                }
 
                 // Move the temp file to it's final destination.
                 File.Move(tempPath, FilePath);

--- a/Shoko.Server/ImageDownload/ImageDownloadRequest.cs
+++ b/Shoko.Server/ImageDownload/ImageDownloadRequest.cs
@@ -108,7 +108,7 @@ public class ImageDownloadRequest
                     fs.Write(bytes, 0, bytes.Length);
 
                 // Make sure the directory structure exists.
-                var dirPath = Path.GetDirectoryName(tempPath);
+                var dirPath = Path.GetDirectoryName(FilePath);
                 if (!string.IsNullOrEmpty(dirPath) && !Directory.Exists(dirPath))
                     Directory.CreateDirectory(dirPath);
 
@@ -116,11 +116,6 @@ public class ImageDownloadRequest
                 if (File.Exists(FilePath))
                 {
                     File.Delete(FilePath);
-                }
-                // Otherwise ensure that the target directory exists.
-                else
-                {
-                    new FileInfo(FilePath).Directory?.Create();
                 }
 
                 // Move the temp file to it's final destination.


### PR DESCRIPTION
Naive fix, but should prevent trace logs like the below from occurring.
```
[2023-01-16 20:40:56:434] Warn|CommandProcessorImages.WorkerCommands_DoWork => CommandRequestImplementation.ProcessCommand => CommandRequest_DownloadImage.Process Error processing CommandRequest_DownloadImage: https://artworks.thetvdb.com/banners/seasons/5cf5825ace9b9.jpg (62) - System.IO.DirectoryNotFoundException: Could not find a part of the path.
   at System.IO.FileSystem.MoveFile(String sourceFullPath, String destFullPath, Boolean overwrite)
   at System.IO.File.Move(String sourceFileName, String destFileName, Boolean overwrite)
   at System.IO.File.Move(String sourceFileName, String destFileName)
   at Shoko.Server.ImageDownload.ImageDownloadRequest.RecursivelyRetryDownload(Int32 count, Int32 maxRetries) in D:\a\ShokoServer\ShokoServer\Shoko.Server\ImageDownload\ImageDownloadRequest.cs:line 120
   at Shoko.Server.ImageDownload.ImageDownloadRequest.DownloadNow(Int32 maxRetries) in D:\a\ShokoServer\ShokoServer\Shoko.Server\ImageDownload\ImageDownloadRequest.cs:line 65
   at Shoko.Server.Commands.CommandRequest_DownloadImage.Process() in D:\a\ShokoServer\ShokoServer\Shoko.Server\Commands\Import\CommandRequest_DownloadImage.cs:line 198```