### PR TITLE
fix: import directory being deleted

### DIFF
--- a/Shoko.Server/Services/VideoLocal_PlaceService.cs
+++ b/Shoko.Server/Services/VideoLocal_PlaceService.cs
@@ -410,9 +410,10 @@ public class VideoLocal_PlaceService
 
             if (dropFolder.IsDropSource == 1 && deleteEmpty)
             {
-                var directories = dropFolder.BaseDirectory.EnumerateDirectories("*", new EnumerationOptions() { RecurseSubdirectories = true, ReturnSpecialDirectories = true, IgnoreInaccessible = true })
+                var directories = dropFolder.BaseDirectory.EnumerateDirectories("*", new EnumerationOptions() { RecurseSubdirectories = true, ReturnSpecialDirectories = false, IgnoreInaccessible = true })
                     .Select(dirInfo => dirInfo.FullName);
-                RecursiveDeleteEmptyDirectories(directories, dropFolder.ImportFolderLocation);
+                if (directories.Any())
+                    RecursiveDeleteEmptyDirectories(directories, dropFolder.ImportFolderLocation);
             }
 
             ShokoEventHandler.Instance.OnFileMoved(dropFolder, destFolder, oldPath, newFilePath, videoLocalPlace);

--- a/Shoko.Server/Services/VideoLocal_PlaceService.cs
+++ b/Shoko.Server/Services/VideoLocal_PlaceService.cs
@@ -410,10 +410,9 @@ public class VideoLocal_PlaceService
 
             if (dropFolder.IsDropSource == 1 && deleteEmpty)
             {
-                var directories = dropFolder.BaseDirectory.EnumerateDirectories("*", new EnumerationOptions() { RecurseSubdirectories = true, ReturnSpecialDirectories = false, IgnoreInaccessible = true })
+                var directories = dropFolder.BaseDirectory.EnumerateDirectories("*", new EnumerationOptions() { RecurseSubdirectories = true, IgnoreInaccessible = true })
                     .Select(dirInfo => dirInfo.FullName);
-                if (directories.Any())
-                    RecursiveDeleteEmptyDirectories(directories, dropFolder.ImportFolderLocation);
+                RecursiveDeleteEmptyDirectories(directories, dropFolder.ImportFolderLocation);
             }
 
             ShokoEventHandler.Instance.OnFileMoved(dropFolder, destFolder, oldPath, newFilePath, videoLocalPlace);


### PR DESCRIPTION
Due to `ReturnSpecialDirectories` being set to `true`, the `IEnumerable` contained `\\.` and `\\..` for current and all subdirectories. This resulted in the path with `\\.` at the end not being seen as equal as `dropFolder.ImportFolderLocation` in `RecursiveDeleteEmptyDirectories`. Simply setting this flag to `false` should resolve this and another issue like duplicate subdirectory entries. Also made the delete function run only when the `IEnumerable` is not empty.