### PR TITLE
Add `/Episode/Watched` endpoint

### DIFF
--- a/Shoko.Server/API/v3/Controllers/EpisodeController.cs
+++ b/Shoko.Server/API/v3/Controllers/EpisodeController.cs
@@ -488,8 +488,8 @@ public class EpisodeController : BaseController
         return Ok();
     }
 
-    private void SetWatchedStatusOnEpisode(SVR_AnimeEpisode episode, bool watched)
-        => episode.ToggleWatchedStatus(watched, true, DateTime.Now, true, User.JMMUserID, true);
+    private void SetWatchedStatusOnEpisode(SVR_AnimeEpisode episode, bool? watched)
+        => episode.ToggleWatchedStatus(watched ?? false, true, DateTime.Now, true, User.JMMUserID, true);
 
     /// <summary>
     /// Get all episodes with no files.

--- a/Shoko.Server/API/v3/Models/Shoko/Episode.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Episode.cs
@@ -432,13 +432,13 @@ public class EpisodeWatchList
     /// <summary>
     /// A list of episode IDs
     /// </summary>
-    [Required(ErrorMessage = "EpisodeIds cannot be null or empty")]
+    [Required]
     public IEnumerable<int> EpisodeIds { get; set; }
 
 
     /// <summary>
     /// The watch state to set  watched episode is changing to
     /// </summary>
-    [Required(ErrorMessage = "Watched cannot be null or empty")]
-    public bool Watched { get; set; }
+    [Required]
+    public bool? Watched { get; set; }
 }

--- a/Shoko.Server/API/v3/Models/Shoko/Episode.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/Episode.cs
@@ -426,3 +426,19 @@ public enum EpisodeType
     /// </summary>
     Extra = 10
 }
+
+public class EpisodeWatchList
+{
+    /// <summary>
+    /// A list of episode IDs
+    /// </summary>
+    [Required(ErrorMessage = "EpisodeIds cannot be null or empty")]
+    public IEnumerable<int> EpisodeIds { get; set; }
+
+
+    /// <summary>
+    /// The watch state to set  watched episode is changing to
+    /// </summary>
+    [Required(ErrorMessage = "Watched cannot be null or empty")]
+    public bool Watched { get; set; }
+}


### PR DESCRIPTION
The `/Episode/Watched` endpoint allows for a list of episodes to be marked as watched in bulk, regardless of what series they belong to.

Most practically, this could be utilised by the Web UI to allow marking a selection of episodes as watched, rather than having to mark everything that matches a search filter as watched.


I have tested the changes, and everything appears to have worked as (I) expected it to do so. For reference, requests with invalid episode IDs are rejected rather than filtering the invalid input out to avoid any misleading responses to the endpoint.

It goes without saying, but like with the other episode watched endpoints, if there are no files linked to the episode to mark as watched, it won't actually impact anything but will return a status of `200`.