### PR TITLE
Update Swashbuckle.AspNetCore

### DIFF
--- a/Shoko.Server/Shoko.Server.csproj
+++ b/Shoko.Server/Shoko.Server.csproj
@@ -95,9 +95,9 @@
     <PackageReference Include="Sentry.NLog" Version="3.25.0" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />
     <PackageReference Include="SharpZipLib" Version="1.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.2.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
     <!-- This needs to be explicit because of dep BS -->
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />


### PR DESCRIPTION
Fixes vulnerability: https://github.com/advisories/GHSA-qrmm-w75w-3wpx
Swagger tested to be still working with 6.5.0