### PR TITLE
Split the anidb address & port settings for HTTP and UDP

### DIFF
--- a/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation.cs
+++ b/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation.cs
@@ -625,8 +625,8 @@ public partial class ShokoServiceImplementation : Controller, IShokoServer
 
                 Thread.Sleep(1000);
                 handler.Init(settings.AniDb.Username, settings.AniDb.Password,
-                    settings.AniDb.ServerAddress,
-                    settings.AniDb.ServerPort, settings.AniDb.ClientPort);
+                    settings.AniDb.UDPServerAddress,
+                    settings.AniDb.UDPServerPort, settings.AniDb.ClientPort);
             }
         }
         catch (Exception ex)
@@ -785,8 +785,8 @@ public partial class ShokoServiceImplementation : Controller, IShokoServer
             log += "Init..." + Environment.NewLine;
             var settings = _settingsProvider.GetSettings();
             handler.Init(settings.AniDb.Username, settings.AniDb.Password,
-                settings.AniDb.ServerAddress,
-                settings.AniDb.ServerPort, settings.AniDb.ClientPort);
+                settings.AniDb.UDPServerAddress,
+                settings.AniDb.UDPServerPort, settings.AniDb.ClientPort);
 
             log += "Login..." + Environment.NewLine;
             if (handler.Login().Result)

--- a/Shoko.Server/API/v2/Modules/Core.cs
+++ b/Shoko.Server/API/v2/Modules/Core.cs
@@ -210,8 +210,8 @@ public class Core : BaseController
         await handler.CloseConnections();
 
         await handler.Init(_settings.AniDb.Username, _settings.AniDb.Password,
-            _settings.AniDb.ServerAddress,
-            _settings.AniDb.ServerPort, _settings.AniDb.ClientPort);
+            _settings.AniDb.UDPServerAddress,
+            _settings.AniDb.UDPServerPort, _settings.AniDb.ClientPort);
 
         if (await handler.Login())
         {

--- a/Shoko.Server/API/v2/Modules/Init.cs
+++ b/Shoko.Server/API/v2/Modules/Init.cs
@@ -283,8 +283,8 @@ public class Init : BaseController
         Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(_settings.Culture);
 
         await handler.Init(_settings.AniDb.Username, _settings.AniDb.Password,
-            _settings.AniDb.ServerAddress,
-            _settings.AniDb.ServerPort, _settings.AniDb.ClientPort);
+            _settings.AniDb.UDPServerAddress,
+            _settings.AniDb.UDPServerPort, _settings.AniDb.ClientPort);
 
         if (!await handler.Login()) return APIStatus.BadRequest("Failed to log in");
         handler.ForceLogout();

--- a/Shoko.Server/API/v3/Controllers/SettingsController.cs
+++ b/Shoko.Server/API/v3/Controllers/SettingsController.cs
@@ -87,7 +87,7 @@ public class SettingsController : BaseController
         var alive = handler.IsAlive;
         var settings = SettingsProvider.GetSettings();
         if (!alive)
-            await handler.Init(credentials.Username, credentials.Password, settings.AniDb.ServerAddress, settings.AniDb.ServerPort, settings.AniDb.ClientPort);
+            await handler.Init(credentials.Username, credentials.Password, settings.AniDb.UDPServerAddress, settings.AniDb.UDPServerPort, settings.AniDb.ClientPort);
         else handler.ForceLogout();
 
         if (!await handler.TestLogin(credentials.Username, credentials.Password))

--- a/Shoko.Server/Providers/AniDB/HTTP/RequestGetAnime.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/RequestGetAnime.cs
@@ -27,7 +27,7 @@ public class RequestGetAnime : HttpRequest<ResponseGetAnime>
         _parser = parser;
         var settings = settingsProvider.GetSettings().AniDb;
         _aniDBUrl = settings.ServerAddress;
-        _aniDBPort = (ushort)(settings.ServerPort + 1);
+        _aniDBPort = settings.ServerPort;
     }
 
     /// <summary>

--- a/Shoko.Server/Providers/AniDB/HTTP/RequestMyList.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/RequestMyList.cs
@@ -86,6 +86,6 @@ public class RequestMyList : HttpRequest<List<ResponseMyList>>
     {
         var settings = settingsProvider.GetSettings().AniDb;
         _aniDBUrl = settings.ServerAddress;
-        _aniDBPort = (ushort)(settings.ServerPort + 1);
+        _aniDBPort = settings.ServerPort;
     }
 }

--- a/Shoko.Server/Providers/AniDB/HTTP/RequestVotes.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/RequestVotes.cs
@@ -116,6 +116,6 @@ public class RequestVotes : HttpRequest<List<ResponseVote>>
     {
         var settings = settingsProvider.GetSettings().AniDb;
         _aniDBUrl = settings.ServerAddress;
-        _aniDBPort = (ushort)(settings.ServerPort + 1);
+        _aniDBPort = settings.ServerPort;
     }
 }

--- a/Shoko.Server/Providers/AniDB/UDP/AniDBUDPConnectionHandler.cs
+++ b/Shoko.Server/Providers/AniDB/UDP/AniDBUDPConnectionHandler.cs
@@ -94,8 +94,8 @@ public class AniDBUDPConnectionHandler : ConnectionHandler, IUDPConnectionHandle
     public async Task<bool> Init(string username, string password, string serverName, ushort serverPort, ushort clientPort)
     {
         var settings = SettingsProvider.GetSettings();
-        settings.AniDb.ServerAddress = serverName;
-        settings.AniDb.ServerPort = serverPort;
+        settings.AniDb.UDPServerAddress = serverName;
+        settings.AniDb.UDPServerPort = serverPort;
         settings.AniDb.ClientPort = clientPort;
 
         if (!ValidAniDBCredentials(username, password)) return false;
@@ -114,10 +114,10 @@ public class AniDBUDPConnectionHandler : ConnectionHandler, IUDPConnectionHandle
         }
 
         var settings = SettingsProvider.GetSettings();
-        ArgumentNullException.ThrowIfNull(settings.AniDb?.ServerAddress);
-        if (settings.AniDb.ServerPort <= 0) throw new ArgumentException("AniDB Server Port is invalid");
+        ArgumentNullException.ThrowIfNull(settings.AniDb?.UDPServerAddress);
+        if (settings.AniDb.UDPServerPort <= 0) throw new ArgumentException("AniDB Server Port is invalid");
         if (settings.AniDb.ClientPort <= 0) throw new ArgumentException("AniDB Client Port is invalid");
-        _socketHandler = new AniDBSocketHandler(_loggerFactory, settings.AniDb.ServerAddress, settings.AniDb.ServerPort,
+        _socketHandler = new AniDBSocketHandler(_loggerFactory, settings.AniDb.UDPServerAddress, settings.AniDb.UDPServerPort,
             settings.AniDb.ClientPort);
         _isLoggedOn = false;
 

--- a/Shoko.Server/Settings/AniDbSettings.cs
+++ b/Shoko.Server/Settings/AniDbSettings.cs
@@ -14,7 +14,11 @@ public class AniDbSettings
     [Required(AllowEmptyStrings = false)]
     public string ServerAddress { get; set; } = "api.anidb.net";
 
-    public ushort ServerPort { get; set; } = 9000;
+    public string UDPServerAddress { get; set; } = "api.anidb.net";
+
+    public ushort ServerPort { get; set; } = 9001;
+
+    public ushort UDPServerPort { get; set; } = 9000;
 
     public ushort ClientPort { get; set; } = 4556;
 

--- a/Shoko.Server/Settings/SettingsMigrations.cs
+++ b/Shoko.Server/Settings/SettingsMigrations.cs
@@ -7,7 +7,7 @@ namespace Shoko.Server.Settings;
 
 public static class SettingsMigrations
 {
-    public const int Version = 5;
+    public const int Version = 6;
 
     /// <summary>
     /// Perform migrations on the settings json, pre-init
@@ -38,7 +38,8 @@ public static class SettingsMigrations
         { 2, MigrateEpisodeLanguagePreference },
         { 3, MigrateAutoGroupRelations },
         { 4, MigrateHostnameToHost },
-        { 5, MigrateAutoGroupRelationsAlternateToAlternative }
+        { 5, MigrateAutoGroupRelationsAlternateToAlternative },
+        { 6, MigrateServerPorts }
     };
 
     private static string MigrateTvDBLanguageEnum(string settings)
@@ -86,5 +87,15 @@ public static class SettingsMigrations
     {
         var regex = new Regex(@"(?<=""AutoGroupSeriesRelationExclusions""\s*:\s*\[)(?<value>[^\]]+)", RegexOptions.Compiled);
         return regex.Replace(settings, match => match.Groups["value"].Value.Replace("alternate", "alternative", StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    private static string MigrateServerPorts(string settings)
+    {
+        var regex = new Regex(@"(?<=""AniDb""\s*:\s*\{.*""ServerPort""\s*:\s*)\d+", RegexOptions.Compiled | RegexOptions.Singleline);
+        return regex.Replace(settings, match =>
+        {
+            var currentServerPort = int.Parse(match.ToString());
+            return $"{currentServerPort + 1},\"UDPServerPort\": {currentServerPort}";
+        });
     }
 }

--- a/Shoko.Server/Settings/SettingsMigrations.cs
+++ b/Shoko.Server/Settings/SettingsMigrations.cs
@@ -39,7 +39,7 @@ public static class SettingsMigrations
         { 3, MigrateAutoGroupRelations },
         { 4, MigrateHostnameToHost },
         { 5, MigrateAutoGroupRelationsAlternateToAlternative },
-        { 6, MigrateServerPorts }
+        { 6, MigrateAniDBServerPorts }
     };
 
     private static string MigrateTvDBLanguageEnum(string settings)
@@ -89,7 +89,7 @@ public static class SettingsMigrations
         return regex.Replace(settings, match => match.Groups["value"].Value.Replace("alternate", "alternative", StringComparison.InvariantCultureIgnoreCase));
     }
 
-    private static string MigrateServerPorts(string settings)
+    private static string MigrateAniDBServerPorts(string settings)
     {
         var regex = new Regex(@"(?<=""AniDb""\s*:\s*\{.*""ServerPort""\s*:\s*)\d+", RegexOptions.Compiled | RegexOptions.Singleline);
         return regex.Replace(settings, match =>


### PR DESCRIPTION
As per the discussion in #support. To have the ability to use a different address for the HTTP API

- Moved UDP address and port settings into a separate property.
- Desktop will only be able to view and edit the HTTP address and port settings