### PR TITLE
Move and Rename in AutoMoveRequest should default true

### DIFF
--- a/Shoko.Server/Renamer/AutoMoveRequest.cs
+++ b/Shoko.Server/Renamer/AutoMoveRequest.cs
@@ -15,7 +15,7 @@ public record AutoMoveRequest : AutoRenameRequest
     public bool DeleteEmptyDirectories = true;
 
     /// <summary>
-    /// Skip the move operation.
+    /// Do the move operation.
     /// </summary>
-    public bool Move = false;
+    public bool Move = true;
 }

--- a/Shoko.Server/Renamer/AutoRenameRequest.cs
+++ b/Shoko.Server/Renamer/AutoRenameRequest.cs
@@ -22,5 +22,5 @@ public record AutoRenameRequest
     /// <summary>
     /// Do the rename operation.
     /// </summary>
-    public bool Rename = false;
+    public bool Rename = true;
 }


### PR DESCRIPTION
When revam renamed `skiprename/move` to `move/rename` the default values weren't flipped. Use of the object initializer without `Rename` set broke renaming from the v1 api implementation.