### PR TITLE
Split the anidb address & port settings for HTTP and UDP

### DIFF
--- a/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation.cs
+++ b/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation.cs
@@ -479,9 +479,9 @@ public partial class ShokoServiceImplementation : Controller, IShokoServer
                 }
             }
 
-            var serverAddressMatches = Regex.Match(settings.AniDb.HTTPServerUrl, @"(?<=https?://)(?<address>.*):(?<port>\d+)");
-            var oldAniDB_ServerAddress = serverAddressMatches.Groups["address"].Value;
-            var oldAniDB_ServerPort = serverAddressMatches.Groups["port"].Value;
+            var serverAddressGroups = Regex.Match(settings.AniDb.HTTPServerUrl, @"(?<=https?://)(?<address>.*):(?<port>\d+)").Groups;
+            var oldAniDB_ServerAddress = serverAddressGroups["address"].Value;
+            var oldAniDB_ServerPort = serverAddressGroups["port"].Value;
             var newAniDB_HTTPServerUrl = $"{contractIn.AniDB_ServerAddress}:{contractIn.AniDB_ServerPort}";
 
             if (contractIn.AniDB_ServerAddress != oldAniDB_ServerAddress || contractIn.AniDB_ServerPort != oldAniDB_ServerPort)

--- a/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation.cs
+++ b/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation.cs
@@ -51,6 +51,8 @@ public partial class ShokoServiceImplementation : Controller, IShokoServer
     private readonly ISchedulerFactory _schedulerFactory;
     private readonly ActionService _actionService;
 
+    private readonly Regex _urlRegex = new Regex(@"(?<=https?://)(?<address>.*):(?<port>\d+)", RegexOptions.Compiled);
+
     public ShokoServiceImplementation(TvDBApiHelper tvdbHelper, TraktTVHelper traktHelper, MovieDBHelper movieDBHelper, ISchedulerFactory schedulerFactory, ISettingsProvider settingsProvider, ILogger<ShokoServiceImplementation> logger, ActionService actionService, AnimeGroupCreator groupCreator, JobFactory jobFactory)
     {
         _tvdbHelper = tvdbHelper;
@@ -479,7 +481,7 @@ public partial class ShokoServiceImplementation : Controller, IShokoServer
                 }
             }
 
-            var serverAddressGroups = Regex.Match(settings.AniDb.HTTPServerUrl, @"(?<=https?://)(?<address>.*):(?<port>\d+)").Groups;
+            var serverAddressGroups = _urlRegex.Match(settings.AniDb.HTTPServerUrl).Groups;
             var oldAniDB_ServerAddress = serverAddressGroups["address"].Value;
             var oldAniDB_ServerPort = serverAddressGroups["port"].Value;
             var newAniDB_HTTPServerUrl = $"{contractIn.AniDB_ServerAddress}:{contractIn.AniDB_ServerPort}";

--- a/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation.cs
+++ b/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation/ShokoServiceImplementation.cs
@@ -501,7 +501,8 @@ public partial class ShokoServiceImplementation : Controller, IShokoServer
                                              Environment.NewLine;
                 }
 
-                if (!Regex.IsMatch(newAniDB_HTTPServerUrl, @"https?://.*"))
+                // This can be a single condition with StartsWith("http"), but there's an edge case of someone having "http.example.org"
+                if (!newAniDB_HTTPServerUrl.StartsWith("http://") && !newAniDB_HTTPServerUrl.StartsWith("https://"))
                 {
                     newAniDB_HTTPServerUrl = $"http://{newAniDB_HTTPServerUrl}";
                 }

--- a/Shoko.Server/API/v2/Modules/Core.cs
+++ b/Shoko.Server/API/v2/Modules/Core.cs
@@ -210,8 +210,8 @@ public class Core : BaseController
         await handler.CloseConnections();
 
         await handler.Init(_settings.AniDb.Username, _settings.AniDb.Password,
-            _settings.AniDb.ServerAddress,
-            _settings.AniDb.ServerPort, _settings.AniDb.ClientPort);
+            _settings.AniDb.UDPServerAddress,
+            _settings.AniDb.UDPServerPort, _settings.AniDb.ClientPort);
 
         if (await handler.Login())
         {

--- a/Shoko.Server/API/v2/Modules/Init.cs
+++ b/Shoko.Server/API/v2/Modules/Init.cs
@@ -283,8 +283,8 @@ public class Init : BaseController
         Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(_settings.Culture);
 
         await handler.Init(_settings.AniDb.Username, _settings.AniDb.Password,
-            _settings.AniDb.ServerAddress,
-            _settings.AniDb.ServerPort, _settings.AniDb.ClientPort);
+            _settings.AniDb.UDPServerAddress,
+            _settings.AniDb.UDPServerPort, _settings.AniDb.ClientPort);
 
         if (!await handler.Login()) return APIStatus.BadRequest("Failed to log in");
         handler.ForceLogout();

--- a/Shoko.Server/API/v3/Controllers/SettingsController.cs
+++ b/Shoko.Server/API/v3/Controllers/SettingsController.cs
@@ -87,7 +87,7 @@ public class SettingsController : BaseController
         var alive = handler.IsAlive;
         var settings = SettingsProvider.GetSettings();
         if (!alive)
-            await handler.Init(credentials.Username, credentials.Password, settings.AniDb.ServerAddress, settings.AniDb.ServerPort, settings.AniDb.ClientPort);
+            await handler.Init(credentials.Username, credentials.Password, settings.AniDb.UDPServerAddress, settings.AniDb.UDPServerPort, settings.AniDb.ClientPort);
         else handler.ForceLogout();
 
         if (!await handler.TestLogin(credentials.Username, credentials.Password))

--- a/Shoko.Server/Databases/DatabaseFixes.cs
+++ b/Shoko.Server/Databases/DatabaseFixes.cs
@@ -119,18 +119,7 @@ public class DatabaseFixes
         session.CreateSQLQuery("DROP TABLE GroupFilter; DROP TABLE GroupFilterCondition").ExecuteUpdate();
     }
     
-    public static void MigrateAniDBToNet()
-    {
-        var settings = Utils.SettingsProvider.GetSettings();
-        var anidb = settings.AniDb.ServerAddress;
-        if (!anidb.EndsWith(".info", StringComparison.InvariantCultureIgnoreCase))
-        {
-            return;
-        }
-
-        settings.AniDb.ServerAddress = anidb.Substring(0, anidb.Length - 5) + ".net";
-        Utils.SettingsProvider.SaveSettings();
-    }
+    public static void MigrateAniDBToNet() { }
 
     public static void DeleteSerieUsersWithoutSeries()
     {

--- a/Shoko.Server/Extensions/ModelClients.cs
+++ b/Shoko.Server/Extensions/ModelClients.cs
@@ -23,7 +23,7 @@ public static class ModelClients
         {
             AniDB_Username = settings.AniDb.Username,
             AniDB_Password = settings.AniDb.Password,
-            AniDB_ServerAddress = Regex.Match(settings.AniDb.HTTPServerUrl, @"(https?://)*[^:]+").ToString(),
+            AniDB_ServerAddress = Regex.Match(settings.AniDb.HTTPServerUrl, @"https?://[^:]+").ToString(),
             AniDB_ServerPort = Regex.Match(settings.AniDb.HTTPServerUrl, @"(?<=:)\d+").ToString(),
             AniDB_ClientPort = settings.AniDb.ClientPort.ToString(),
             AniDB_AVDumpClientPort = settings.AniDb.AVDumpClientPort.ToString(),

--- a/Shoko.Server/Extensions/ModelClients.cs
+++ b/Shoko.Server/Extensions/ModelClients.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using NLog;
 using Shoko.Models.Client;
 using Shoko.Models.Enums;
@@ -22,8 +23,8 @@ public static class ModelClients
         {
             AniDB_Username = settings.AniDb.Username,
             AniDB_Password = settings.AniDb.Password,
-            AniDB_ServerAddress = settings.AniDb.ServerAddress,
-            AniDB_ServerPort = settings.AniDb.ServerPort.ToString(),
+            AniDB_ServerAddress = Regex.Match(settings.AniDb.HTTPServerUrl, @"(https?://)*[^:]+").ToString(),
+            AniDB_ServerPort = Regex.Match(settings.AniDb.HTTPServerUrl, @"(?<=:)\d+").ToString(),
             AniDB_ClientPort = settings.AniDb.ClientPort.ToString(),
             AniDB_AVDumpClientPort = settings.AniDb.AVDumpClientPort.ToString(),
             AniDB_AVDumpKey = settings.AniDb.AVDumpKey,

--- a/Shoko.Server/Extensions/ModelClients.cs
+++ b/Shoko.Server/Extensions/ModelClients.cs
@@ -17,14 +17,18 @@ public static class ModelClients
 {
     private static Logger logger = LogManager.GetCurrentClassLogger();
 
+    private static readonly Regex _urlRegex = new Regex(@"(?<=https?://)(?<address>.*):(?<port>\d+)", RegexOptions.Compiled);
+
     public static CL_ServerSettings ToContract(this IServerSettings settings)
     {
+        var serverAddressGroups = _urlRegex.Match(settings.AniDb.HTTPServerUrl).Groups;
+
         return new CL_ServerSettings
         {
             AniDB_Username = settings.AniDb.Username,
             AniDB_Password = settings.AniDb.Password,
-            AniDB_ServerAddress = Regex.Match(settings.AniDb.HTTPServerUrl, @"https?://[^:]+").ToString(),
-            AniDB_ServerPort = Regex.Match(settings.AniDb.HTTPServerUrl, @"(?<=:)\d+").ToString(),
+            AniDB_ServerAddress = serverAddressGroups["address"].Value,
+            AniDB_ServerPort = serverAddressGroups["port"].Value,
             AniDB_ClientPort = settings.AniDb.ClientPort.ToString(),
             AniDB_AVDumpClientPort = settings.AniDb.AVDumpClientPort.ToString(),
             AniDB_AVDumpKey = settings.AniDb.AVDumpKey,

--- a/Shoko.Server/Providers/AniDB/HTTP/AniDBHttpConnectionHandler.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/AniDBHttpConnectionHandler.cs
@@ -5,6 +5,7 @@ using System.Net.Security;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Shoko.Server.Providers.AniDB.Interfaces;
+using Shoko.Server.Utilities;
 
 namespace Shoko.Server.Providers.AniDB.HTTP;
 
@@ -31,6 +32,7 @@ public class AniDBHttpConnectionHandler : ConnectionHandler, IHttpConnectionHand
         _httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new System.Net.Http.Headers.StringWithQualityHeaderValue("gzip"));
         _httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new System.Net.Http.Headers.StringWithQualityHeaderValue("deflate"));
         _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1");
+        _httpClient.BaseAddress = new Uri(Utils.SettingsProvider.GetSettings().AniDb.HTTPServerUrl);
     }
 
     public async Task<HttpResponse<string>> GetHttp(string url)

--- a/Shoko.Server/Providers/AniDB/HTTP/RequestGetAnime.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/RequestGetAnime.cs
@@ -13,12 +13,11 @@ public class RequestGetAnime : HttpRequest<ResponseGetAnime>
     private readonly HttpXmlUtils _xmlUtils;
     private readonly HttpAnimeParser _parser;
     private readonly string _aniDBUrl;
-    private readonly ushort _aniDBPort;
 
     public int AnimeID { get; set; }
 
     protected override string BaseCommand =>
-        $"http://{_aniDBUrl}:{_aniDBPort}/httpapi?client=animeplugin&clientver=1&protover=1&request=anime&aid={AnimeID}";
+        $"{_aniDBUrl}/httpapi?client=animeplugin&clientver=1&protover=1&request=anime&aid={AnimeID}";
 
     public RequestGetAnime(IHttpConnectionHandler handler, ILoggerFactory loggerFactory, HttpXmlUtils xmlUtils,
         HttpAnimeParser parser, ISettingsProvider settingsProvider) : base(handler, loggerFactory)
@@ -26,8 +25,7 @@ public class RequestGetAnime : HttpRequest<ResponseGetAnime>
         _xmlUtils = xmlUtils;
         _parser = parser;
         var settings = settingsProvider.GetSettings().AniDb;
-        _aniDBUrl = settings.ServerAddress;
-        _aniDBPort = (ushort)(settings.ServerPort + 1);
+        _aniDBUrl = settings.HTTPServerUrl;
     }
 
     /// <summary>

--- a/Shoko.Server/Providers/AniDB/HTTP/RequestGetAnime.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/RequestGetAnime.cs
@@ -12,20 +12,17 @@ public class RequestGetAnime : HttpRequest<ResponseGetAnime>
 {
     private readonly HttpXmlUtils _xmlUtils;
     private readonly HttpAnimeParser _parser;
-    private readonly string _aniDBUrl;
 
     public int AnimeID { get; set; }
 
     protected override string BaseCommand =>
-        $"{_aniDBUrl}/httpapi?client=animeplugin&clientver=1&protover=1&request=anime&aid={AnimeID}";
+        $"httpapi?client=animeplugin&clientver=1&protover=1&request=anime&aid={AnimeID}";
 
     public RequestGetAnime(IHttpConnectionHandler handler, ILoggerFactory loggerFactory, HttpXmlUtils xmlUtils,
         HttpAnimeParser parser, ISettingsProvider settingsProvider) : base(handler, loggerFactory)
     {
         _xmlUtils = xmlUtils;
         _parser = parser;
-        var settings = settingsProvider.GetSettings().AniDb;
-        _aniDBUrl = settings.HTTPServerUrl;
     }
 
     /// <summary>

--- a/Shoko.Server/Providers/AniDB/HTTP/RequestMyList.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/RequestMyList.cs
@@ -11,10 +11,8 @@ namespace Shoko.Server.Providers.AniDB.HTTP;
 
 public class RequestMyList : HttpRequest<List<ResponseMyList>>
 {
-    private readonly string _aniDBUrl;
-
     protected override string BaseCommand =>
-        $"{_aniDBUrl}/httpapi?client=animeplugin&clientver=1&protover=1&request=mylist&user={Username}&pass={Password}";
+        $"httpapi?client=animeplugin&clientver=1&protover=1&request=mylist&user={Username}&pass={Password}";
 
     public string Username { private get; set; }
     public string Password { private get; set; }
@@ -81,9 +79,5 @@ public class RequestMyList : HttpRequest<List<ResponseMyList>>
         }
     }
 
-    public RequestMyList(IHttpConnectionHandler handler, ILoggerFactory loggerFactory, ISettingsProvider settingsProvider) : base(handler, loggerFactory)
-    {
-        var settings = settingsProvider.GetSettings().AniDb;
-        _aniDBUrl = settings.HTTPServerUrl;
-    }
+    public RequestMyList(IHttpConnectionHandler handler, ILoggerFactory loggerFactory, ISettingsProvider settingsProvider) : base(handler, loggerFactory) { }
 }

--- a/Shoko.Server/Providers/AniDB/HTTP/RequestMyList.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/RequestMyList.cs
@@ -12,10 +12,9 @@ namespace Shoko.Server.Providers.AniDB.HTTP;
 public class RequestMyList : HttpRequest<List<ResponseMyList>>
 {
     private readonly string _aniDBUrl;
-    private readonly ushort _aniDBPort;
 
     protected override string BaseCommand =>
-        $"http://{_aniDBUrl}:{_aniDBPort}/httpapi?client=animeplugin&clientver=1&protover=1&request=mylist&user={Username}&pass={Password}";
+        $"{_aniDBUrl}/httpapi?client=animeplugin&clientver=1&protover=1&request=mylist&user={Username}&pass={Password}";
 
     public string Username { private get; set; }
     public string Password { private get; set; }
@@ -85,7 +84,6 @@ public class RequestMyList : HttpRequest<List<ResponseMyList>>
     public RequestMyList(IHttpConnectionHandler handler, ILoggerFactory loggerFactory, ISettingsProvider settingsProvider) : base(handler, loggerFactory)
     {
         var settings = settingsProvider.GetSettings().AniDb;
-        _aniDBUrl = settings.ServerAddress;
-        _aniDBPort = (ushort)(settings.ServerPort + 1);
+        _aniDBUrl = settings.HTTPServerUrl;
     }
 }

--- a/Shoko.Server/Providers/AniDB/HTTP/RequestVotes.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/RequestVotes.cs
@@ -13,10 +13,8 @@ namespace Shoko.Server.Providers.AniDB.HTTP;
 
 public class RequestVotes : HttpRequest<List<ResponseVote>>
 {
-    private readonly string _aniDBUrl;
-
     protected override string BaseCommand =>
-        $"{_aniDBUrl}/httpapi?client=animeplugin&clientver=1&protover=1&request=votes&user={Username}&pass={Password}";
+        $"httpapi?client=animeplugin&clientver=1&protover=1&request=votes&user={Username}&pass={Password}";
 
     public string Username { private get; set; }
     public string Password { private get; set; }
@@ -111,9 +109,5 @@ public class RequestVotes : HttpRequest<List<ResponseVote>>
         return new ResponseVote { EntityID = entityID, VoteType = AniDBVoteType.Episode, VoteValue = val };
     }
 
-    public RequestVotes(IHttpConnectionHandler handler, ILoggerFactory loggerFactory, ISettingsProvider settingsProvider) : base(handler, loggerFactory)
-    {
-        var settings = settingsProvider.GetSettings().AniDb;
-        _aniDBUrl = settings.HTTPServerUrl;
-    }
+    public RequestVotes(IHttpConnectionHandler handler, ILoggerFactory loggerFactory, ISettingsProvider settingsProvider) : base(handler, loggerFactory) { }
 }

--- a/Shoko.Server/Providers/AniDB/HTTP/RequestVotes.cs
+++ b/Shoko.Server/Providers/AniDB/HTTP/RequestVotes.cs
@@ -14,10 +14,9 @@ namespace Shoko.Server.Providers.AniDB.HTTP;
 public class RequestVotes : HttpRequest<List<ResponseVote>>
 {
     private readonly string _aniDBUrl;
-    private readonly ushort _aniDBPort;
 
     protected override string BaseCommand =>
-        $"http://{_aniDBUrl}:{_aniDBPort}/httpapi?client=animeplugin&clientver=1&protover=1&request=votes&user={Username}&pass={Password}";
+        $"{_aniDBUrl}/httpapi?client=animeplugin&clientver=1&protover=1&request=votes&user={Username}&pass={Password}";
 
     public string Username { private get; set; }
     public string Password { private get; set; }
@@ -115,7 +114,6 @@ public class RequestVotes : HttpRequest<List<ResponseVote>>
     public RequestVotes(IHttpConnectionHandler handler, ILoggerFactory loggerFactory, ISettingsProvider settingsProvider) : base(handler, loggerFactory)
     {
         var settings = settingsProvider.GetSettings().AniDb;
-        _aniDBUrl = settings.ServerAddress;
-        _aniDBPort = (ushort)(settings.ServerPort + 1);
+        _aniDBUrl = settings.HTTPServerUrl;
     }
 }

--- a/Shoko.Server/Providers/AniDB/UDP/AniDBUDPConnectionHandler.cs
+++ b/Shoko.Server/Providers/AniDB/UDP/AniDBUDPConnectionHandler.cs
@@ -94,8 +94,8 @@ public class AniDBUDPConnectionHandler : ConnectionHandler, IUDPConnectionHandle
     public async Task<bool> Init(string username, string password, string serverName, ushort serverPort, ushort clientPort)
     {
         var settings = SettingsProvider.GetSettings();
-        settings.AniDb.ServerAddress = serverName;
-        settings.AniDb.ServerPort = serverPort;
+        settings.AniDb.UDPServerAddress = serverName;
+        settings.AniDb.UDPServerPort = serverPort;
         settings.AniDb.ClientPort = clientPort;
 
         if (!ValidAniDBCredentials(username, password)) return false;
@@ -114,10 +114,10 @@ public class AniDBUDPConnectionHandler : ConnectionHandler, IUDPConnectionHandle
         }
 
         var settings = SettingsProvider.GetSettings();
-        ArgumentNullException.ThrowIfNull(settings.AniDb?.ServerAddress);
-        if (settings.AniDb.ServerPort <= 0) throw new ArgumentException("AniDB Server Port is invalid");
-        if (settings.AniDb.ClientPort <= 0) throw new ArgumentException("AniDB Client Port is invalid");
-        _socketHandler = new AniDBSocketHandler(_loggerFactory, settings.AniDb.ServerAddress, settings.AniDb.ServerPort,
+        ArgumentNullException.ThrowIfNull(settings.AniDb?.UDPServerAddress);
+        if (settings.AniDb.UDPServerPort == 0) throw new ArgumentException("AniDB UDP Server Port is invalid");
+        if (settings.AniDb.ClientPort == 0) throw new ArgumentException("AniDB Client Port is invalid");
+        _socketHandler = new AniDBSocketHandler(_loggerFactory, settings.AniDb.UDPServerAddress, settings.AniDb.UDPServerPort,
             settings.AniDb.ClientPort);
         _isLoggedOn = false;
 

--- a/Shoko.Server/Settings/AniDbSettings.cs
+++ b/Shoko.Server/Settings/AniDbSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using Shoko.Models.Enums;
 
@@ -12,9 +13,14 @@ public class AniDbSettings
     public string Password { get; set; }
 
     [Required(AllowEmptyStrings = false)]
+    public string HTTPServerUrl { get; set; } = "http://api.anidb.net:9001";
+
+    [Obsolete("Deprecated in favor of HTTPServerUrl")] // Cannot be removed due to `MigrateAniDBToNet` in DatabaseFixes.cs
     public string ServerAddress { get; set; } = "api.anidb.net";
 
-    public ushort ServerPort { get; set; } = 9000;
+    public string UDPServerAddress { get; set; } = "api.anidb.net";
+
+    public ushort UDPServerPort { get; set; } = 9000;
 
     public ushort ClientPort { get; set; } = 4556;
 

--- a/Shoko.Server/Settings/AniDbSettings.cs
+++ b/Shoko.Server/Settings/AniDbSettings.cs
@@ -15,9 +15,6 @@ public class AniDbSettings
     [Required(AllowEmptyStrings = false)]
     public string HTTPServerUrl { get; set; } = "http://api.anidb.net:9001";
 
-    [Obsolete("Deprecated in favor of HTTPServerUrl")] // Cannot be removed due to `MigrateAniDBToNet` in DatabaseFixes.cs
-    public string ServerAddress { get; set; } = "api.anidb.net";
-
     public string UDPServerAddress { get; set; } = "api.anidb.net";
 
     public ushort UDPServerPort { get; set; } = 9000;

--- a/Shoko.Server/Settings/SettingsMigrations.cs
+++ b/Shoko.Server/Settings/SettingsMigrations.cs
@@ -105,6 +105,8 @@ public static class SettingsMigrations
         return serverAddressRegex.Replace(newSettings, match =>
         {
             var serverAddress = match.Groups["value"].Value;
+            // This is basically what MigrateAniDBToNet migration did in DatabaseFixes.cs, which is now made blank to remove ServerAddress from settings
+            serverAddress = serverAddress.Replace("api.anidb.info", "api.anidb.net");
             return $"\"HTTPServerUrl\": \"http://{serverAddress}:{serverPort + 1}\",\"UDPServerAddress\": \"{serverAddress}\"";
         });
     }

--- a/Shoko.Server/Settings/SettingsProvider.cs
+++ b/Shoko.Server/Settings/SettingsProvider.cs
@@ -88,8 +88,7 @@ public class SettingsProvider : ISettingsProvider
             {
                 Username = legacy.AniDB_Username,
                 Password = legacy.AniDB_Password,
-                ServerAddress = legacy.AniDB_ServerAddress,
-                ServerPort = ushort.Parse(legacy.AniDB_ServerPort),
+                HTTPServerUrl = $"http://${legacy.AniDB_ServerAddress}:{ushort.Parse(legacy.AniDB_ServerPort)}",
                 ClientPort = ushort.Parse(legacy.AniDB_ClientPort),
                 AVDumpKey = legacy.AniDB_AVDumpKey,
                 AVDumpClientPort = ushort.Parse(legacy.AniDB_AVDumpClientPort),


### PR DESCRIPTION
As per the discussion in #support. To have the ability to use a different address for the HTTP API

- Combined HTTP address and port into `HTTPServerUrl`
- Moved UDP address and port settings into a separate property.
- Desktop will only be able to view and edit the HTTP address and port settings
- Too much regex