### PR TITLE
Fix: Get release groups correctly for WebUI

### DIFF
--- a/Shoko.Server/API/v3/Controllers/WebUIController.cs
+++ b/Shoko.Server/API/v3/Controllers/WebUIController.cs
@@ -32,7 +32,7 @@ using Input = Shoko.Server.API.v3.Models.Shoko.WebUI.Input;
 namespace Shoko.Server.API.v3.Controllers;
 
 /// <summary>
-/// The WebUI spesific controller. Only WebUI should use these endpoints.
+/// The WebUI specific controller. Only WebUI should use these endpoints.
 /// They may break at any time if the WebUI client needs to change something,
 /// and is therefore unsafe for other clients.
 /// </summary>

--- a/Shoko.Server/API/v3/Models/Shoko/WebUI.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/WebUI.cs
@@ -201,7 +201,7 @@ public class WebUI
                 .DistinctBy(anidbFile => anidbFile.Hash)
                 .ToDictionary(anidbFile => anidbFile.Hash);
             var releaseGroups = anidbFiles.Values
-                .Select(anidbFile => anidbFile.ReleaseGroup.GroupID)
+                .Select(anidbFile => anidbFile.GroupID)
                 .Distinct()
                 .Where(groupID => groupID != 0)
                 .Select(RepoFactory.AniDB_ReleaseGroup.GetByGroupID)

--- a/Shoko.Server/API/v3/Models/Shoko/WebUI.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/WebUI.cs
@@ -172,7 +172,7 @@ public class WebUI
             groupByCriteria ??= new();
             var crossRefs = RepoFactory.CrossRef_File_Episode
                 .GetByAnimeID(series.AniDB_ID);
-            // The episodes we want to look at. We filter it down to only normal and speical episodes.
+            // The episodes we want to look at. We filter it down to only normal and special episodes.
             var episodes = series.GetAnimeEpisodes()
                 .Select(shoko =>
                 {
@@ -201,10 +201,10 @@ public class WebUI
                 .DistinctBy(anidbFile => anidbFile.Hash)
                 .ToDictionary(anidbFile => anidbFile.Hash);
             var releaseGroups = anidbFiles.Values
-                .Select(anidbFile => anidbFile.AniDB_FileID)
+                .Select(anidbFile => anidbFile.ReleaseGroup.GroupID)
                 .Distinct()
                 .Where(groupID => groupID != 0)
-                .Select(groupID =>  RepoFactory.AniDB_ReleaseGroup.GetByGroupID(groupID))
+                .Select(RepoFactory.AniDB_ReleaseGroup.GetByGroupID)
                 .Where(releaseGroup => releaseGroup != null)
                 .ToDictionary(releaseGroup => releaseGroup.GroupID);
             // We only care about files with exist and have actual media info and with an actual physical location. (Which should hopefully exclude nothing.)
@@ -227,8 +227,8 @@ public class WebUI
                     // Release group criterias
                     if (groupByCriteria.Contains(FileSummaryGroupByCriteria.GroupName))
                     {
-                        groupByDetails.GroupName = isAutoLinked ? file.ReleaseGroup?.GroupName ?? "Unknown" : "None";
-                        groupByDetails.GroupNameShort = isAutoLinked ? file.ReleaseGroup?.GroupNameShort ?? "Unk" : "-";
+                        groupByDetails.GroupName = isAutoLinked ? releaseGroup?.GroupName ?? "Unknown" : "None";
+                        groupByDetails.GroupNameShort = isAutoLinked ? releaseGroup?.GroupNameShort ?? "Unk" : "-";
                     }
 
                     // File criterias
@@ -649,7 +649,7 @@ public class WebUI
         {
             /// <summary>
             /// AniDB Episode ID.
-            /// /// </summary>
+            /// </summary>
             public int EpisodeID;
 
             /// <summary>


### PR DESCRIPTION
Ignore the typo amendments, the WebUIController one was killing me every time I opened swagger.

Fix is to make sure the file summary endpoint gets group ids as expected.