### PR TITLE
Restrict IDs in v3 API using Range annotation

### DIFF
--- a/Shoko.Server/API/v3/Controllers/EpisodeController.cs
+++ b/Shoko.Server/API/v3/Controllers/EpisodeController.cs
@@ -42,8 +42,6 @@ public class EpisodeController : BaseController
 
     private readonly WatchedStatusService _watchedService;
 
-    internal const string EpisodeWithZeroID = "episodeID must be greater than 0";
-
     internal const string EpisodeNotFoundWithEpisodeID = "No Episode entry for the given episodeID";
 
     internal const string EpisodeNotFoundForAnidbEpisodeID = "No Episode entry for the given anidbEpisodeID";
@@ -308,16 +306,13 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <returns></returns>
     [HttpGet("{episodeID}")]
     public ActionResult<Episode> GetEpisodeByEpisodeID(
-        [FromRoute] int episodeID,
+        [FromRoute, Range(1, int.MaxValue)] int episodeID,
         [FromQuery] bool includeFiles = false,
         [FromQuery] bool includeMediaInfo = false,
         [FromQuery] bool includeAbsolutePaths = false,
         [FromQuery] bool includeXRefs = false,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<DataSource> includeDataFrom = null)
     {
-        if (episodeID == 0)
-            return BadRequest(EpisodeWithZeroID);
-
         var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
         if (episode == null)
             return NotFound(EpisodeNotFoundWithEpisodeID);
@@ -340,11 +335,8 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <returns></returns>
     [Authorize("admin")]
     [HttpPost("{episodeID}/OverrideTitle")]
-    public ActionResult OverrideEpisodeTitle([FromRoute] int episodeID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Episode.Input.EpisodeTitleOverrideBody body)
+    public ActionResult OverrideEpisodeTitle([FromRoute, Range(1, int.MaxValue)] int episodeID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Episode.Input.EpisodeTitleOverrideBody body)
     {
-        if (episodeID == 0)
-            return BadRequest(EpisodeWithZeroID);
-
         var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
 
         if (episode == null)
@@ -378,11 +370,8 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <returns></returns>
     [Authorize("admin")]
     [HttpPost("{episodeID}/SetHidden")]
-    public ActionResult PostEpisodeSetHidden([FromRoute] int episodeID, [FromQuery] bool value = true, [FromQuery] bool updateStats = true)
+    public ActionResult PostEpisodeSetHidden([FromRoute, Range(1, int.MaxValue)] int episodeID, [FromQuery] bool value = true, [FromQuery] bool updateStats = true)
     {
-        if (episodeID == 0)
-            return BadRequest(EpisodeWithZeroID);
-
         var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
         if (episode == null)
             return NotFound(EpisodeNotFoundWithEpisodeID);
@@ -422,11 +411,8 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <param name="episodeID">Shoko ID</param>
     /// <returns></returns>
     [HttpGet("{episodeID}/AniDB")]
-    public ActionResult<Episode.AniDB> GetEpisodeAnidbByEpisodeID([FromRoute] int episodeID)
+    public ActionResult<Episode.AniDB> GetEpisodeAnidbByEpisodeID([FromRoute, Range(1, int.MaxValue)] int episodeID)
     {
-        if (episodeID == 0)
-            return BadRequest(EpisodeWithZeroID);
-
         var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
         if (episode == null)
             return NotFound(EpisodeNotFoundWithEpisodeID);
@@ -490,11 +476,8 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <param name="vote"></param>
     /// <returns></returns>
     [HttpPost("{episodeID}/Vote")]
-    public ActionResult PostEpisodeVote([FromRoute] int episodeID, [FromBody] Vote vote)
+    public ActionResult PostEpisodeVote([FromRoute, Range(1, int.MaxValue)] int episodeID, [FromBody] Vote vote)
     {
-        if (episodeID == 0)
-            return BadRequest(EpisodeWithZeroID);
-
         var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
         if (episode == null)
             return NotFound(EpisodeNotFoundWithEpisodeID);
@@ -527,7 +510,7 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <returns>All TMDB Movies linked directly to the Shoko Episode.</returns>
     [HttpGet("{episodeID}/TMDB/Movie")]
     public ActionResult<List<TmdbMovie>> GetTmdbMoviesByEpisodeID(
-        [FromRoute] int episodeID,
+        [FromRoute, Range(1, int.MaxValue)] int episodeID,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<TmdbMovie.IncludeDetails> include = null,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<TitleLanguage> language = null
     )
@@ -550,7 +533,7 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <returns>All TMDB Movie cross-references for the Shoko Episode.</returns>
     [HttpGet("{seriesID}/TMDB/Movie/CrossReferences")]
     public ActionResult<IReadOnlyList<TmdbMovie.CrossReference>> GetTMDBMovieCrossReferenceByEpisodeID(
-        [FromRoute] int seriesID
+        [FromRoute, Range(1, int.MaxValue)] int seriesID
     )
     {
         var episode = RepoFactory.AnimeEpisode.GetByID(seriesID);
@@ -572,7 +555,7 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <returns>All TMDB Episodes linked to the Shoko Episode.</returns>
     [HttpGet("{episodeID}/TMDB/Episode")]
     public ActionResult<List<TmdbEpisode>> GetTmdbEpisodesByEpisodeID(
-        [FromRoute] int episodeID,
+        [FromRoute, Range(1, int.MaxValue)] int episodeID,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<TmdbEpisode.IncludeDetails> include = null,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<TitleLanguage> language = null
     )
@@ -595,7 +578,7 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <returns>All TMDB Episode cross-references for the Shoko Episode.</returns>
     [HttpGet("{seriesID}/TMDB/Episode/CrossReferences")]
     public ActionResult<IReadOnlyList<TmdbEpisode.CrossReference>> GetTMDBEpisodeCrossReferenceByEpisodeID(
-        [FromRoute] int seriesID
+        [FromRoute, Range(1, int.MaxValue)] int seriesID
     )
     {
         var episode = RepoFactory.AnimeEpisode.GetByID(seriesID);
@@ -618,11 +601,8 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <param name="episodeID">Shoko ID</param>
     /// <returns></returns>
     [HttpGet("{episodeID}/TvDB")]
-    public ActionResult<List<Episode.TvDB>> GetEpisodeTvDBDetails([FromRoute] int episodeID)
+    public ActionResult<List<Episode.TvDB>> GetEpisodeTvDBDetails([FromRoute, Range(1, int.MaxValue)] int episodeID)
     {
-        if (episodeID == 0)
-            return BadRequest(EpisodeWithZeroID);
-
         var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
         if (episode == null)
             return NotFound(EpisodeNotFoundWithEpisodeID);
@@ -658,11 +638,8 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <param name="includeDisabled"></param>
     /// <returns></returns>
     [HttpGet("{episodeID}/Images")]
-    public ActionResult<Images> GetSeriesImages([FromRoute] int episodeID, [FromQuery] bool includeDisabled)
+    public ActionResult<Images> GetSeriesImages([FromRoute, Range(1, int.MaxValue)] int episodeID, [FromQuery] bool includeDisabled)
     {
-        if (episodeID == 0)
-            return BadRequest(EpisodeWithZeroID);
-
         var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
         if (episode == null)
             return NotFound(EpisodeNotFoundWithEpisodeID);
@@ -688,14 +665,11 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <param name="imageType">Poster, Banner, Fanart</param>
     /// <returns></returns>
     [HttpGet("{episodeID}/Images/{imageType}")]
-    public ActionResult<Image> GetSeriesDefaultImageForType([FromRoute] int episodeID,
+    public ActionResult<Image> GetSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int episodeID,
         [FromRoute] Image.ImageType imageType)
     {
         if (!_allowedImageTypes.Contains(imageType))
             return NotFound();
-
-        if (episodeID == 0)
-            return BadRequest(EpisodeWithZeroID);
 
         var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
         if (episode == null)
@@ -733,14 +707,11 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <param name="body">The body containing the source and id used to set.</param>
     /// <returns></returns>
     [HttpPut("{episodeID}/Images/{imageType}")]
-    public ActionResult<Image> SetSeriesDefaultImageForType([FromRoute] int episodeID,
+    public ActionResult<Image> SetSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int episodeID,
         [FromRoute] Image.ImageType imageType, [FromBody] Image.Input.DefaultImageBody body)
     {
         if (!_allowedImageTypes.Contains(imageType))
             return NotFound();
-
-        if (episodeID == 0)
-            return BadRequest(EpisodeWithZeroID);
 
         var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
         if (episode == null)
@@ -779,13 +750,10 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <param name="imageType">Poster, Banner, Fanart</param>
     /// <returns></returns>
     [HttpDelete("{episodeID}/Images/{imageType}")]
-    public ActionResult DeleteSeriesDefaultImageForType([FromRoute] int episodeID, [FromRoute] Image.ImageType imageType)
+    public ActionResult DeleteSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int episodeID, [FromRoute] Image.ImageType imageType)
     {
         if (!_allowedImageTypes.Contains(imageType))
             return NotFound();
-
-        if (episodeID == 0)
-            return BadRequest(EpisodeWithZeroID);
 
         var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
         if (episode == null)
@@ -822,11 +790,8 @@ addValue: allowedShowDict.TryAdd(episode.SeriesID, isAllowed);
     /// <param name="watched"></param>
     /// <returns></returns>
     [HttpPost("{episodeID}/Watched/{watched}")]
-    public async Task<ActionResult> SetWatchedStatusOnEpisode([FromRoute] int episodeID, [FromRoute] bool watched)
+    public async Task<ActionResult> SetWatchedStatusOnEpisode([FromRoute, Range(1, int.MaxValue)] int episodeID, [FromRoute] bool watched)
     {
-        if (episodeID == 0)
-            return BadRequest(EpisodeWithZeroID);
-
         var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
         if (episode == null)
             return NotFound(EpisodeNotFoundWithEpisodeID);

--- a/Shoko.Server/API/v3/Controllers/FilterController.cs
+++ b/Shoko.Server/API/v3/Controllers/FilterController.cs
@@ -213,7 +213,7 @@ public class FilterController : BaseController
     /// <param name="withConditions">Include conditions and sort criteria in the response.</param>
     /// <returns>The filter</returns>
     [HttpGet("{filterID}")]
-    public ActionResult<Filter> GetFilter([FromRoute] int filterID, [FromQuery] bool withConditions = false)
+    public ActionResult<Filter> GetFilter([FromRoute, Range(1, int.MaxValue)] int filterID, [FromQuery] bool withConditions = false)
     {
         var filterPreset = RepoFactory.FilterPreset.GetByID(filterID);
         if (filterPreset == null)
@@ -231,7 +231,7 @@ public class FilterController : BaseController
     /// <returns>The updated filter.</returns>
     [Authorize("admin")]
     [HttpPatch("{filterID}")]
-    public ActionResult<Filter> PatchFilter([FromRoute] int filterID, JsonPatchDocument<Filter.Input.CreateOrUpdateFilterBody> document)
+    public ActionResult<Filter> PatchFilter([FromRoute, Range(1, int.MaxValue)] int filterID, JsonPatchDocument<Filter.Input.CreateOrUpdateFilterBody> document)
     {
         var filterPreset = RepoFactory.FilterPreset.GetByID(filterID);
         if (filterPreset == null)
@@ -265,7 +265,7 @@ public class FilterController : BaseController
     /// <returns>The updated filter.</returns>
     [Authorize("admin")]
     [HttpPut("{filterID}")]
-    public ActionResult<Filter> PutFilter([FromRoute] int filterID, Filter.Input.CreateOrUpdateFilterBody body)
+    public ActionResult<Filter> PutFilter([FromRoute, Range(1, int.MaxValue)] int filterID, Filter.Input.CreateOrUpdateFilterBody body)
     {
         var filterPreset = RepoFactory.FilterPreset.GetByID(filterID);
         if (filterPreset == null)
@@ -293,7 +293,7 @@ public class FilterController : BaseController
     /// <returns>Void.</returns>
     [Authorize("admin")]
     [HttpDelete("{filterID}")]
-    public ActionResult DeleteFilter(int filterID)
+    public ActionResult DeleteFilter([FromRoute, Range(1, int.MaxValue)] int filterID)
     {
         var filterPreset = RepoFactory.FilterPreset.GetByID(filterID);
         if (filterPreset == null)
@@ -433,14 +433,13 @@ public class FilterController : BaseController
     /// <param name="includeEmpty">Include <see cref="Series"/> with missing <see cref="Episode"/>s in the search.</param>
     /// <returns></returns>
     [HttpPost("Preview/Group/{groupID}/Group")]
-    public ActionResult<List<Group>> GetPreviewFilteredSubGroups([FromBody] Filter.Input.CreateOrUpdateFilterBody filter, [FromRoute] int groupID,
+    public ActionResult<List<Group>> GetPreviewFilteredSubGroups([FromBody] Filter.Input.CreateOrUpdateFilterBody filter, [FromRoute, Range(1, int.MaxValue)] int groupID,
         [FromQuery] bool randomImages = false, [FromQuery] bool includeEmpty = false)
     {
         var filterPreset = _factory.GetFilterPreset(filter, ModelState);
         if (!ModelState.IsValid) return ValidationProblem(ModelState);
 
         // Check if the group exists.
-        if (groupID == 0) return BadRequest(GroupController.GroupWithZeroID);
         var group = RepoFactory.AnimeGroup.GetByID(groupID);
         if (group == null)
             return NotFound(GroupController.GroupNotFound);
@@ -493,7 +492,7 @@ public class FilterController : BaseController
     /// <param name="includeDataFrom">Include data from selected <see cref="DataSource"/>s.</param>
     /// /// <returns></returns>
     [HttpPost("Preview/Group/{groupID}/Series")]
-    public ActionResult<List<Series>> GetPreviewSeriesInFilteredGroup([FromBody] Filter.Input.CreateOrUpdateFilterBody filter, [FromRoute] int groupID,
+    public ActionResult<List<Series>> GetPreviewSeriesInFilteredGroup([FromBody] Filter.Input.CreateOrUpdateFilterBody filter, [FromRoute, Range(1, int.MaxValue)] int groupID,
         [FromQuery] bool recursive = false, [FromQuery] bool includeMissing = false,
         [FromQuery] bool randomImages = false, [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<DataSource> includeDataFrom = null)
     {
@@ -501,7 +500,6 @@ public class FilterController : BaseController
         if (!ModelState.IsValid) return ValidationProblem(ModelState);
 
         // Check if the group exists.
-        if (groupID == 0) return BadRequest(GroupController.GroupWithZeroID);
         var group = RepoFactory.AnimeGroup.GetByID(groupID);
         if (group == null)
             return NotFound(GroupController.GroupNotFound);

--- a/Shoko.Server/API/v3/Controllers/GroupController.cs
+++ b/Shoko.Server/API/v3/Controllers/GroupController.cs
@@ -30,8 +30,6 @@ public class GroupController : BaseController
 
     #region Return messages
 
-    internal const string GroupWithZeroID = "GroupID must be greater than 0";
-
     internal const string GroupNotFound = "No Group entry for the given groupID";
 
     internal const string GroupForbiddenForUser = "Accessing Group is not allowed for the current user";
@@ -162,9 +160,8 @@ public class GroupController : BaseController
     /// <param name="groupID"></param>
     /// <returns></returns>
     [HttpGet("{groupID}")]
-    public ActionResult<Group> GetGroup([FromRoute] int groupID)
+    public ActionResult<Group> GetGroup([FromRoute, Range(1, int.MaxValue)] int groupID)
     {
-        if (groupID == 0) return BadRequest(GroupWithZeroID);
         var group = RepoFactory.AnimeGroup.GetByID(groupID);
         if (group == null)
         {
@@ -190,9 +187,8 @@ public class GroupController : BaseController
     /// <param name="body">The new details for the group.</param>
     /// <returns>The updated group.</returns>
     [HttpPut("{groupID}")]
-    public ActionResult<Group> PutGroup([FromRoute] int groupID, [FromBody] Group.Input.CreateOrUpdateGroupBody body)
+    public ActionResult<Group> PutGroup([FromRoute, Range(1, int.MaxValue)] int groupID, [FromBody] Group.Input.CreateOrUpdateGroupBody body)
     {
-        if (groupID == 0) return BadRequest(GroupWithZeroID);
         var animeGroup = RepoFactory.AnimeGroup.GetByID(groupID);
         if (animeGroup == null)
         {
@@ -226,9 +222,8 @@ public class GroupController : BaseController
     /// <param name="patchDocument">The JSON Patch document containing the changes to be applied to the group.</param>
     /// <returns>The updated group.</returns>
     [HttpPatch("{groupID}")]
-    public ActionResult<Group> PatchGroup([FromRoute] int groupID, [FromBody] JsonPatchDocument<Group.Input.CreateOrUpdateGroupBody> patchDocument)
+    public ActionResult<Group> PatchGroup([FromRoute, Range(1, int.MaxValue)] int groupID, [FromBody] JsonPatchDocument<Group.Input.CreateOrUpdateGroupBody> patchDocument)
     {
-        if (groupID == 0) return BadRequest(GroupWithZeroID);
         var animeGroup = RepoFactory.AnimeGroup.GetByID(groupID);
         if (animeGroup == null)
         {
@@ -268,10 +263,9 @@ public class GroupController : BaseController
     /// <param name="recursive">Show relations for all series within the group, even for series within sub-groups.</param>
     /// <returns></returns>
     [HttpGet("{groupID}/Relations")]
-    public ActionResult<List<SeriesRelation>> GetShokoRelationsBySeriesID([FromRoute] int groupID,
+    public ActionResult<List<SeriesRelation>> GetShokoRelationsBySeriesID([FromRoute, Range(1, int.MaxValue)] int groupID,
         [FromQuery] bool recursive = false)
     {
-        if (groupID == 0) return BadRequest(GroupWithZeroID);
         var group = RepoFactory.AnimeGroup.GetByID(groupID);
         if (group == null)
         {
@@ -315,9 +309,8 @@ public class GroupController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpDelete("{groupID}")]
-    public async Task<ActionResult> DeleteGroup(int groupID, bool deleteSeries = false, bool deleteFiles = false)
+    public async Task<ActionResult> DeleteGroup([FromRoute, Range(1, int.MaxValue)] int groupID, bool deleteSeries = false, bool deleteFiles = false)
     {
-        if (groupID == 0) return BadRequest(GroupWithZeroID);
         var group = RepoFactory.AnimeGroup.GetByID(groupID);
         if (group == null)
         {
@@ -351,9 +344,8 @@ public class GroupController : BaseController
     /// <param name="groupID"></param>
     /// <returns></returns>
     [HttpPost("{groupID}/Recalculate")]
-    public async Task<ActionResult> RecalculateStats(int groupID)
+    public async Task<ActionResult> RecalculateStats([FromRoute, Range(1, int.MaxValue)] int groupID)
     {
-        if (groupID == 0) return BadRequest(GroupWithZeroID);
         var group = RepoFactory.AnimeGroup.GetByID(groupID);
         if (group == null)
         {

--- a/Shoko.Server/API/v3/Controllers/ImageController.cs
+++ b/Shoko.Server/API/v3/Controllers/ImageController.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -29,12 +30,12 @@ public class ImageController : BaseController
     [ProducesResponseType(typeof(FileStreamResult), 200)]
     [ProducesResponseType(404)]
     public ActionResult GetImage([FromRoute] Image.ImageSource source, [FromRoute] Image.ImageType type,
-        [FromRoute] int value)
+        [FromRoute, Range(1, int.MaxValue)] int value)
     {
         // Unrecognized combination of source, type and/or value.
         var dataSource = source.ToServer();
         var imageEntityType = type.ToServer();
-        if (imageEntityType == ImageEntityType.None || dataSource == DataSourceType.None || value <= 0)
+        if (imageEntityType == ImageEntityType.None || dataSource == DataSourceType.None)
             return NotFound(ImageNotFound);
 
         // User avatars are stored in the database.
@@ -65,12 +66,12 @@ public class ImageController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpPost("{source}/{type}/{value}/Enabled")]
-    public ActionResult EnableOrDisableImage([FromRoute] Image.ImageSource source, [FromRoute] Image.ImageType type, [FromRoute] int value, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Image.Input.EnableImageBody body)
+    public ActionResult EnableOrDisableImage([FromRoute] Image.ImageSource source, [FromRoute] Image.ImageType type, [FromRoute, Range(1, int.MaxValue)] int value, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Image.Input.EnableImageBody body)
     {
         // Unrecognized combination of source, type and/or value.
         var dataSource = source.ToServer();
         var imageEntityType = type.ToServer();
-        if (imageEntityType == ImageEntityType.None || dataSource == DataSourceType.None || value <= 0)
+        if (imageEntityType == ImageEntityType.None || dataSource == DataSourceType.None)
             return NotFound(ImageNotFound);
 
         // User avatars are stored in the database.

--- a/Shoko.Server/API/v3/Controllers/ImportFolderController.cs
+++ b/Shoko.Server/API/v3/Controllers/ImportFolderController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -75,9 +76,8 @@ public class ImportFolderController : BaseController
     /// <param name="folderID">Import Folder ID</param>
     /// <returns></returns>
     [HttpGet("{folderID}")]
-    public ActionResult<ImportFolder> GetImportFolderByFolderID([FromRoute] int folderID)
+    public ActionResult<ImportFolder> GetImportFolderByFolderID([FromRoute, Range(1, int.MaxValue)] int folderID)
     {
-        if (folderID == 0) return BadRequest("ID must be greater than 0");
         var folder = RepoFactory.ImportFolder.GetByID(folderID);
         if (folder == null)
         {
@@ -95,7 +95,7 @@ public class ImportFolderController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpPatch("{folderID}")]
-    public ActionResult PatchImportFolderByFolderID([FromRoute] int folderID,
+    public ActionResult PatchImportFolderByFolderID([FromRoute, Range(1, int.MaxValue)] int folderID,
         [FromBody] JsonPatchDocument<ImportFolder> patch)
     {
         if (patch == null)
@@ -163,14 +163,9 @@ public class ImportFolderController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpDelete("{folderID}")]
-    public async Task<ActionResult> DeleteImportFolderByFolderID([FromRoute] int folderID, [FromQuery] bool removeRecords = true,
+    public async Task<ActionResult> DeleteImportFolderByFolderID([FromRoute, Range(1, int.MaxValue)] int folderID, [FromQuery] bool removeRecords = true,
         [FromQuery] bool updateMyList = true)
     {
-        if (folderID == 0)
-        {
-            return NotFound("Folder not found.");
-        }
-
         if (!removeRecords)
         {
             // These are annoying to clean up later, so do it now. We can easily recreate them.
@@ -195,7 +190,7 @@ public class ImportFolderController : BaseController
     /// <param name="folderID">Import Folder ID</param>
     /// <returns></returns>
     [HttpGet("{folderID}/Scan")]
-    public async Task<ActionResult> ScanImportFolderByFolderID([FromRoute] int folderID)
+    public async Task<ActionResult> ScanImportFolderByFolderID([FromRoute, Range(1, int.MaxValue)] int folderID)
     {
         var folder = RepoFactory.ImportFolder.GetByID(folderID);
         if (folder == null)

--- a/Shoko.Server/API/v3/Controllers/ReleaseManagementController.cs
+++ b/Shoko.Server/API/v3/Controllers/ReleaseManagementController.cs
@@ -62,7 +62,7 @@ public class ReleaseManagementController : BaseController
     /// <returns></returns>
     [HttpGet("Series/{seriesID}")]
     public ActionResult<ListResult<Episode>> GetEpisodesForSeries(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<DataSource> includeDataFrom = null,
         [FromQuery] bool includeFiles = true,
         [FromQuery] bool includeMediaInfo = true,
@@ -72,7 +72,6 @@ public class ReleaseManagementController : BaseController
         [FromQuery, Range(0, 1000)] int pageSize = 100,
         [FromQuery, Range(1, int.MaxValue)] int page = 1)
     {
-        if (seriesID == 0) return BadRequest(SeriesController.SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return new ListResult<Episode>();
@@ -124,11 +123,10 @@ public class ReleaseManagementController : BaseController
     /// <returns></returns>
     [HttpGet("Series/{seriesID}/Episode/FilesToDelete")]
     public ActionResult<List<int>> GetFileIdsWithPreference(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery] bool ignoreVariations = true
     )
     {
-        if (seriesID == 0) return BadRequest(SeriesController.SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return new List<int>();

--- a/Shoko.Server/API/v3/Controllers/RenamerController.cs
+++ b/Shoko.Server/API/v3/Controllers/RenamerController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -514,10 +515,8 @@ public class RenamerController : BaseController
     /// <returns>A result object containing information about the relocation process.</returns>
     [Authorize("admin")]
     [HttpPost("Relocate/Location/{locationID}")]
-    public async Task<ActionResult<RelocationResult>> DirectlyRelocateFileLocation([FromRoute] int locationID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] RelocateArgs body)
+    public async Task<ActionResult<RelocationResult>> DirectlyRelocateFileLocation([FromRoute, Range(1, int.MaxValue)] int locationID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] RelocateArgs body)
     {
-        if (locationID <= 0)
-            return NotFound(FileController.FileLocationNotFoundWithLocationID);
         var fileLocation = _vlpRepository.GetByID(locationID);
         if (fileLocation == null)
             return NotFound(FileController.FileLocationNotFoundWithLocationID);

--- a/Shoko.Server/API/v3/Controllers/ReverseTreeController.cs
+++ b/Shoko.Server/API/v3/Controllers/ReverseTreeController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -38,7 +39,7 @@ public class ReverseTreeController : BaseController
     /// <param name="topLevel">Always get the top-level <see cref="Filter"/></param>
     /// <returns></returns>
     [HttpGet("Filter/{filterID}/Parent")]
-    public ActionResult<Filter> GetParentFromFilter([FromRoute] int filterID, [FromQuery] bool topLevel = false)
+    public ActionResult<Filter> GetParentFromFilter([FromRoute, Range(1, int.MaxValue)] int filterID, [FromQuery] bool topLevel = false)
     {
         var filter = RepoFactory.FilterPreset.GetByID(filterID);
         if (filter == null)
@@ -74,9 +75,8 @@ public class ReverseTreeController : BaseController
     /// <param name="topLevel">Always get the top-level <see cref="Group"/></param>
     /// <returns></returns>
     [HttpGet("Group/{groupID}/Parent")]
-    public ActionResult<Group> GetParentFromGroup([FromRoute] int groupID, [FromQuery] bool topLevel = false)
+    public ActionResult<Group> GetParentFromGroup([FromRoute, Range(1, int.MaxValue)] int groupID, [FromQuery] bool topLevel = false)
     {
-        if (groupID == 0) return BadRequest(GroupController.GroupWithZeroID);
         var group = RepoFactory.AnimeGroup.GetByID(groupID);
         if (group == null)
         {
@@ -114,9 +114,8 @@ public class ReverseTreeController : BaseController
     /// <param name="topLevel">Always get the top-level <see cref="Group"/></param>
     /// <returns></returns>
     [HttpGet("Series/{seriesID}/Group")]
-    public ActionResult<Group> GetGroupFromSeries([FromRoute] int seriesID, [FromQuery] bool topLevel = false)
+    public ActionResult<Group> GetGroupFromSeries([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromQuery] bool topLevel = false)
     {
-        if (seriesID == 0) return BadRequest(SeriesController.SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -145,7 +144,7 @@ public class ReverseTreeController : BaseController
     /// <param name="includeDataFrom">Include data from selected <see cref="DataSource"/>s.</param>
     /// <returns></returns>
     [HttpGet("Episode/{episodeID}/Series")]
-    public ActionResult<Series> GetSeriesFromEpisode([FromRoute] int episodeID, [FromQuery] bool randomImages = false,
+    public ActionResult<Series> GetSeriesFromEpisode([FromRoute, Range(1, int.MaxValue)] int episodeID, [FromQuery] bool randomImages = false,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<DataSource> includeDataFrom = null)
     {
         var episode = RepoFactory.AnimeEpisode.GetByID(episodeID);
@@ -180,7 +179,7 @@ public class ReverseTreeController : BaseController
     /// <returns></returns>
     [HttpGet("File/{fileID}/Episode")]
     public ActionResult<List<Episode>> GetEpisodeFromFile(
-        [FromRoute] int fileID,
+        [FromRoute, Range(1, int.MaxValue)] int fileID,
         [FromQuery] bool includeFiles = false,
         [FromQuery] bool includeMediaInfo = false,
         [FromQuery] bool includeAbsolutePaths = false,

--- a/Shoko.Server/API/v3/Controllers/SeriesController.cs
+++ b/Shoko.Server/API/v3/Controllers/SeriesController.cs
@@ -77,8 +77,6 @@ public class SeriesController : BaseController
 
     #region Return messages
 
-    internal const string SeriesWithZeroID = "SeriesID must be greater than 0";
-
     internal const string SeriesNotFoundWithSeriesID = "No Series entry for the given seriesID";
 
     internal const string SeriesNotFoundWithAnidbID = "No Series entry for the given anidbID";
@@ -142,10 +140,9 @@ public class SeriesController : BaseController
     /// <param name="includeDataFrom">Include data from selected <see cref="DataSource"/>s.</param>
     /// <returns></returns>
     [HttpGet("{seriesID}")]
-    public ActionResult<Series> GetSeries([FromRoute] int seriesID, [FromQuery] bool randomImages = false,
+    public ActionResult<Series> GetSeries([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromQuery] bool randomImages = false,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<DataSource> includeDataFrom = null)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -169,11 +166,8 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpDelete("{seriesID}")]
-    public async Task<ActionResult> DeleteSeries([FromRoute] int seriesID, [FromQuery] bool deleteFiles = false, [FromQuery] bool completelyRemove = false)
+    public async Task<ActionResult> DeleteSeries([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromQuery] bool deleteFiles = false, [FromQuery] bool completelyRemove = false)
     {
-        if (seriesID == 0)
-            return BadRequest(SeriesWithZeroID);
-
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -191,11 +185,8 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpPost("{seriesID}/OverrideTitle")]
-    public ActionResult OverrideSeriesTitle([FromRoute] int seriesID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Series.Input.TitleOverrideBody body)
+    public ActionResult OverrideSeriesTitle([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Series.Input.TitleOverrideBody body)
     {
-        if (seriesID == 0)
-            return BadRequest(SeriesWithZeroID);
-
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -222,9 +213,8 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpGet("{seriesID}/AutoMatchSettings")]
-    public ActionResult<Series.AutoMatchSettings> GetAutoMatchSettingsBySeriesID([FromRoute] int seriesID)
+    public ActionResult<Series.AutoMatchSettings> GetAutoMatchSettingsBySeriesID([FromRoute, Range(1, int.MaxValue)] int seriesID)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -244,9 +234,8 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpPatch("{seriesID}/AutoMatchSettings")]
-    public ActionResult<Series.AutoMatchSettings> PatchAutoMatchSettingsBySeriesID([FromRoute] int seriesID, [FromBody] JsonPatchDocument<Series.AutoMatchSettings> patchDocument)
+    public ActionResult<Series.AutoMatchSettings> PatchAutoMatchSettingsBySeriesID([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromBody] JsonPatchDocument<Series.AutoMatchSettings> patchDocument)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -273,9 +262,8 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpPut("{seriesID}/AutoMatchSettings")]
-    public ActionResult<Series.AutoMatchSettings> PutAutoMatchSettingsBySeriesID([FromRoute] int seriesID, [FromBody] Series.AutoMatchSettings autoMatchSettings)
+    public ActionResult<Series.AutoMatchSettings> PutAutoMatchSettingsBySeriesID([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromBody] Series.AutoMatchSettings autoMatchSettings)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -292,9 +280,8 @@ public class SeriesController : BaseController
     /// <param name="seriesID">Shoko ID</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/Relations")]
-    public ActionResult<List<SeriesRelation>> GetShokoRelationsBySeriesID([FromRoute] int seriesID)
+    public ActionResult<List<SeriesRelation>> GetShokoRelationsBySeriesID([FromRoute, Range(1, int.MaxValue)] int seriesID)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -455,9 +442,8 @@ public class SeriesController : BaseController
     /// <param name="seriesID">Shoko ID</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/AniDB")]
-    public ActionResult<Series.AniDB> GetSeriesAnidbBySeriesID([FromRoute] int seriesID)
+    public ActionResult<Series.AniDB> GetSeriesAnidbBySeriesID([FromRoute, Range(1, int.MaxValue)] int seriesID)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -484,9 +470,8 @@ public class SeriesController : BaseController
     /// <param name="seriesID">Shoko ID</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/AniDB/Similar")]
-    public ActionResult<List<Series.AniDB>> GetAnidbSimilarBySeriesID([FromRoute] int seriesID)
+    public ActionResult<List<Series.AniDB>> GetAnidbSimilarBySeriesID([FromRoute, Range(1, int.MaxValue)] int seriesID)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -515,9 +500,8 @@ public class SeriesController : BaseController
     /// <param name="seriesID">Shoko ID</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/AniDB/Related")]
-    public ActionResult<List<Series.AniDB>> GetAnidbRelatedBySeriesID([FromRoute] int seriesID)
+    public ActionResult<List<Series.AniDB>> GetAnidbRelatedBySeriesID([FromRoute, Range(1, int.MaxValue)] int seriesID)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -546,9 +530,8 @@ public class SeriesController : BaseController
     /// <param name="seriesID">Shoko ID</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/AniDB/Relations")]
-    public ActionResult<List<SeriesRelation>> GetAnidbRelationsBySeriesID([FromRoute] int seriesID)
+    public ActionResult<List<SeriesRelation>> GetAnidbRelationsBySeriesID([FromRoute, Range(1, int.MaxValue)] int seriesID)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -891,11 +874,10 @@ public class SeriesController : BaseController
     /// <param name="cacheOnly">Only used data from the cache when performing the refresh. <paramref name="force"/> takes precedence over this option.</param>
     /// <returns>True if the refresh is done, otherwise false if it was queued.</returns>
     [HttpPost("{seriesID}/AniDB/Refresh")]
-    public async Task<ActionResult<bool>> RefreshAniDBBySeriesID([FromRoute] int seriesID, [FromQuery] bool force = false,
+    public async Task<ActionResult<bool>> RefreshAniDBBySeriesID([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromQuery] bool force = false,
         [FromQuery] bool downloadRelations = false, [FromQuery] bool? createSeriesEntry = null,
         [FromQuery] bool immediate = false, [FromQuery] bool cacheOnly = false)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         if (!createSeriesEntry.HasValue)
         {
             var settings = SettingsProvider.GetSettings();
@@ -931,7 +913,7 @@ public class SeriesController : BaseController
     /// <returns>True if the refresh is done, otherwise false if it failed.</returns>
     [HttpPost("{seriesID}/AniDB/Refresh/ForceFromXML")]
     [Obsolete("Use Refresh with cacheOnly set to true")]
-    public async Task<ActionResult<bool>> RefreshAniDBFromXML([FromRoute] int seriesID)
+    public async Task<ActionResult<bool>> RefreshAniDBFromXML([FromRoute, Range(1, int.MaxValue)] int seriesID)
         => await RefreshAniDBBySeriesID(seriesID, false, false, true, true, true);
 
     #endregion
@@ -944,9 +926,8 @@ public class SeriesController : BaseController
     /// <param name="seriesID">Shoko ID</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/TvDB")]
-    public ActionResult<List<Series.TvDB>> GetSeriesTvdb([FromRoute] int seriesID)
+    public ActionResult<List<Series.TvDB>> GetSeriesTvdb([FromRoute, Range(1, int.MaxValue)] int seriesID)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -972,9 +953,8 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpPost("{seriesID}/TvDB")]
-    public async Task<ActionResult> LinkTvDB([FromRoute] int seriesID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Series.Input.LinkCommonBody body)
+    public async Task<ActionResult> LinkTvDB([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Series.Input.LinkCommonBody body)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(TvdbNotFoundForSeriesID);
@@ -996,9 +976,8 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpDelete("{seriesID}/TvDB")]
-    public ActionResult UnlinkTvDB([FromRoute] int seriesID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Series.Input.UnlinkCommonBody body)
+    public ActionResult UnlinkTvDB([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Series.Input.UnlinkCommonBody body)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(TvdbNotFoundForSeriesID);
@@ -1024,9 +1003,8 @@ public class SeriesController : BaseController
     /// <param name="force">Forcefully retrieve updated data from TvDB</param>
     /// <returns></returns>
     [HttpPost("{seriesID}/TvDB/Refresh")]
-    public async Task<ActionResult> RefreshSeriesTvdbBySeriesID([FromRoute] int seriesID, [FromQuery] bool force = false)
+    public async Task<ActionResult> RefreshSeriesTvdbBySeriesID([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromQuery] bool force = false)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -1136,7 +1114,7 @@ public class SeriesController : BaseController
     /// <returns>Void.</returns>
     [HttpGet("{seriesID}/TMDB/Action/AutoSearch")]
     public async Task<ActionResult<List<TmdbSearch.AutoMatchResult>>> PreviewAutoMatchTMDBMoviesBySeriesID(
-        [FromRoute] int seriesID
+        [FromRoute, Range(1, int.MaxValue)] int seriesID
     )
     {
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
@@ -1164,7 +1142,7 @@ public class SeriesController : BaseController
     /// <returns>Void.</returns>
     [HttpPost("{seriesID}/TMDB/Action/AutoSearch")]
     public async Task<ActionResult> ScheduleAutoMatchTMDBMoviesBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery] bool force = false
     )
     {
@@ -1191,7 +1169,7 @@ public class SeriesController : BaseController
     /// <returns>All TMDB Movies linked to the Shoko Series.</returns>
     [HttpGet("{seriesID}/TMDB/Movie")]
     public ActionResult<List<TmdbMovie>> GetTMDBMoviesBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<TmdbMovie.IncludeDetails> include = null,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<TitleLanguage> language = null
     )
@@ -1219,7 +1197,7 @@ public class SeriesController : BaseController
     [Authorize("admin")]
     [HttpPost("{seriesID}/TMDB/Movie")]
     public async Task<ActionResult> AddLinkToTMDBMoviesBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Series.Input.LinkMovieBody body
     )
     {
@@ -1254,7 +1232,7 @@ public class SeriesController : BaseController
     [Authorize("admin")]
     [HttpDelete("{seriesID}/TMDB/Movie")]
     public async Task<ActionResult> RemoveLinkToTMDBMoviesBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Series.Input.UnlinkCommonBody body
     )
     {
@@ -1285,7 +1263,7 @@ public class SeriesController : BaseController
     [Authorize("admin")]
     [HttpPost("{seriesID}/TMDB/Movie/Action/Refresh")]
     public async Task<ActionResult> RefreshTMDBMoviesBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery] bool force = false,
         [FromQuery] bool downloadImages = true,
         [FromQuery] bool? downloadCrewAndCast = null,
@@ -1312,7 +1290,7 @@ public class SeriesController : BaseController
     /// <returns>All TMDB Movie cross-references for the Shoko Series.</returns>
     [HttpGet("{seriesID}/TMDB/Movie/CrossReferences")]
     public ActionResult<IReadOnlyList<TmdbMovie.CrossReference>> GetTMDBMovieCrossReferenceBySeriesID(
-        [FromRoute] int seriesID
+        [FromRoute, Range(1, int.MaxValue)] int seriesID
     )
     {
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
@@ -1341,7 +1319,7 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [HttpGet("{seriesID}/TMDB/Show")]
     public ActionResult<List<TmdbShow>> GetTMDBShowsBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<TmdbShow.IncludeDetails> include = null,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<TitleLanguage> language = null
     )
@@ -1369,7 +1347,7 @@ public class SeriesController : BaseController
     [Authorize("admin")]
     [HttpPost("{seriesID}/TMDB/Show")]
     public async Task<ActionResult> AddLinkToTMDBShowsBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Series.Input.LinkShowBody body
     )
     {
@@ -1404,7 +1382,7 @@ public class SeriesController : BaseController
     [Authorize("admin")]
     [HttpDelete("{seriesID}/TMDB/Show")]
     public async Task<ActionResult> RemoveLinkToTMDBShowsBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Series.Input.UnlinkCommonBody body
     )
     {
@@ -1435,7 +1413,7 @@ public class SeriesController : BaseController
     [Authorize("admin")]
     [HttpPost("{seriesID}/TMDB/Show/Action/Refresh")]
     public async Task<ActionResult> RefreshTMDBShowsBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery] bool force = false,
         [FromQuery] bool downloadImages = true,
         [FromQuery] bool? downloadCrewAndCast = null,
@@ -1462,7 +1440,7 @@ public class SeriesController : BaseController
     /// <returns>All TMDB Show cross-references for the Shoko Series.</returns>
     [HttpGet("{seriesID}/TMDB/Show/CrossReferences")]
     public ActionResult<IReadOnlyList<TmdbShow.CrossReference>> GetTMDBShowCrossReferenceBySeriesID(
-        [FromRoute] int seriesID
+        [FromRoute, Range(1, int.MaxValue)] int seriesID
     )
     {
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
@@ -1491,7 +1469,7 @@ public class SeriesController : BaseController
     /// <returns>A list of TMDB episode cross-references as part of the preview result, based on the provided filtering and pagination settings.</returns>
     [HttpGet("{seriesID}/TMDB/Show/CrossReferences/Episode")]
     public ActionResult<ListResult<TmdbEpisode.CrossReference>> GetTMDBEpisodeMappingsBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery] int? tmdbShowID,
         [FromQuery, Range(0, 1000)] int pageSize = 50,
         [FromQuery, Range(1, int.MaxValue)] int page = 1
@@ -1527,7 +1505,7 @@ public class SeriesController : BaseController
     [Authorize("admin")]
     [HttpPost("{seriesID}/TMDB/Show/CrossReferences/Episode")]
     public async Task<ActionResult> OverrideTMDBEpisodeMappingsBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Series.Input.OverrideEpisodeMappingBody body
     )
     {
@@ -1607,7 +1585,7 @@ public class SeriesController : BaseController
     [Authorize("admin")]
     [HttpGet("{seriesID}/TMDB/Show/CrossReferences/Episode/Auto")]
     public ActionResult<ListResult<TmdbEpisode.CrossReference>> PreviewAutoTMDBEpisodeMappingsBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery] int? tmdbShowID,
         [FromQuery] int? tmdbSeasonID,
         [FromQuery] bool keepExisting = true,
@@ -1661,7 +1639,7 @@ public class SeriesController : BaseController
     [Authorize("admin")]
     [HttpPost("{seriesID}/TMDB/Show/CrossReferences/Episode/Auto")]
     public async Task<ActionResult> AutoTMDBEpisodeMappingsBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery] int? tmdbShowID,
         [FromQuery] int? tmdbSeasonID,
         [FromQuery] bool keepExisting = true
@@ -1720,7 +1698,7 @@ public class SeriesController : BaseController
     [Authorize("admin")]
     [HttpDelete("{seriesID}/TMDB/Show/CrossReferences/Episode")]
     public ActionResult RemoveTMDBEpisodeMappingsBySeriesID(
-        [FromRoute] int seriesID
+        [FromRoute, Range(1, int.MaxValue)] int seriesID
     )
     {
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
@@ -1750,7 +1728,7 @@ public class SeriesController : BaseController
     /// <returns>All TMDB Seasons indirectly linked to the Shoko Series.</returns>
     [HttpGet("{seriesID}/TMDB/Season")]
     public ActionResult<List<TmdbSeason>> GetTMDBSeasonsBySeriesID(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<TmdbSeason.IncludeDetails> include = null,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<TitleLanguage> language = null
     )
@@ -1805,7 +1783,7 @@ public class SeriesController : BaseController
     /// <returns>A list of episodes based on the specified filters.</returns>
     [HttpGet("{seriesID}/Episode")]
     public ActionResult<ListResult<Episode>> GetEpisodes(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery, Range(0, 1000)] int pageSize = 20,
         [FromQuery, Range(1, int.MaxValue)] int page = 1,
         [FromQuery] IncludeOnlyFilter includeMissing = IncludeOnlyFilter.False,
@@ -1821,7 +1799,6 @@ public class SeriesController : BaseController
         [FromQuery] bool fuzzy = true
     )
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -1847,7 +1824,7 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [HttpPost("{seriesID}/Episode/Watched")]
     public async Task<ActionResult> MarkSeriesWatched(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery] bool value = true,
         [FromQuery] IncludeOnlyFilter includeMissing = IncludeOnlyFilter.False,
         [FromQuery] IncludeOnlyFilter includeHidden = IncludeOnlyFilter.False,
@@ -1856,7 +1833,6 @@ public class SeriesController : BaseController
         [FromQuery] string search = null,
         [FromQuery] bool fuzzy = true)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -2110,7 +2086,7 @@ public class SeriesController : BaseController
     /// <param name="includeDataFrom">Include data from selected <see cref="DataSource"/>s.</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/NextUpEpisode")]
-    public ActionResult<Episode> GetNextUnwatchedEpisode([FromRoute] int seriesID,
+    public ActionResult<Episode> GetNextUnwatchedEpisode([FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery] bool onlyUnwatched = true,
         [FromQuery] bool includeSpecials = true,
         [FromQuery] bool includeMissing = true,
@@ -2123,7 +2099,6 @@ public class SeriesController : BaseController
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<DataSource> includeDataFrom = null)
     {
         var user = User;
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -2156,9 +2131,8 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpPost("{seriesID}/File/Rescan")]
-    public async Task<ActionResult> RescanSeriesFiles([FromRoute] int seriesID, [FromQuery] bool priority = false)
+    public async Task<ActionResult> RescanSeriesFiles([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromQuery] bool priority = false)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -2195,9 +2169,8 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpPost("{seriesID}/File/Rehash")]
-    public async Task<ActionResult> RehashSeriesFiles([FromRoute] int seriesID)
+    public async Task<ActionResult> RehashSeriesFiles([FromRoute, Range(1, int.MaxValue)] int seriesID)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -2234,9 +2207,8 @@ public class SeriesController : BaseController
     /// <param name="vote"></param>
     /// <returns></returns>
     [HttpPost("{seriesID}/Vote")]
-    public async Task<ActionResult> PostSeriesUserVote([FromRoute] int seriesID, [FromBody] Vote vote)
+    public async Task<ActionResult> PostSeriesUserVote([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromBody] Vote vote)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -2277,9 +2249,8 @@ public class SeriesController : BaseController
     /// <param name="includeDisabled"></param>
     /// <returns></returns>
     [HttpGet("{seriesID}/Images")]
-    public ActionResult<Images> GetSeriesImages([FromRoute] int seriesID, [FromQuery] bool includeDisabled)
+    public ActionResult<Images> GetSeriesImages([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromQuery] bool includeDisabled)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -2305,13 +2276,12 @@ public class SeriesController : BaseController
     /// <param name="imageType">Poster, Banner, Fanart</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/Images/{imageType}")]
-    public ActionResult<Image> GetSeriesDefaultImageForType([FromRoute] int seriesID,
+    public ActionResult<Image> GetSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromRoute] Image.ImageType imageType)
     {
         if (!_allowedImageTypes.Contains(imageType))
             return NotFound();
 
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -2344,13 +2314,12 @@ public class SeriesController : BaseController
     /// <param name="body">The body containing the source and id used to set.</param>
     /// <returns></returns>
     [HttpPut("{seriesID}/Images/{imageType}")]
-    public ActionResult<Image> SetSeriesDefaultImageForType([FromRoute] int seriesID,
+    public ActionResult<Image> SetSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromRoute] Image.ImageType imageType, [FromBody] Image.Input.DefaultImageBody body)
     {
         if (!_allowedImageTypes.Contains(imageType))
             return NotFound();
 
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -2387,13 +2356,12 @@ public class SeriesController : BaseController
     /// <param name="imageType">Poster, Banner, Fanart</param>
     /// <returns></returns>
     [HttpDelete("{seriesID}/Images/{imageType}")]
-    public ActionResult DeleteSeriesDefaultImageForType([FromRoute] int seriesID, [FromRoute] Image.ImageType imageType)
+    public ActionResult DeleteSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromRoute] Image.ImageType imageType)
     {
         if (!_allowedImageTypes.Contains(imageType))
             return NotFound();
 
         // Check if the series exists and if the user can access the series.
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);
@@ -2433,11 +2401,10 @@ public class SeriesController : BaseController
     /// <param name="onlyVerified">Only show verified tags.</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/Tags")]
-    public ActionResult<List<Tag>> GetSeriesTags([FromRoute] int seriesID, [FromQuery] TagFilter.Filter filter = 0,
+    public ActionResult<List<Tag>> GetSeriesTags([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromQuery] TagFilter.Filter filter = 0,
         [FromQuery] bool excludeDescriptions = false, [FromQuery] bool orderByName = false,
         [FromQuery] bool onlyVerified = true)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -2466,7 +2433,7 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [HttpGet("{seriesID}/Tags/User")]
     public ActionResult<List<Tag>> GetSeriesUserTags(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery] bool excludeDescriptions = false)
         => GetSeriesTags(seriesID, TagFilter.Filter.User | TagFilter.Filter.Invert, excludeDescriptions, true, true);
 
@@ -2479,11 +2446,10 @@ public class SeriesController : BaseController
     [HttpPost("{seriesID}/Tags/User")]
     [Authorize("admin")]
     public ActionResult AddSeriesUserTags(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Series.Input.AddOrRemoveUserTagsBody body
     )
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -2522,11 +2488,10 @@ public class SeriesController : BaseController
     [HttpDelete("{seriesID}/Tags/User")]
     [Authorize("admin")]
     public ActionResult RemoveSeriesUserTags(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Series.Input.AddOrRemoveUserTagsBody body
     )
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -2559,10 +2524,9 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [HttpGet("{seriesID}/Tags/{filter}")]
     [Obsolete("Use Tags with query parameter instead.")]
-    public ActionResult<List<Tag>> GetSeriesTagsFromPath([FromRoute] int seriesID, [FromRoute] TagFilter.Filter filter,
+    public ActionResult<List<Tag>> GetSeriesTagsFromPath([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromRoute] TagFilter.Filter filter,
         [FromQuery] bool excludeDescriptions = false)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         return GetSeriesTags(seriesID, filter, excludeDescriptions);
     }
 
@@ -2577,10 +2541,9 @@ public class SeriesController : BaseController
     /// <param name="roleType">Filter by role type</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/Cast")]
-    public ActionResult<List<Role>> GetSeriesCast([FromRoute] int seriesID,
+    public ActionResult<List<Role>> GetSeriesCast([FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<Role.CreatorRoleType> roleType = null)
     {
-        if (seriesID == 0) return BadRequest(SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
         {
@@ -2607,14 +2570,8 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpPatch("{seriesID}/Move/{groupID}")]
-    public ActionResult MoveSeries([FromRoute] int seriesID, [FromRoute] int groupID)
+    public ActionResult MoveSeries([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromRoute, Range(1, int.MaxValue)] int groupID)
     {
-        if (seriesID == 0)
-            return BadRequest(SeriesWithZeroID);
-
-        if (groupID == 0)
-            return BadRequest(GroupController.GroupWithZeroID);
-
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
             return NotFound(SeriesNotFoundWithSeriesID);

--- a/Shoko.Server/API/v3/Controllers/TagController.cs
+++ b/Shoko.Server/API/v3/Controllers/TagController.cs
@@ -119,9 +119,9 @@ public class TagController : BaseController
     /// <param name="excludeDescription">Exclude tag description from response.</param>
     /// <returns></returns>
     [HttpGet("User/{tagID}")]
-    public ActionResult<Tag> GetUserTag([FromRoute] int tagID, [FromQuery] bool excludeDescription = false)
+    public ActionResult<Tag> GetUserTag([FromRoute, Range(1, int.MaxValue)] int tagID, [FromQuery] bool excludeDescription = false)
     {
-        var tag = tagID <= 0 ? null : RepoFactory.CustomTag.GetByID(tagID);
+        var tag = RepoFactory.CustomTag.GetByID(tagID);
         if (tag == null)
             return NotFound("No User Tag entry for the given tagID");
 
@@ -136,9 +136,9 @@ public class TagController : BaseController
     /// <returns>The updated user tag, or an error action result.</returns>
     [HttpPut("User/{tagID}")]
     [Authorize("admin")]
-    public ActionResult<Tag> EditUserTag([FromRoute] int tagID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Tag.Input.CreateOrUpdateCustomTagBody body)
+    public ActionResult<Tag> EditUserTag([FromRoute, Range(1, int.MaxValue)] int tagID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Tag.Input.CreateOrUpdateCustomTagBody body)
     {
-        var tag = tagID <= 0 ? null : RepoFactory.CustomTag.GetByID(tagID);
+        var tag = RepoFactory.CustomTag.GetByID(tagID);
         if (tag == null)
             return NotFound("No User Tag entry for the given tagID");
 
@@ -158,9 +158,9 @@ public class TagController : BaseController
     /// <returns>The updated user tag, or an error action result.</returns>
     [HttpPatch("User/{tagID}")]
     [Authorize("admin")]
-    public ActionResult<Tag> PatchUserTag([FromRoute] int tagID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] JsonPatchDocument<Tag.Input.CreateOrUpdateCustomTagBody> patchDocument)
+    public ActionResult<Tag> PatchUserTag([FromRoute, Range(1, int.MaxValue)] int tagID, [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] JsonPatchDocument<Tag.Input.CreateOrUpdateCustomTagBody> patchDocument)
     {
-        var tag = tagID <= 0 ? null : RepoFactory.CustomTag.GetByID(tagID);
+        var tag = RepoFactory.CustomTag.GetByID(tagID);
         if (tag == null)
             return NotFound("No User Tag entry for the given tagID");
         var body = new Tag.Input.CreateOrUpdateCustomTagBody();
@@ -182,9 +182,9 @@ public class TagController : BaseController
     /// <returns>No content or an error action result.</returns>
     [HttpDelete("User/{tagID}")]
     [Authorize("admin")]
-    public ActionResult RemoveUserTag([FromRoute] int tagID)
+    public ActionResult RemoveUserTag([FromRoute, Range(1, int.MaxValue)] int tagID)
     {
-        var tag = tagID <= 0 ? null : RepoFactory.CustomTag.GetByID(tagID);
+        var tag = RepoFactory.CustomTag.GetByID(tagID);
         if (tag == null)
             return NotFound("No User Tag entry for the given tagID");
 

--- a/Shoko.Server/API/v3/Controllers/TreeController.cs
+++ b/Shoko.Server/API/v3/Controllers/TreeController.cs
@@ -43,7 +43,7 @@ public class TreeController : BaseController
     /// <param name="includeDataFrom">Include data from selected <see cref="DataSource"/>s.</param>
     /// <returns></returns>
     [HttpGet("ImportFolder/{folderID}/File")]
-    public ActionResult<ListResult<File>> GetFilesInImportFolder([FromRoute] int folderID,
+    public ActionResult<ListResult<File>> GetFilesInImportFolder([FromRoute, Range(1, int.MaxValue)] int folderID,
         [FromQuery, Range(0, 10000)] int pageSize = 200,
         [FromQuery, Range(1, int.MaxValue)] int page = 1,
         [FromQuery] string folderPath = null,
@@ -52,7 +52,7 @@ public class TreeController : BaseController
     {
         include ??= [];
 
-        var importFolder = folderID > 0 ? RepoFactory.ImportFolder.GetByID(folderID) : null;
+        var importFolder = RepoFactory.ImportFolder.GetByID(folderID);
         if (importFolder == null)
             return NotFound("Import folder not found: " + folderID);
 
@@ -104,7 +104,7 @@ public class TreeController : BaseController
     /// <param name="showHidden">Show hidden filters</param>
     /// <returns></returns>
     [HttpGet("Filter/{filterID}/Filter")]
-    public ActionResult<ListResult<Filter>> GetSubFilters([FromRoute] int filterID,
+    public ActionResult<ListResult<Filter>> GetSubFilters([FromRoute, Range(1, int.MaxValue)] int filterID,
         [FromQuery, Range(0, 100)] int pageSize = 50, [FromQuery, Range(1, int.MaxValue)] int page = 1,
         [FromQuery] bool showHidden = false)
     {
@@ -137,7 +137,7 @@ public class TreeController : BaseController
     /// <param name="orderByName">Ignore the group filter sort criteria and always order the returned list by name.</param>
     /// <returns></returns>
     [HttpGet("Filter/{filterID}/Group")]
-    public ActionResult<ListResult<Group>> GetFilteredGroups([FromRoute] int filterID,
+    public ActionResult<ListResult<Group>> GetFilteredGroups([FromRoute, Range(0, int.MaxValue)] int filterID,
         [FromQuery, Range(0, 100)] int pageSize = 50, [FromQuery, Range(1, int.MaxValue)] int page = 1,
         [FromQuery] bool includeEmpty = false, [FromQuery] bool randomImages = false, [FromQuery] bool orderByName = false)
     {
@@ -208,12 +208,12 @@ public class TreeController : BaseController
     /// <see cref="Episode"/>s in the count.</param>
     /// <returns></returns>
     [HttpGet("Filter/{filterID}/Group/Letters")]
-    public ActionResult<Dictionary<char, int>> GetGroupNameLettersInFilter([FromRoute] int? filterID = null, [FromQuery] bool includeEmpty = false)
+    public ActionResult<Dictionary<char, int>> GetGroupNameLettersInFilter([FromRoute, Range(0, int.MaxValue)] int filterID, [FromQuery] bool includeEmpty = false)
     {
         var user = User;
-        if (filterID.HasValue && filterID > 0)
+        if (filterID > 0)
         {
-            var filterPreset = RepoFactory.FilterPreset.GetByID(filterID.Value);
+            var filterPreset = RepoFactory.FilterPreset.GetByID(filterID);
             if (filterPreset == null)
                 return NotFound(FilterController.FilterNotFound);
 
@@ -275,7 +275,7 @@ public class TreeController : BaseController
     /// <see cref="Episode"/>s in the count.</param>
     /// <returns></returns>
     [HttpGet("Filter/{filterID}/Series")]
-    public ActionResult<ListResult<Series>> GetSeriesInFilteredGroup([FromRoute] int filterID,
+    public ActionResult<ListResult<Series>> GetSeriesInFilteredGroup([FromRoute, Range(0, int.MaxValue)] int filterID,
         [FromQuery, Range(0, 100)] int pageSize = 50, [FromQuery, Range(1, int.MaxValue)] int page = 1,
         [FromQuery] bool randomImages = false, [FromQuery] bool includeMissing = false)
     {
@@ -320,7 +320,7 @@ public class TreeController : BaseController
     /// <param name="includeEmpty">Include <see cref="Series"/> with missing <see cref="Episode"/>s in the search.</param>
     /// <returns></returns>
     [HttpGet("Filter/{filterID}/Group/{groupID}/Group")]
-    public ActionResult<List<Group>> GetFilteredSubGroups([FromRoute] int filterID, [FromRoute] int groupID,
+    public ActionResult<List<Group>> GetFilteredSubGroups([FromRoute, Range(0, int.MaxValue)] int filterID, [FromRoute, Range(1, int.MaxValue)] int groupID,
         [FromQuery] bool randomImages = false, [FromQuery] bool includeEmpty = false)
     {
         // Return sub-groups with no group filter applied.
@@ -332,7 +332,6 @@ public class TreeController : BaseController
             return NotFound(FilterController.FilterNotFound);
 
         // Check if the group exists.
-        if (groupID == 0) return BadRequest(GroupController.GroupWithZeroID);
         var group = RepoFactory.AnimeGroup.GetByID(groupID);
         if (group == null)
             return NotFound(GroupController.GroupNotFound);
@@ -392,11 +391,10 @@ public class TreeController : BaseController
     /// <param name="includeDataFrom">Include data from selected <see cref="DataSource"/>s.</param>
     /// /// <returns></returns>
     [HttpGet("Filter/{filterID}/Group/{groupID}/Series")]
-    public ActionResult<List<Series>> GetSeriesInFilteredGroup([FromRoute] int filterID, [FromRoute] int groupID,
+    public ActionResult<List<Series>> GetSeriesInFilteredGroup([FromRoute, Range(0, int.MaxValue)] int filterID, [FromRoute, Range(1, int.MaxValue)] int groupID,
         [FromQuery] bool recursive = false, [FromQuery] bool includeMissing = false,
         [FromQuery] bool randomImages = false, [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<DataSource> includeDataFrom = null)
     {
-        if (groupID == 0) return BadRequest(GroupController.GroupWithZeroID);
         // Return the groups with no group filter applied.
         if (filterID == 0)
             return GetSeriesInGroup(groupID, recursive, includeMissing, randomImages, includeDataFrom);
@@ -451,11 +449,10 @@ public class TreeController : BaseController
     /// <param name="includeEmpty">Include <see cref="Series"/> with missing <see cref="Episode"/>s in the search.</param>
     /// <returns></returns>
     [HttpGet("Group/{groupID}/Group")]
-    public ActionResult<List<Group>> GetSubGroups([FromRoute] int groupID, [FromQuery] bool randomImages = false,
+    public ActionResult<List<Group>> GetSubGroups([FromRoute, Range(1, int.MaxValue)] int groupID, [FromQuery] bool randomImages = false,
         [FromQuery] bool includeEmpty = false)
     {
         // Check if the group exists.
-        if (groupID == 0) return BadRequest(GroupController.GroupWithZeroID);
         var group = RepoFactory.AnimeGroup.GetByID(groupID);
         if (group == null)
             return NotFound(GroupController.GroupNotFound);
@@ -495,12 +492,11 @@ public class TreeController : BaseController
     /// <param name="includeDataFrom">Include data from selected <see cref="DataSource"/>s.</param>
     /// <returns></returns>
     [HttpGet("Group/{groupID}/Series")]
-    public ActionResult<List<Series>> GetSeriesInGroup([FromRoute] int groupID, [FromQuery] bool recursive = false,
+    public ActionResult<List<Series>> GetSeriesInGroup([FromRoute, Range(1, int.MaxValue)] int groupID, [FromQuery] bool recursive = false,
         [FromQuery] bool includeMissing = false, [FromQuery] bool randomImages = false,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<DataSource> includeDataFrom = null)
     {
         // Check if the group exists.
-        if (groupID == 0) return BadRequest(GroupController.GroupWithZeroID);
         var group = RepoFactory.AnimeGroup.GetByID(groupID);
         if (group == null)
             return NotFound(GroupController.GroupNotFound);
@@ -527,11 +523,10 @@ public class TreeController : BaseController
     /// <param name="includeDataFrom">Include data from selected <see cref="DataSource"/>s.</param>
     /// <returns></returns>
     [HttpGet("Group/{groupID}/MainSeries")]
-    public ActionResult<Series> GetMainSeriesInGroup([FromRoute] int groupID, [FromQuery] bool randomImages = false,
+    public ActionResult<Series> GetMainSeriesInGroup([FromRoute, Range(1, int.MaxValue)] int groupID, [FromQuery] bool randomImages = false,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<DataSource> includeDataFrom = null)
     {
         // Check if the group exists.
-        if (groupID == 0) return BadRequest(GroupController.GroupWithZeroID);
         var group = RepoFactory.AnimeGroup.GetByID(groupID);
         if (group == null)
             return NotFound(GroupController.GroupNotFound);
@@ -563,7 +558,7 @@ public class TreeController : BaseController
     /// <param name="includeDataFrom">Include data from selected <see cref="DataSource"/>s.</param>
     /// <returns></returns>
     [HttpGet("Series/{seriesID}/File")]
-    public ActionResult<ListResult<File>> GetFilesForSeries([FromRoute] int seriesID,
+    public ActionResult<ListResult<File>> GetFilesForSeries([FromRoute, Range(1, int.MaxValue)] int seriesID,
     [FromQuery, Range(0, 1000)] int pageSize = 100,
     [FromQuery, Range(1, int.MaxValue)] int page = 1,
     [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] FileNonDefaultIncludeType[] include = default,
@@ -572,7 +567,6 @@ public class TreeController : BaseController
     [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] List<string> sortOrder = null,
     [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<DataSource> includeDataFrom = null)
     {
-        if (seriesID == 0) return BadRequest(SeriesController.SeriesWithZeroID);
         var user = User;
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series == null)
@@ -599,7 +593,7 @@ public class TreeController : BaseController
     /// <param name="includeDataFrom">Include data from selected <see cref="DataSource"/>s.</param>
     /// <returns></returns>
     [HttpGet("Episode/{episodeID}/File")]
-    public ActionResult<ListResult<File>> GetFilesForEpisode([FromRoute] int episodeID,
+    public ActionResult<ListResult<File>> GetFilesForEpisode([FromRoute, Range(1, int.MaxValue)] int episodeID,
         [FromQuery, Range(0, 1000)] int pageSize = 100,
         [FromQuery, Range(1, int.MaxValue)] int page = 1,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] FileNonDefaultIncludeType[] include = default,

--- a/Shoko.Server/API/v3/Controllers/UserController.cs
+++ b/Shoko.Server/API/v3/Controllers/UserController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.JsonPatch;
@@ -116,7 +117,7 @@ public class UserController : BaseController
     /// <returns>The user.</returns>
     [Authorize("admin")]
     [HttpGet("{userID}")]
-    public ActionResult<User> GetUserByUserID([FromRoute] int userID)
+    public ActionResult<User> GetUserByUserID([FromRoute, Range(1, int.MaxValue)] int userID)
     {
         var user = RepoFactory.JMMUser.GetByID(userID);
         if (user == null)
@@ -136,7 +137,7 @@ public class UserController : BaseController
     /// <returns>The updated user.</returns>
     [Authorize("admin")]
     [HttpPatch("{userID}")]
-    public ActionResult<User> PatchUserByUserID([FromRoute] int userID, [FromBody] JsonPatchDocument<User.Input.CreateOrUpdateUserBody> document)
+    public ActionResult<User> PatchUserByUserID([FromRoute, Range(1, int.MaxValue)] int userID, [FromBody] JsonPatchDocument<User.Input.CreateOrUpdateUserBody> document)
     {
         var user = RepoFactory.JMMUser.GetByID(userID);
         if (user == null)
@@ -166,7 +167,7 @@ public class UserController : BaseController
     /// <returns>The updated user.</returns>
     [Authorize("admin")]
     [HttpPut("{userID}")]
-    public ActionResult<User> PutUserByUserID([FromRoute] int userID, [FromBody] User.Input.CreateOrUpdateUserBody body)
+    public ActionResult<User> PutUserByUserID([FromRoute, Range(1, int.MaxValue)] int userID, [FromBody] User.Input.CreateOrUpdateUserBody body)
     {
         var user = RepoFactory.JMMUser.GetByID(userID);
         if (user == null)
@@ -189,7 +190,7 @@ public class UserController : BaseController
     /// <returns>Void.</returns>
     [Authorize("admin")]
     [HttpDelete("{userID}")]
-    public ActionResult DeleteUser([FromRoute] int userID)
+    public ActionResult DeleteUser([FromRoute, Range(1, int.MaxValue)] int userID)
     {
         var user = RepoFactory.JMMUser.GetByID(userID);
         if (user == null)
@@ -215,7 +216,7 @@ public class UserController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpPost("{userID}/ChangePassword")]
-    public ActionResult ChangePasswordForUserByUserID([FromRoute] int userID, [FromBody] User.Input.ChangePasswordBody body) =>
+    public ActionResult ChangePasswordForUserByUserID([FromRoute, Range(1, int.MaxValue)] int userID, [FromBody] User.Input.ChangePasswordBody body) =>
         ChangePassword(RepoFactory.JMMUser.GetByID(userID), body);
 
     [NonAction]

--- a/Shoko.Server/API/v3/Controllers/WebUIController.cs
+++ b/Shoko.Server/API/v3/Controllers/WebUIController.cs
@@ -254,10 +254,8 @@ public class WebUIController : BaseController
     /// <param name="seriesID">The ID of the series to retrieve information for.</param>
     /// <returns>A <c>WebUISeriesExtra</c> object containing extra information for the series.</returns>
     [HttpGet("Series/{seriesID}")]
-    public ActionResult<WebUISeriesExtra> GetSeries([FromRoute] int seriesID)
+    public ActionResult<WebUISeriesExtra> GetSeries([FromRoute, Range(1, int.MaxValue)] int seriesID)
     {
-        if (seriesID == 0) return BadRequest(SeriesController.SeriesWithZeroID);
-
         // Retrieve extra information for the specified series if it exists and the user has permissions.
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series is null)
@@ -285,7 +283,7 @@ public class WebUIController : BaseController
     /// <returns>A <c>WebUISeriesFileSummary</c> object containing a summary of file information for the series.</returns>
     [HttpGet("Series/{seriesID}/FileSummary")]
     public ActionResult<WebUISeriesFileSummary> GetSeriesFileSummary(
-        [FromRoute] int seriesID,
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<EpisodeType> type = null,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<FileSummaryGroupByCriteria> groupBy = null,
         [FromQuery] bool includeEpisodeDetails = false,
@@ -293,7 +291,6 @@ public class WebUIController : BaseController
         [FromQuery] bool includeMissingFutureEpisodes = false)
     {
         // Retrieve a summary of file information for the specified series if it exists and the user has permissions.
-        if (seriesID == 0) return BadRequest(SeriesController.SeriesWithZeroID);
         var series = RepoFactory.AnimeSeries.GetByID(seriesID);
         if (series is null)
         {


### PR DESCRIPTION
Also made the `filterID` in `TreeController`'s  `/Filter/{filterID}/Group/Letters` a non-null since its a route param.