### PR TITLE
Fix image validation for TVDB episode images

### DIFF
--- a/Shoko.Server/Commands/Import/CommandRequest_ValidateAllImages.cs
+++ b/Shoko.Server/Commands/Import/CommandRequest_ValidateAllImages.cs
@@ -50,7 +50,7 @@ public class CommandRequest_ValidateAllImages : CommandRequestImplementation
         UpdateProgress(Resources.Command_ValidateAllImages_TvDBEpisodes);
         Logger.LogInformation(ScanForType, "TvDB episodes");
         var episodes = RepoFactory.TvDB_Episode.GetAll()
-            .Where(episode => Misc.IsImageValid(episode.GetFullImagePath()))
+            .Where(episode => !Misc.IsImageValid(episode.GetFullImagePath()))
             .ToList();
 
         Logger.LogInformation(FoundCorruptedOfType, episodes.Count, episodes.Count == 1 ? "TvDB episode thumbnail" : "TvDB episode thumbnails");


### PR DESCRIPTION
Valid images were being deleted and redownloaded instead of invalid images.