### PR TITLE
Fix: Emit the actual duration of an AniDB ban

### DIFF
--- a/Shoko.Server/API/SignalR/Aggregate/AniDBEmitter.cs
+++ b/Shoko.Server/API/SignalR/Aggregate/AniDBEmitter.cs
@@ -44,14 +44,14 @@ public class AniDBEmitter : BaseEmitter, IDisposable
                 UpdateType = UpdateType.UDPBan,
                 UpdateTime = UDPHandler.BanTime ?? DateTime.Now,
                 Value = UDPHandler.IsBanned,
-                PauseTimeSecs = TimeSpan.FromHours(UDPHandler.BanTimerResetLength).Seconds
+                PauseTimeSecs = (int)TimeSpan.FromHours(UDPHandler.BanTimerResetLength).TotalSeconds
             },
             new()
             {
                 UpdateType = UpdateType.HTTPBan,
                 UpdateTime = HttpHandler.BanTime ?? DateTime.Now,
                 Value = HttpHandler.IsBanned,
-                PauseTimeSecs = TimeSpan.FromHours(HttpHandler.BanTimerResetLength).Seconds
+                PauseTimeSecs = (int)TimeSpan.FromHours(HttpHandler.BanTimerResetLength).TotalSeconds
             }
         };
     }


### PR DESCRIPTION
Apparently, only the seconds component of the ban duration was emitted, rather than the total duration in seconds... I was a little confused when the value was always returning `0`!

This looks to get things working as expected on my end (including in the current WebUI), but I'm not too sure if changing this might cause any issues elsewhere...