### PR TITLE
Resolves searches returning null

### DIFF
--- a/Shoko.Server/Utilities/SeriesSearch.cs
+++ b/Shoko.Server/Utilities/SeriesSearch.cs
@@ -125,14 +125,14 @@ public static class SeriesSearch
                     if (fuzzy)
                     {
                         var result = DiceFuzzySearch(title, search, t);
-                        if (result.Index == -1 || result.Distance > (current?.Distance ?? int.MaxValue))
+                        if (result.Index == -1 || result.Distance >= (current?.Distance ?? int.MaxValue))
                             return current;
 
                         return result;
                     }
 
                     var index = title.IndexOf(search, StringComparison.OrdinalIgnoreCase);
-                    if (index == -1 || index > (current?.Index ?? int.MaxValue))
+                   if (index == -1 || index >= (current?.Index ?? int.MaxValue))
                         return current;
 
                     return new()

--- a/Shoko.Server/Utilities/SeriesSearch.cs
+++ b/Shoko.Server/Utilities/SeriesSearch.cs
@@ -125,14 +125,14 @@ public static class SeriesSearch
                     if (fuzzy)
                     {
                         var result = DiceFuzzySearch(title, search, t);
-                        if (result.Index == -1 || result.Distance < (current?.Distance ?? int.MaxValue))
+                        if (result.Index == -1 || result.Distance > (current?.Distance ?? int.MaxValue))
                             return current;
 
                         return result;
                     }
 
                     var index = title.IndexOf(search, StringComparison.OrdinalIgnoreCase);
-                    if (index == -1 || index < (current?.Index ?? int.MaxValue))
+                    if (index == -1 || index > (current?.Index ?? int.MaxValue))
                         return current;
 
                     return new()


### PR DESCRIPTION
I've tested these changes using the `/api/v3/Series/AniDB/Search` endpoint and it seems to get things working.

Given that the initial values for `current.Distance` & `current.Index` were always null-coalesced to `int.MaxValue`, `result.Distance` & `index` would always be less and as such the initial `null` value was always returned as the search result.