### PR TITLE
Pass correct CharID for AniDB character image validation

### DIFF
--- a/Shoko.Server/Scheduling/Jobs/Shoko/ValidateAllImagesJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Shoko/ValidateAllImagesJob.cs
@@ -181,7 +181,7 @@ public class ValidateAllImagesJob : BaseJob
             foreach (var character in characters)
             {
                 _logger.LogTrace(CorruptImageFound, character.GetPosterPath());
-                await RemoveImageAndQueueRedownload<DownloadAniDBImageJob>(ImageEntityType.AniDB_Character, character.AniDB_CharacterID);
+                await RemoveImageAndQueueRedownload<DownloadAniDBImageJob>(ImageEntityType.AniDB_Character, character.CharID);
                 if (++count % 10 != 0) continue;
                 _logger.LogInformation(ReQueueingForDownload, count, characters.Count);
                 UpdateProgress($" - AniDB Characters - {count}/{characters.Count}");


### PR DESCRIPTION
`AniDBImageHandler.GetPaths` uses `AniDB_Character.GetByCharID` to look up character data, so we should pass `CharID` to it instead of `AniDB_CharacterID`
