### PR TITLE
fix: exception while deleting empty directories

### DIFF
--- a/Shoko.Server/Services/VideoLocal_PlaceService.cs
+++ b/Shoko.Server/Services/VideoLocal_PlaceService.cs
@@ -481,6 +481,7 @@ public class VideoLocal_PlaceService
     {
         try
         {
+            directoryToClean = directoryToClean.TrimEnd(Path.DirectorySeparatorChar);
             var directoriesToClean = toBeChecked
                 .SelectMany(path =>
                 {


### PR DESCRIPTION
`SVR_ImportFolder.ImportFolderLocation` has a trailing `Path.DirectorySeparatorChar` like seen here https://github.com/ShokoAnime/ShokoServer/blob/5b016cbce43e0c60bee05138f08671051a3e182b/Shoko.Server/Models/SVR_ImportFolder.cs#L33

Due to those trailing path separators an issue occurs when the the path is passed as `directoryToClean` to the `RecursiveDeleteEmptyDirectories` function. The function iterates over all directories in `toBeChecked` up to `directoryToClean` and adds any valid paths to `directoriesToClean`.

So when the function reaches a `path` equal to `directoryToClean` it should stop iterating over that tree. The issue is that the `path` returned by
https://github.com/ShokoAnime/ShokoServer/blob/5b016cbce43e0c60bee05138f08671051a3e182b/Shoko.Server/Services/VideoLocal_PlaceService.cs#L497
does not have any trailing path separators. Resulting in the equality check here to be false, even though the two paths are technically equal
https://github.com/ShokoAnime/ShokoServer/blob/5b016cbce43e0c60bee05138f08671051a3e182b/Shoko.Server/Services/VideoLocal_PlaceService.cs#L491
This results in a `ArgumentOutOfRangeException` from the substring it is trying to build due to `directoriesToClean` being longer with its trailing path separators.

The behaviour can be seen in the following debug window:
![image](https://github.com/ShokoAnime/ShokoServer/assets/8273440/430d0ce6-10df-4f91-b1e7-693b5c98f6fe)
The function was given `["C:\\shoko\\import\\tsukimichi"]` as `toBeChecked` and `"C:\\shoko\\import\\"` as `directoryToClean`. Which obviously results in an exception when it reaches that ternary operator.

Simply removing those trailing path separators from `directoryToClean` fixes this issue on my end.