### PR TITLE
Adds additional censorship when logging

### DIFF
--- a/Shoko.Server/Settings/SettingsProvider.cs
+++ b/Shoko.Server/Settings/SettingsProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
@@ -359,7 +359,9 @@ public class SettingsProvider : ISettingsProvider
                 value = Serialize(value);
             }
 
-            if (prop.Name.ToLower().EndsWith("password"))
+            if (prop.Name.ToLower().EndsWith("password") ||
+                prop.Name.ToLower().EndsWith("key") ||
+                prop.Name.ToLower().EndsWith("token"))
             {
                 value = "***HIDDEN***";
             }

--- a/Shoko.Server/Settings/SettingsProvider.cs
+++ b/Shoko.Server/Settings/SettingsProvider.cs
@@ -359,13 +359,6 @@ public class SettingsProvider : ISettingsProvider
                 value = Serialize(value);
             }
 
-            if (prop.Name.ToLower().EndsWith("password") ||
-                prop.Name.ToLower().EndsWith("key") ||
-                prop.Name.ToLower().EndsWith("token"))
-            {
-                value = "***HIDDEN***";
-            }
-
             _logger.LogInformation("{Path}.{PropName}: {Value}", path, prop.Name, value);
         }
     }

--- a/Shoko.Server/Utilities/AVDumpHelper.cs
+++ b/Shoko.Server/Utilities/AVDumpHelper.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 using NLog;
 using SharpCompress.Common;
 using SharpCompress.Readers;
@@ -194,7 +195,9 @@ public static class AVDumpHelper
 
             var filenameArgs = GetFilenameAndArgsForOS(file);
 
-            logger.Info($"Dumping File with AVDump: {filenameArgs.Item1} {filenameArgs.Item2}");
+            // Censor the --Auth section for logging, replacing only the password
+            var censoredArgs = Regex.Replace(filenameArgs.Item2, "(--Auth=([^:]+):)([^ ]+)", "$1***HIDDEN***");
+            logger.Info($"Dumping File with AVDump: {filenameArgs.Item1} {censoredArgs}");
 
             var pProcess = new Process
             {

--- a/Shoko.Server/Utilities/AVDumpHelper.cs
+++ b/Shoko.Server/Utilities/AVDumpHelper.cs
@@ -206,7 +206,7 @@ public static class AVDumpHelper
         }
         catch (Exception ex)
         {
-            logger.Error($"An error occurred while AVDumping the file \"file\":\n{ex}");
+            logger.Error($"An error occurred while AVDumping the file \"{file}\":\n{ex}");
             return $"An error occurred while AVDumping the file:\n{ex}";
         }
     }

--- a/Shoko.Server/Utilities/AVDumpHelper.cs
+++ b/Shoko.Server/Utilities/AVDumpHelper.cs
@@ -197,8 +197,7 @@ public static class AVDumpHelper
             // Logs only the last argument to AVDump, the filename
             logger.Info($"Dumping File with AVDump: \"{startInfo.ArgumentList[^1]}\"");
 
-            using var pProcess = new Process();
-            pProcess.StartInfo = startInfo;
+            using var pProcess = new Process { StartInfo = startInfo };
             pProcess.Start();
             var strOutput = pProcess.StandardOutput.ReadToEnd();
             pProcess.WaitForExit();

--- a/Shoko.Server/Utilities/Utils.cs
+++ b/Shoko.Server/Utilities/Utils.cs
@@ -13,6 +13,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
 using NLog.Config;
+using NLog.Filters;
 using NLog.Targets;
 using NLog.Targets.Wrappers;
 using Shoko.Models.Enums;
@@ -101,6 +102,19 @@ public static class Utils
         if (consoleTarget != null)
         {
             consoleTarget.Layout = "${date:format=HH\\:mm\\:ss}| ${logger:shortname=true} --- ${message}";
+        }
+
+        foreach (var loggingRule in LogManager.Configuration.LoggingRules)
+        {
+            if (loggingRule.Targets.Contains(target) || loggingRule.Targets.Contains(consoleTarget) || loggingRule.Targets.Contains(signalrTarget))
+            {
+                loggingRule.FilterDefaultAction = FilterResult.Log;
+                loggingRule.Filters.Add(new ConditionBasedFilter()
+                {
+                    Action = FilterResult.Ignore,
+                    Condition = "(contains(message, 'password') or contains(message, 'token') or contains(message, 'key')) and starts-with(message, 'Settings.')"
+                });
+            }
         }
 
         LogManager.ReconfigExistingLoggers();

--- a/Shoko.Server/nlog.config
+++ b/Shoko.Server/nlog.config
@@ -13,13 +13,7 @@
     <logger name="Shoko.Server.API.Authentication.CustomAuthHandler" maxlevel="Info"
             final="true"/> <!-- Auth log spam (blackhole) -->
 
-    <logger name="*" minlevel="Info" writeTo="file">
-      <filters defaultAction="Log">
-        <when condition="contains(message, 'password') and starts-with(message, 'Settings.')" action="Ignore" />
-        <when condition="contains(message, 'token') and starts-with(message, 'Settings.')" action="Ignore" />
-        <when condition="contains(message, 'key') and starts-with(message, 'Settings.')" action="Ignore" />
-      </filters>
-    </logger>
+    <logger name="*" minlevel="Info" writeTo="file"/>
     <logger name="*" minlevel="Trace" writeTo="console"/>
   </rules>
 </nlog>

--- a/Shoko.Server/nlog.config
+++ b/Shoko.Server/nlog.config
@@ -13,7 +13,13 @@
     <logger name="Shoko.Server.API.Authentication.CustomAuthHandler" maxlevel="Info"
             final="true"/> <!-- Auth log spam (blackhole) -->
 
-    <logger name="*" minlevel="Info" writeTo="file"/>
+    <logger name="*" minlevel="Info" writeTo="file">
+      <filters defaultAction="Log">
+        <when condition="contains(message, 'password') and starts-with(message, 'Settings.')" action="Ignore" />
+        <when condition="contains(message, 'token') and starts-with(message, 'Settings.')" action="Ignore" />
+        <when condition="contains(message, 'key') and starts-with(message, 'Settings.')" action="Ignore" />
+      </filters>
+    </logger>
     <logger name="*" minlevel="Trace" writeTo="console"/>
   </rules>
 </nlog>


### PR DESCRIPTION
The first commit uses regex to avoid logging the auth key when utilising AVDump. As @Cazzar has noted in #support (https://discord.com/channels/96234011612958720/96235819366371328/1079930915054170172), it probably makes more sense to just simply log the filename here instead, however I daren't make such a change myself.

The second commit just additionally censors settings (when dumping) that have names ending in `key` & `token` (rather than just `password`). Admittedly, my inclusion of `token` in this change is a bit of a guess since I don't use Plex nor Trakt, however I'd imagine that users might expect these credentials to be kept secret if sharing the logfile?