### PR TITLE
Fix unknown episode air date null exception

### DIFF
--- a/Shoko.Server/Services/AnimeSeriesService.cs
+++ b/Shoko.Server/Services/AnimeSeriesService.cs
@@ -539,13 +539,17 @@ public class AnimeSeriesService
 
             var airdate = ep.AniDB_Episode.GetAirDateAsDate();
 
+            // If episode air date is unknown, air date of the anime is used instead
+            airdate ??= ep.AniDB_Episode.AniDB_Anime.AirDate;
+
             // Only count episodes that have already aired
-            if (aniEp.HasAired)
+            // airdate could, in theory, only be null here if AniDB neither has information on the episode
+            // air date, nor on the anime air date. luckily, as of 2024-07-09, no such case exists.
+            if (aniEp.HasAired && airdate != null)
             {
                 // Only convert if we have time info
                 DateTime airdateLocal;
-                // ignore the possible null on airdate, it's checked in GetFutureDated
-                if (airdate!.Value.Hour == 0 && airdate.Value.Minute == 0 && airdate.Value.Second == 0)
+                if (airdate.Value.Hour == 0 && airdate.Value.Minute == 0 && airdate.Value.Second == 0)
                 {
                     airdateLocal = airdate.Value;
                 }


### PR DESCRIPTION
Fix exception that would be thrown if the episode had an unknown air/release date according to AniDB (example: https://anidb.net/episode/132080) which would result airdate to be null

This change will use the series air date if the episode doesn't have one.

Additionally, if the series also doesn't have one, the air date will be omitted. (Luckily, as of today, no such case exists on AniDB, however, if such a thing was to be added in the future, it would also cause an exception here. I'm not exactly sure whether in this super edge case scenario, it should just throw an exception here, but I suppose that if such an edge case were to be handled, it would happen before it gets passed into function. So I am assuming that if both the EP and anime air date is null at this point, that just means that both are unknown.)