### PR TITLE
Fix: Pass Tag (not Version) to GetUrlAndUpdate

### DIFF
--- a/Shoko.Server/API/v3/Controllers/WebUIController.cs
+++ b/Shoko.Server/API/v3/Controllers/WebUIController.cs
@@ -84,7 +84,7 @@ public class WebUIController : BaseController
                 return BadRequest("If trying to update");
         }
 
-        WebUIHelper.GetUrlAndUpdate(LatestWebUIVersion(channel).Version);
+        WebUIHelper.GetUrlAndUpdate(LatestWebUIVersion(channel).Tag);
         return Redirect("/webui/index.html");
     }
 
@@ -99,7 +99,7 @@ public class WebUIController : BaseController
     [HttpGet("Update")]
     public ActionResult UpdateWebUI([FromQuery] ReleaseChannel channel = ReleaseChannel.Stable)
     {
-        WebUIHelper.GetUrlAndUpdate(LatestWebUIVersion(channel).Version);
+        WebUIHelper.GetUrlAndUpdate(LatestWebUIVersion(channel).Tag);
         return NoContent();
     }
 


### PR DESCRIPTION
Tried updating to latest WebUI and was receiving 404's when trying to update.

Did a bit of digging and it looks like `GetUrlAndUpdate` expects the tag name to be passed to it, rather than the version. I've tested my changes and it "works on my machine™".