### PR TITLE
Plex webhook episode detection for non-episode videos

### DIFF
--- a/Shoko.Server/API/v2/Modules/PlexWebhook.cs
+++ b/Shoko.Server/API/v2/Modules/PlexWebhook.cs
@@ -14,6 +14,7 @@ using Shoko.Commons.Extensions;
 using Shoko.Models.Enums;
 using Shoko.Models.Plex.Collection;
 using Shoko.Models.Plex.Connections;
+using Shoko.Models.Plex.Libraries;
 using Shoko.Models.Plex.TVShow;
 using Shoko.Models.Server;
 using Shoko.Server.API.v2.Models.core;
@@ -98,7 +99,7 @@ public class PlexWebhook : BaseController
     private void TraktScrobble(PlexEvent evt, ScrobblePlayingStatus type, JMMUser user)
     {
         var metadata = evt.Metadata;
-        var (episode, _) = GetEpisode(metadata, user);
+        var (episode, _) = GetEpisodeForUser(metadata, user);
 
         if (episode == null) return;
 
@@ -120,7 +121,7 @@ public class PlexWebhook : BaseController
     private void Scrobble(PlexEvent data, SVR_JMMUser user)
     {
         var metadata = data.Metadata;
-        var (episode, anime) = GetEpisode(metadata, user);
+        var (episode, anime) = GetEpisodeForUser(metadata, user);
         if (episode == null)
         {
             _logger.LogInformation(
@@ -140,7 +141,7 @@ public class PlexWebhook : BaseController
     #endregion
 
     [NonAction]
-    private (SVR_AnimeEpisode, SVR_AnimeSeries) GetEpisode(PlexEvent.PlexMetadata metadata, JMMUser user)
+    private (SVR_AnimeEpisode, SVR_AnimeSeries) GetEpisodeForUser(PlexEvent.PlexMetadata metadata, JMMUser user)
     {
         var guid = new Uri(metadata.Guid);
         if (guid.Scheme != "com.plexapp.agents.shoko" && guid.Scheme != "com.plexapp.agents.shokorelay")

--- a/Shoko.Server/API/v2/Modules/PlexWebhook.cs
+++ b/Shoko.Server/API/v2/Modules/PlexWebhook.cs
@@ -194,19 +194,16 @@ public class PlexWebhook : BaseController
         {
             if (episode == null)
             {
-                _logger.LogInformation(
-                    $"Failed to get anime episode from plex using key {metadata.Key}.");
+                _logger.LogInformation($"Failed to get anime episode from plex using key {metadata.Key}.");
                 return (null, anime);
             }
 
-            if (episode.EpisodeTypeEnum == episodeType
-                && anime.GetAnimeEpisodes().Contains(episode))
+            if (episode.EpisodeTypeEnum == episodeType && anime.GetAnimeEpisodes().Contains(episode))
             {
                 return (episode, anime);
             }
 
-            _logger.LogInformation(
-            $"Unable to work out the metadata for {metadata.Guid}.");
+            _logger.LogInformation($"Unable to work out the metadata for {metadata.Guid}.");
 
             return (null, anime);
         }
@@ -299,7 +296,7 @@ public class PlexWebhook : BaseController
 
     [Authorize]
     [HttpGet("libraries")]
-    public ActionResult<Shoko.Models.Plex.Libraries.Directory[]> GetLibraries()
+    public ActionResult<Directory[]> GetLibraries()
     {
         var result = CallPlexHelper(h => h.GetDirectories());
 

--- a/Shoko.Server/Plex/Collection/SVR_PlexLibrary.cs
+++ b/Shoko.Server/Plex/Collection/SVR_PlexLibrary.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Shoko.Models.Plex;
 using Shoko.Models.Plex.Collection;
 using Shoko.Models.Plex.TVShow;
@@ -18,6 +18,15 @@ internal class SVR_PlexLibrary : PlexLibrary
     public Episode[] GetEpisodes()
     {
         var (_, data) = Helper.RequestFromPlexAsync($"/library/metadata/{RatingKey}/allLeaves").GetAwaiter()
+            .GetResult();
+        return JsonConvert
+            .DeserializeObject<MediaContainer<MediaContainer>>(data, Helper.SerializerSettings)
+            .Container.Metadata;
+    }
+
+    public Episode[] GetEpisode(string ratingKey)
+    {
+        var (_, data) = Helper.RequestFromPlexAsync($"/library/metadata/{ratingKey}").GetAwaiter()
             .GetResult();
         return JsonConvert
             .DeserializeObject<MediaContainer<MediaContainer>>(data, Helper.SerializerSettings)

--- a/Shoko.Server/Plex/Collection/SVR_PlexLibrary.cs
+++ b/Shoko.Server/Plex/Collection/SVR_PlexLibrary.cs
@@ -17,8 +17,7 @@ internal class SVR_PlexLibrary : PlexLibrary
 
     public Episode[] GetEpisodes()
     {
-        var (_, data) = Helper.RequestFromPlexAsync($"/library/metadata/{RatingKey}/allLeaves").GetAwaiter()
-            .GetResult();
+        var (_, data) = Helper.RequestFromPlexAsync($"/library/metadata/{RatingKey}/allLeaves").Result;
         return JsonConvert
             .DeserializeObject<MediaContainer<MediaContainer>>(data, Helper.SerializerSettings)
             .Container.Metadata;

--- a/Shoko.Server/Plex/TVShow/SVR_Episode.cs
+++ b/Shoko.Server/Plex/TVShow/SVR_Episode.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using Shoko.Models.Plex.TVShow;
 using Shoko.Server.Models;
 using Shoko.Server.Repositories;
@@ -15,7 +15,7 @@ internal class SVR_Episode : Episode
     }
 
     public SVR_AnimeEpisode AnimeEpisode =>
-        RepoFactory.AnimeEpisode.GetByFilename(Path.GetFileName(Media[0].Part[0].File));
+        RepoFactory.AnimeEpisode.GetByFilename(Path.GetFileName(Media[0].Part[0].File), Media[0].Part[0].Size);
 
     public void Unscrobble()
     {

--- a/Shoko.Server/Plex/TVShow/SVR_Episode.cs
+++ b/Shoko.Server/Plex/TVShow/SVR_Episode.cs
@@ -15,7 +15,7 @@ internal class SVR_Episode : Episode
     }
 
     public SVR_AnimeEpisode AnimeEpisode =>
-        RepoFactory.AnimeEpisode.GetByFilename(Path.GetFileName(Media[0].Part[0].File), Media[0].Part[0].Size);
+        RepoFactory.AnimeEpisode.GetByFilenameAndSize(Path.GetFileName(Media[0].Part[0].File), Media[0].Part[0].Size);
 
     public void Unscrobble()
     {

--- a/Shoko.Server/Repositories/Cached/AnimeEpisodeRepository.cs
+++ b/Shoko.Server/Repositories/Cached/AnimeEpisodeRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -56,8 +56,9 @@ public class AnimeEpisodeRepository : BaseCachedRepository<SVR_AnimeEpisode, int
     /// Get the AnimeEpisode 
     /// </summary>
     /// <param name="name">The filename of the anime to search for.</param>
+    /// <param name="size">The size of the file in bytes</param>
     /// <returns>the AnimeEpisode given the file information</returns>
-    public SVR_AnimeEpisode GetByFilename(string name)
+    public SVR_AnimeEpisode GetByFilename(string name, long? size = null)
     {
         if (string.IsNullOrEmpty(name))
         {
@@ -68,6 +69,7 @@ public class AnimeEpisodeRepository : BaseCachedRepository<SVR_AnimeEpisode, int
             .Where(v => name.Equals(v?.FilePath?.Split(Path.DirectorySeparatorChar).LastOrDefault(),
                 StringComparison.InvariantCultureIgnoreCase))
             .Select(a => RepoFactory.VideoLocal.GetByID(a.VideoLocalID)).Where(a => a != null)
+            .Where(a => size == null || a.FileSize == size)
             .SelectMany(a => GetByHash(a.Hash)).ToArray();
         var ep = eps.FirstOrDefault(a => a.AniDB_Episode.EpisodeType == (int)EpisodeType.Episode);
         return ep ?? eps.FirstOrDefault();

--- a/Shoko.Server/Repositories/Cached/AnimeEpisodeRepository.cs
+++ b/Shoko.Server/Repositories/Cached/AnimeEpisodeRepository.cs
@@ -55,10 +55,9 @@ public class AnimeEpisodeRepository : BaseCachedRepository<SVR_AnimeEpisode, int
     /// <summary>
     /// Get the AnimeEpisode 
     /// </summary>
-    /// <param name="name">The filename of the anime to search for.</param>
-    /// <param name="size">The size of the file in bytes</param>
-    /// <returns>the AnimeEpisode given the file information</returns>
-    public SVR_AnimeEpisode GetByFilename(string name, long? size = null)
+    /// <param name="name">The filename of the anime to search for. Only the characters after the last directory separator are considered</param>
+    /// <returns>the AnimeEpisode given the file name</returns>
+    public SVR_AnimeEpisode GetByFilename(string name)
     {
         if (string.IsNullOrEmpty(name))
         {
@@ -69,8 +68,29 @@ public class AnimeEpisodeRepository : BaseCachedRepository<SVR_AnimeEpisode, int
             .Where(v => name.Equals(v?.FilePath?.Split(Path.DirectorySeparatorChar).LastOrDefault(),
                 StringComparison.InvariantCultureIgnoreCase))
             .Select(a => RepoFactory.VideoLocal.GetByID(a.VideoLocalID)).Where(a => a != null)
-            .Where(a => size == null || a.FileSize == size)
             .SelectMany(a => GetByHash(a.Hash)).ToArray();
+        var ep = eps.FirstOrDefault(a => a.AniDB_Episode.EpisodeType == (int)EpisodeType.Episode);
+        return ep ?? eps.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Get the AnimeEpisode 
+    /// </summary>
+    /// <param name="name">The filename of the anime to search for. Only the characters after the last directory separator are considered</param>
+    /// <param name="size">The size of the file in bytes</param>
+    /// <returns>the AnimeEpisode given the file name and size</returns>
+    public SVR_AnimeEpisode GetByFilenameAndSize(string name, long size)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+        var eps = RepoFactory.VideoLocalPlace.GetAll()
+        .Where(v => name.Equals(v?.FilePath?.Split(Path.DirectorySeparatorChar).LastOrDefault(),
+            StringComparison.InvariantCultureIgnoreCase))
+        .Select(a => RepoFactory.VideoLocal.GetByID(a.VideoLocalID)).Where(a => a != null)
+        .Where(a => a.FileSize == size)
+        .SelectMany(a => GetByHash(a.Hash)).ToArray();
         var ep = eps.FirstOrDefault(a => a.AniDB_Episode.EpisodeType == (int)EpisodeType.Episode);
         return ep ?? eps.FirstOrDefault();
     }


### PR DESCRIPTION
~~Use title + episode number (or TVDB season + episode #) for non-Episode type videos.~~

Use Plex API to fetch the filename of the watched video file (for non-episode type videos). 

This should allow the Plex webhook to mark specials and other video types as watched.

There is a corner case where the user has multiple episodes with the same file name in a series, handling that is TBD.
