### PR TITLE
Fix AniDB languages not being updated properly

### DIFF
--- a/Shoko.Server/Providers/AniDB/UDP/Info/RequestGetFile.cs
+++ b/Shoko.Server/Providers/AniDB/UDP/Info/RequestGetFile.cs
@@ -222,10 +222,10 @@ public class RequestGetFile : UDPRequest<ResponseGetFile>
                     }
 
                     // audio languages
-                    var alangs = parts[10].Split(new[] { '\'' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+                    var alangs = parts[10].Split(new[] { '\'' }, StringSplitOptions.RemoveEmptyEntries).Where(lang => lang != "none").ToList();
 
                     // sub languages
-                    var slangs = parts[11].Split(new[] { '\'' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+                    var slangs = parts[11].Split(new[] { '\'' }, StringSplitOptions.RemoveEmptyEntries).Where(lang => lang != "none").ToList();
 
                     // mylist
                     var myList = ParseMyList(parts);


### PR DESCRIPTION
Noticed this while testing my renamer, when a file has either no dub or no sub AniDB returns "none" in the UDP response for the track languages. This is being incorrectly saved to the DB and will return as "Unknown" in the renamer interface. Fixed by ignoring "none" and returning an empty list.

The languages pulled fron AniDB were not syncing with the DB correctly when using update file info. CreateLanguages in CommandRequest_GetFile.cs did not create a transaction and commit it. Observed duplicate language entries being created, and none deleted upon multiple updates.

The condition for updating the languages was if the returned count of languages from AniDB was > 0, changed to only check if the response was null, tracks can be deleted on AniDB and should be deleted in DB.