### PR TITLE
Fix: PathEndsWithQuery parsing path as intended

### DIFF
--- a/Shoko.Server/API/v3/Controllers/FileController.cs
+++ b/Shoko.Server/API/v3/Controllers/FileController.cs
@@ -768,7 +768,7 @@ public class FileController : BaseController
     /// <param name="limit">Limit the number of returned results.</param>
     /// <returns>A list of all files with a file location that ends with the given path.</returns>
     [HttpGet("PathEndsWith")]
-    public ActionResult<List<File>> PathEndsWithQuery([FromRoute, FromQuery] string path, [FromQuery] bool includeXRefs = true,
+    public ActionResult<List<File>> PathEndsWithQuery([FromQuery] string path, [FromQuery] bool includeXRefs = true,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<DataSource> includeDataFrom = null,
         [Range(0, 100)] int limit = 0)
         => PathEndsWithInternal(path, includeXRefs, includeDataFrom, limit);


### PR DESCRIPTION
`/api/v3/File/PathEndsWith` was receiving the path as a null paramater when passed as a query rather than path. (Working fine when passed as a path)

I don't fully understand my own change, but I couldn't find any other instances of `[FromRoute, FromQuery]` being used so I tweaked & tested.

This seems to fix the aforementioned issue, at least on my equipment.