### PR TITLE
Refactor episode updates

### DIFF
--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -19,7 +19,7 @@ namespace Shoko.Server.Databases;
 public class MySQL : BaseDatabase<MySqlConnection>, IDatabase
 {
     public string Name { get; } = "MySQL";
-    public int RequiredVersion { get; } = 112;
+    public int RequiredVersion { get; } = 113;
 
 
     private List<DatabaseCommand> createVersionTable = new()
@@ -727,6 +727,7 @@ public class MySQL : BaseDatabase<MySqlConnection>, IDatabase
         new(112, 2, "ALTER TABLE AniDB_Anime DROP COLUMN AnimePlanetID;"),
         new(112, 3, "ALTER TABLE AniDB_Anime DROP COLUMN AnimeNfo;"),
         new(112, 4, "ALTER TABLE AniDB_Anime ADD LainID INT NULL"),
+        new(113, 1, DatabaseFixes.FixEpisodeDateTimeUpdated),
     };
 
     private DatabaseCommand linuxTableVersionsFix = new("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -22,7 +22,7 @@ namespace Shoko.Server.Databases;
 public class SQLServer : BaseDatabase<SqlConnection>, IDatabase
 {
     public string Name { get; } = "SQLServer";
-    public int RequiredVersion { get; } = 105;
+    public int RequiredVersion { get; } = 106;
 
     public void BackupDatabase(string fullfilename)
     {
@@ -678,6 +678,7 @@ public class SQLServer : BaseDatabase<SqlConnection>, IDatabase
         new DatabaseCommand(105, 2, "ALTER TABLE AniDB_Anime DROP COLUMN AnimePlanetID;"),
         new DatabaseCommand(105, 3, "ALTER TABLE AniDB_Anime DROP COLUMN AnimeNfo;"),
         new DatabaseCommand(105, 4, "ALTER TABLE AniDB_Anime ADD LainID INT NULL"),
+        new DatabaseCommand(106, 1, DatabaseFixes.FixEpisodeDateTimeUpdated),
     };
 
     private static Tuple<bool, string> DropDefaultsOnAnimeEpisode_User(object connection)

--- a/Shoko.Server/Databases/SQLite.cs
+++ b/Shoko.Server/Databases/SQLite.cs
@@ -22,7 +22,7 @@ public class SQLite : BaseDatabase<SqliteConnection>, IDatabase
 {
     public string Name { get; } = "SQLite";
 
-    public int RequiredVersion { get; } = 98;
+    public int RequiredVersion { get; } = 99;
 
 
     public void BackupDatabase(string fullfilename)
@@ -647,6 +647,7 @@ public class SQLite : BaseDatabase<SqliteConnection>, IDatabase
         new(98, 2, "ALTER TABLE AniDB_Anime DROP COLUMN AnimePlanetID;"),
         new(98, 3, "ALTER TABLE AniDB_Anime DROP COLUMN AnimeNfo;"),
         new(98, 4, "ALTER TABLE AniDB_Anime ADD LainID INT NULL"),
+        new(99, 1, DatabaseFixes.FixEpisodeDateTimeUpdated),
     };
 
     private static Tuple<bool, string> DropLanguage(object connection)

--- a/Shoko.Server/Providers/AniDB/HTTP/GetAnime/ResponseEpisode.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/GetAnime/ResponseEpisode.cs
@@ -23,5 +23,7 @@ public class ResponseEpisode
 
     public DateTime? AirDate { get; set; }
 
+    public DateTime LastUpdated { get; set; }
+
     public List<ResponseTitle> Titles = new();
 }

--- a/Shoko.Server/Providers/AniDB/HTTP/HttpAnimeParser.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/HttpAnimeParser.cs
@@ -342,22 +342,19 @@ public class HttpAnimeParser
 
         decimal.TryParse(TryGetProperty(node, "rating"), style, culture, out var rating);
         int.TryParse(TryGetAttribute(node, "rating", "votes"), out var votes);
+        if (!DateTime.TryParse(TryGetAttribute(node, "update"), out var lastUpdated))
+            lastUpdated = DateTime.UnixEpoch;
 
         var titles = node.ChildNodes.Cast<XmlNode>()
-            .Select(nodeChild => new
+            .Where(nodeChild => Equals("title", nodeChild?.Name))
+            .Select(nodeChild => new ResponseTitle
             {
-                nodeChild,
-                episodeTitle = new ResponseTitle
-                {
-                    Language =
-                        nodeChild?.Attributes?["xml:lang"]?.Value.GetTitleLanguage() ?? TitleLanguage.Unknown,
-                    Title = UnescapeXml(nodeChild?.InnerText.Trim())?.Replace('`', '\''),
-                    TitleType = TitleType.None
-                }
+                Language = nodeChild?.Attributes?["xml:lang"]?.Value.GetTitleLanguage() ?? TitleLanguage.Unknown,
+                Title = UnescapeXml(nodeChild?.InnerText.Trim())?.Replace('`', '\''),
+                TitleType = TitleType.None,
             })
-            .Where(t => Equals("title", t.nodeChild?.Name) && !string.IsNullOrEmpty(t.nodeChild.InnerText) &&
-                        t.episodeTitle.Language != TitleLanguage.Unknown)
-            .Select(t => t.episodeTitle).ToList();
+            .Where(episodeTitle => !string.IsNullOrEmpty(episodeTitle.Title) && episodeTitle.Language != TitleLanguage.Unknown)
+            .ToList();
 
         var dateString = TryGetProperty(node, "airdate");
         var airDate = GetDate(dateString, true);
@@ -374,6 +371,7 @@ public class HttpAnimeParser
             EpisodeID = id,
             AnimeID = animeID,
             AirDate = airDate,
+            LastUpdated = lastUpdated,
             Titles = titles
         };
     }


### PR DESCRIPTION
This refactor is mainly to prevent episodes moving between different series from throwing errors. I changed it so the code tracks when an episode was last updated _at the remote_ (or in the entry stored in the cache), and made it so it conditionally updates the episode record and/or updates the episode title records accordingly.

Also, for the best compatibility with updating existing episode entries did I add a database migration to reset the last updated timestamp on all existing anidb episode records. This won't affect anything other than it will force the episode records to be updated on the first anime refresh/update — be it from the cache or online — after this PR has been merged.