### PR TITLE
Fix file relocation without rename

### DIFF
--- a/Shoko.Server/Renamer/WebAOMRenamer.cs
+++ b/Shoko.Server/Renamer/WebAOMRenamer.cs
@@ -42,7 +42,7 @@ public class WebAOMRenamer : IRenamer<WebAOMSettings>
         }
 
         string newFilename = null;
-        var success = false;
+        var success = true;
         (IImportFolder dest, string folder) destination = default;
         Exception ex = null;
         try
@@ -56,6 +56,7 @@ public class WebAOMRenamer : IRenamer<WebAOMSettings>
         }
         catch (Exception e)
         {
+            success = false;
             ex = e;
         }
 

--- a/Shoko.Server/Services/VideoLocal_PlaceService.cs
+++ b/Shoko.Server/Services/VideoLocal_PlaceService.cs
@@ -526,12 +526,26 @@ public class VideoLocal_PlaceService
 
         if (result.Error != null) return new Renamer.RelocationResult() { Success = false, ShouldRetry = false, ErrorMessage = result.Error.Message, Exception = result.Error.Exception };
 
-        if (string.IsNullOrWhiteSpace(result.FileName) || result.FileName.StartsWith("*Error:"))
+        if (request.Rename && (string.IsNullOrWhiteSpace(result.FileName) || result.FileName.StartsWith("*Error:")))
         {
             var errorMessage = !string.IsNullOrWhiteSpace(result.FileName)
                 ? result.FileName[7..].Trim()
                 : "The file renamer returned a null or empty value.";
             _logger.LogError("An error occurred while trying to find a new file name for {FilePath}: {ErrorMessage}", place.FullServerPath, errorMessage);
+            return new()
+            {
+                Success = false,
+                ShouldRetry = false,
+                ErrorMessage = errorMessage,
+            };
+        }
+
+        if (request.Move && (string.IsNullOrWhiteSpace(result.Path) || result.Path.StartsWith("*Error:")))
+        {
+            var errorMessage = !string.IsNullOrWhiteSpace(result.Path)
+                ? result.Path[7..].Trim()
+                : "Could not find a valid destination.";
+            _logger.LogWarning("An error occurred while trying to find a destination for {FilePath}: {ErrorMessage}", place.FullServerPath, errorMessage);
             return new()
             {
                 Success = false,


### PR DESCRIPTION
With "Move on import" enabled and "Rename on import" disabled the file remains in the import folder for two reasons:
- in `WebAOMRenamer.cs` the variable `success` is always false, unless `GetNewFileName` is called (only if rename is enabled)
- in `VideoLocal_PlaceService.cs` there is a check on `result.FileName`, which is always null if the rename is disabled, and the file is never moved

This commit should fix that behavior.