### PR TITLE
Fix group refreshing for good

### DIFF
--- a/Shoko.Server/Tasks/AnimeGroupCreator.cs
+++ b/Shoko.Server/Tasks/AnimeGroupCreator.cs
@@ -498,13 +498,6 @@ public class AnimeGroupCreator
 
             await UpdateAnimeSeriesContractsAndSave(session, animeSeries);
 
-            await BaseRepository.Lock(async () =>
-            {
-                using var trans = session.BeginTransaction();
-                await session.DeleteAsync(tempGroup); // We should no longer need the temporary group we created earlier
-                await trans.CommitAsync();
-            });
-
             // We need groups and series cached for updating of AnimeGroup contracts to work
             _animeGroupRepo.Populate(session, false);
             _animeSeriesRepo.Populate(session, false);


### PR DESCRIPTION
Attempting to delete the temp group here would throw NHibernate.StaleStateException : Unexpected row count: 0; expected: 1

That is because it's not being added to the db in the first place, or as line 76 in AnimeGroupCreator.cs states: "We won't use AnimeGroupRepository.Save because we don't need to perform all the extra stuff since this is for temporary use only"