### PR TITLE
Fix cross-platform plex sync, get episode data using both parent folder and filename

### DIFF
--- a/Shoko.Server/Plex/TVShow/SVR_Episode.cs
+++ b/Shoko.Server/Plex/TVShow/SVR_Episode.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Linq;
 using Shoko.Models.Plex.TVShow;
 using Shoko.Server.Models;
 using Shoko.Server.Repositories;
@@ -14,12 +16,24 @@ internal class SVR_Episode : Episode
         Helper = helper;
     }
 
-    public SVR_AnimeEpisode AnimeEpisode =>
-        RepoFactory.AnimeEpisode.GetByFilename(
-            Path.GetFileName(Media[0].Part[0].File
-                .Replace('\\', Path.DirectorySeparatorChar)
-                .Replace('/', Path.DirectorySeparatorChar)
-            ));
+    public SVR_AnimeEpisode AnimeEpisode
+    {
+        get
+        {
+            var normalizedPath = Media[0].Part[0].File.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+
+            var finalPath = Path.Combine(
+                Path.GetFileName(Path.GetDirectoryName(normalizedPath)) ?? string.Empty,
+                Path.GetFileName(normalizedPath)
+                );
+
+            var file = RepoFactory.VideoLocalPlace
+                .GetAll()
+                .FirstOrDefault(location => location.FullServerPath?.EndsWith(finalPath, StringComparison.OrdinalIgnoreCase) ?? false);
+
+            return string.IsNullOrEmpty(file?.Hashes.ED2K) ? null : RepoFactory.AnimeEpisode.GetByHash(file.Hashes.ED2K).FirstOrDefault();
+        }
+    }
 
     public void Unscrobble()
     {

--- a/Shoko.Server/Plex/TVShow/SVR_Episode.cs
+++ b/Shoko.Server/Plex/TVShow/SVR_Episode.cs
@@ -15,7 +15,11 @@ internal class SVR_Episode : Episode
     }
 
     public SVR_AnimeEpisode AnimeEpisode =>
-        RepoFactory.AnimeEpisode.GetByFilename(Path.GetFileName(Media[0].Part[0].File));
+        RepoFactory.AnimeEpisode.GetByFilename(
+            Path.GetFileName(Media[0].Part[0].File
+                .Replace('\\', Path.DirectorySeparatorChar)
+                .Replace('/', Path.DirectorySeparatorChar)
+            ));
 
     public void Unscrobble()
     {


### PR DESCRIPTION
Tested with plex on linux and shoko on windows, but should work the other way also.

- Plex on linux, shoko on windows
  - First replace -> no change, path doesn't have back slashes
  - Second replace -> forward slashes are replaced with back slashes
- Plex on windows, shoko on linux
  - First replace -> back slashes are replaced with forward slashes
  - Second replace -> no change, already has forward slashes
- Both plex and shoko on linux
  - First replace -> no change. Except for extreme cases where the filename somehow has `\` which it shouldn't
  - Second replace -> no change
- Both plex and shoko on windows
  - First and second replace -> no change