### PR TITLE
Handle "HTTP 400 and 410" for Trakt Auth correctly...

### DIFF
--- a/Shoko.Server/Providers/TraktTV/TraktConstants.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktConstants.cs
@@ -80,6 +80,7 @@ public static class TraktStatusCodes
     public const int Success = 200;
     public const int Success_Post = 201;
     public const int Success_Delete = 204;
+    public const int Awaiting_Auth = 400;
 
     public const int Bad_Request = 400;
     public const int Unauthorized = 401;

--- a/Shoko.Server/Providers/TraktTV/TraktConstants.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktConstants.cs
@@ -6,7 +6,6 @@ public static class TraktConstants
 
     // Production
     public const string ClientID = "a20707fa9666bea4acd86bc6ea2123bd6ffdbe996b4927cfdba96f4d3fca3042";
-
     public const string ClientSecret = "7ef5eec766070fa0b34a4a4a2fea2ad0ddbe9bb1bc1e8eb621551c52fb288739";
     public const string BaseAPIURL = @"https://api.trakt.tv";
     public const string BaseWebsiteURL = @"https://trakt.tv";
@@ -24,7 +23,6 @@ public static class TraktSearchType
 {
     // movie , show , episode , person , list 
     public const string movie = "movie";
-
     public const string show = "show";
     public const string episode = "episode";
     public const string person = "person";
@@ -36,7 +34,6 @@ public static class TraktSearchIDType
 {
     // movie , show , episode , person , list 
     public const string traktmovie = "trakt-movie";
-
     public const string traktshow = "trakt-show";
     public const string traktepisode = "trakt-episode";
     public const string imdb = "imdb";

--- a/Shoko.Server/Providers/TraktTV/TraktConstants.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktConstants.cs
@@ -78,6 +78,7 @@ public static class TraktStatusCodes
     public const int Success_Post = 201;
     public const int Success_Delete = 204;
     public const int Awaiting_Auth = 400;
+    public const int Token_Expired = 410;
 
     public const int Bad_Request = 400;
     public const int Unauthorized = 401;

--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -108,7 +108,7 @@ public class TraktTVHelper
             if (webEx.Status == WebExceptionStatus.ProtocolError)
             {
                 if (webEx.Response is HttpWebResponse response)
-                    if (!response.ResponseUri.AbsoluteUri.Contains("device/token") && response.StatusCode == HttpStatusCode.BadRequest) {
+                    if (response.ResponseUri.AbsoluteUri != TraktURIs.OAuthDeviceToken && response.StatusCode == HttpStatusCode.BadRequest) {
                         {
                             _logger.LogError(webEx, "Error in SendData: {StatusCode}", (int)response.StatusCode);
                             ret = (int)response.StatusCode;
@@ -131,7 +131,7 @@ public class TraktTVHelper
                         }
                     }
             }
-            if (webEx.Response != null && !webEx.Response.ResponseUri.AbsoluteUri.Contains("device/token"))
+            if (webEx.Response != null && webEx.Response.ResponseUri.AbsoluteUri != TraktURIs.OAuthDeviceToken)
             {
                 _logger.LogError(webEx, "{Ex}", webEx.ToString());
             }
@@ -337,7 +337,7 @@ public class TraktTVHelper
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error in TraktTVHelper.GetTraktDeviceCode");
-                throw;
+            throw;
         }
     }
 

--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Sentry;
+using NHibernate;
 using Shoko.Commons.Extensions;
 using Shoko.Models.Client;
 using Shoko.Models.Enums;
@@ -20,7 +20,6 @@ using Shoko.Server.Providers.TraktTV.Contracts;
 using Shoko.Server.Repositories;
 using Shoko.Server.Settings;
 using Shoko.Server.Utilities;
-using ISession = NHibernate.ISession;
 
 namespace Shoko.Server.Providers.TraktTV;
 

--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using NHibernate;
 using Sentry;
 using Shoko.Commons.Extensions;
 using Shoko.Models.Client;
@@ -21,6 +20,7 @@ using Shoko.Server.Providers.TraktTV.Contracts;
 using Shoko.Server.Repositories;
 using Shoko.Server.Settings;
 using Shoko.Server.Utilities;
+using ISession = NHibernate.ISession;
 
 namespace Shoko.Server.Providers.TraktTV;
 

--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -140,6 +140,105 @@ public class TraktTVHelper
 
         return ret;
     }
+    
+    // We need SendDataAuth separately to catch HTTP 400 because it's "pending auth", not an actual error
+     private int SendDataAuth(string uri, string json, string verb, Dictionary<string, string> headers,
+        ref string webResponse)
+    {
+        var ret = 400;
+
+        try
+        {
+            var data = new UTF8Encoding().GetBytes(json);
+            _logger.LogTrace("Trakt SEND AUTH Data\\nVerb: {Verb}\\nuri: {Uri}\\njson: {Json}", verb, uri, json);
+
+            var request = (HttpWebRequest)WebRequest.Create(uri);
+            request.KeepAlive = true;
+
+            request.Method = verb;
+            request.ContentLength = data.Length;
+            request.Timeout = 120000;
+            request.ContentType = "application/json";
+            request.UserAgent = "JMM";
+            foreach (var header in headers)
+            {
+                request.Headers.Add(header.Key, header.Value);
+            }
+
+            // post to trakt
+            var postStream = request.GetRequestStream();
+            postStream.Write(data, 0, data.Length);
+
+            // get the response
+            var response = (HttpWebResponse)request.GetResponse();
+
+            var responseStream = response.GetResponseStream();
+            if (responseStream == null)
+            {
+                return ret;
+            }
+
+            var reader = new StreamReader(responseStream);
+            var strResponse = reader.ReadToEnd();
+
+            var statusCode = (int)response.StatusCode;
+
+            // cleanup
+            postStream.Close();
+            responseStream.Close();
+            reader.Close();
+            response.Close();
+
+            webResponse = strResponse;
+            _logger.LogTrace("Trakt SEND AUTH Data - Response\nStatus Code:{ StatusCode}\nResponse: {Response}", statusCode,
+                strResponse);
+
+            return statusCode;
+        }
+        catch (WebException webEx)
+        {
+            if (webEx.Status == WebExceptionStatus.ProtocolError)
+            {
+                if (webEx.Response is HttpWebResponse response && response.StatusCode != HttpStatusCode.BadRequest)
+                {
+                    _logger.LogError(webEx, "Error in SendDataAuth: {StatusCode}", (int)response.StatusCode);
+                    ret = (int)response.StatusCode;
+
+                    try
+                    {
+                        var responseStream2 = response.GetResponseStream();
+                        if (responseStream2 == null)
+                        {
+                            return ret;
+                        }
+
+                        var reader2 = new StreamReader(responseStream2);
+                        webResponse = reader2.ReadToEnd();
+                        _logger.LogError("Error in SendDataAuth: {Response}", webResponse);
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                }
+            }
+            
+            if (!webEx.Message.Contains("400"))
+            {
+                _logger.LogError(webEx, "{Ex}", webEx.ToString());
+            }
+        }
+        catch (Exception ex)
+        {
+            if (ex.Message.Contains("400"))
+            {
+                _logger.LogInformation(ex, "Authorization for Shoko still pending, please enter the code displayed by clicking the link");
+            }
+            _logger.LogError(ex, "Error in SendDataAuth");
+        }
+
+        return ret;
+    }
 
     private string GetFromTrakt(string uri)
     {
@@ -245,8 +344,8 @@ public class TraktTVHelper
 
             var retData = string.Empty;
             TraktTVRateLimiter.Instance.EnsureRate();
-            var response = SendData(TraktURIs.Oauth, json, "POST", headers, ref retData);
-            if (response is TraktStatusCodes.Success or TraktStatusCodes.Success_Post)
+            var response = SendDataAuth(TraktURIs.Oauth, json, "POST", headers, ref retData);
+            if (response is TraktStatusCodes.Success or TraktStatusCodes.Success_Post or TraktStatusCodes.Awaiting_Auth)
             {
                 var loginResponse = retData.FromJSON<TraktAuthToken>();
 
@@ -319,8 +418,9 @@ public class TraktTVHelper
 
             var retData = string.Empty;
             TraktTVRateLimiter.Instance.EnsureRate();
-            var response = SendData(TraktURIs.OAuthDeviceCode, json, "POST", headers, ref retData);
-            if (response != TraktStatusCodes.Success && response != TraktStatusCodes.Success_Post)
+            var response = SendDataAuth(TraktURIs.OAuthDeviceCode, json, "POST", headers, ref retData);
+            // We need to catch HTTP "400" here, as it's not "bad request" but "awaiting authorization" from the API definition
+            if (response != TraktStatusCodes.Success && response != TraktStatusCodes.Success_Post && response != TraktStatusCodes.Awaiting_Auth)
             {
                 throw new Exception($"Error returned from Trakt: {response}");
             }
@@ -333,8 +433,13 @@ public class TraktTVHelper
         }
         catch (Exception ex)
         {
+            if (ex.Message.Contains("400"))
+            {
+                // Signaling the user that auth is still pending
+                _logger.LogInformation(ex, "Authorization for Shoko pending, please enter the code displayed by clicking the link");
+            }
             _logger.LogError(ex, "Error in TraktTVHelper.GetTraktDeviceCode");
-            throw;
+                throw;
         }
     }
 
@@ -368,7 +473,7 @@ public class TraktTVHelper
 
                 var retData = string.Empty;
                 TraktTVRateLimiter.Instance.EnsureRate();
-                var response = SendData(TraktURIs.OAuthDeviceToken, json, "POST", headers, ref retData);
+                var response = SendDataAuth(TraktURIs.OAuthDeviceToken, json, "POST", headers, ref retData);
                 if (response == TraktStatusCodes.Success)
                 {
                     var settings = _settingsProvider.GetSettings();
@@ -391,7 +496,13 @@ public class TraktTVHelper
                     Thread.Sleep(TimeSpan.FromSeconds(1));
                 }
 
-                if (response != TraktStatusCodes.Bad_Request && response != TraktStatusCodes.Rate_Limit_Exceeded)
+                if (response == TraktStatusCodes.Awaiting_Auth)
+                {
+                    // Signaling the user that auth is still pending
+                    _logger.LogInformation (response, "Authorization for Shoko pending, please enter the code displayed by clicking the link");
+                }
+
+                if (response != TraktStatusCodes.Awaiting_Auth && response != TraktStatusCodes.Rate_Limit_Exceeded)
                 {
                     throw new Exception($"Error returned from Trakt: {response}");
                 }

--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -342,6 +342,13 @@ public class TraktTVHelper
                 // Signaling the user that auth is still pending
                 _logger.LogInformation(ex, "Authorization for Shoko pending, please enter the code displayed by clicking the link");
             }
+
+            if (ex.Message.Contains("Expired"))
+            {
+                // Signaling the user that Token has expired and he needs to restart
+                _logger.LogInformation(ex, "Trakt token has expired, please restart the pairing process");
+            }
+            
             _logger.LogError(ex, "Error in TraktTVHelper.GetTraktDeviceCode");
                 throw;
         }


### PR DESCRIPTION
...to actually show a correct message instead of throwing an exception.

According to the API, it means: "400 Pending - waiting for the user to authorize your app"
So error 400 keeps showing until Trakt is correctly authorized/linked and approved using the displayed code.

Created a new helper SendDataAuth which handles HTTP 400 differently from other SendData and also made changes to show the correct messages in Shoko logs.

closes #1062 