### PR TITLE
Update APIExtensions.cs

### DIFF
--- a/Shoko.Server/API/APIExtensions.cs
+++ b/Shoko.Server/API/APIExtensions.cs
@@ -116,7 +116,7 @@ public static class APIExtensions
                 options.MapType<SeriesType>(() => new OpenApiSchema { Type = "string" });
                 options.MapType<EpisodeType>(() => new OpenApiSchema { Type = "string" });
 
-                options.CustomSchemaIds(x => x.FullName.Replace("+", "."));
+                options.CustomSchemaIds(x => x.ToString().Replace("+", "."));
             });
         services.AddSwaggerGenNewtonsoftSupport();
         services.AddSignalR(o => { o.EnableDetailedErrors = true; });


### PR DESCRIPTION
Get rid of assembly information in schema names for generic types in swagger (as in https://stackoverflow.com/a/56278259)

for example it shortens this:

Shoko.Models.FileQualityPreferences.FileQualityTypeListPair`1[[System.Collections.Generic.List`1[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]

to this:

Shoko.Models.FileQualityPreferences.FileQualityTypeListPair`1[System.Collections.Generic.List`1[System.String]]
