### PR TITLE
Update Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN unzip -o latest.zip
 RUN rm latest.zip
 
 VOLUME /home/shoko/.shoko/
-VOLUME /usr/src/app/build/webui
 
 HEALTHCHECK --start-period=5m CMD curl -H "Content-Type: application/json" -H 'Accept: application/json' 'http://localhost:8111/v1/Server' || exit 1
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -40,7 +40,6 @@ RUN unzip -o latest.zip
 RUN rm latest.zip
 
 VOLUME /home/shoko/.shoko/
-VOLUME /usr/src/app/build/webui
 
 HEALTHCHECK --start-period=5m CMD curl -H "Content-Type: application/json" -H 'Accept: application/json' 'http://localhost:8111/v1/Server' || exit 1
 


### PR DESCRIPTION
Remove obsolete webui volume as it's in the already exported home directory - if I'm not wrong.

This should solve:

- QNAP Container Station keeps bugging to map it to a volume or share
- Portainer creating an empty volume