### PR TITLE
Allows swagger authorisation to persist across sessions

### DIFF
--- a/Shoko.Server/API/APIExtensions.cs
+++ b/Shoko.Server/API/APIExtensions.cs
@@ -258,6 +258,7 @@ public static class APIExtensions
                     options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json",
                         description.GroupName.ToUpperInvariant());
                 }
+                options.EnablePersistAuthorization();
             });
         // Important for first run at least
         app.UseAuthentication();


### PR DESCRIPTION
A blissfully simple change as per this [documentation](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#:~:text=persistAuthorization).

This could also have been utilised at any point by adding `persistAuthorization=true` as a search parameter 🙃

Tested the change and it works on my machine™