### PR TITLE
Add logging for exceptions thrown from Quartz Jobs

### DIFF
--- a/Shoko.Server/Utilities/Utils.cs
+++ b/Shoko.Server/Utilities/Utils.cs
@@ -16,6 +16,7 @@ using NLog.Config;
 using NLog.Filters;
 using NLog.Targets;
 using NLog.Targets.Wrappers;
+using Quartz.Logging;
 using Shoko.Models.Enums;
 using Shoko.Server.API.SignalR.NLog;
 using Shoko.Server.Providers.AniDB.Titles;
@@ -124,6 +125,8 @@ public static class Utils
             }
         }
 
+        LogProvider.SetLogProvider(new NLog.Extensions.Logging.NLogLoggerFactory());
+        
         LogManager.ReconfigExistingLoggers();
     }
 


### PR DESCRIPTION
Seems to work, the exceptions appeared in the webui, console, and file.

An alternative would be to uncomment line 23 in BaseJob.cs. That would only log exceptions from Process(). LogProvider.SetLogProvider could probably log something other than exceptions, I haven't tested it though.