### PR TITLE
Add import folder filters

### DIFF
--- a/Shoko.Server/Filters/FilterExtensions.cs
+++ b/Shoko.Server/Filters/FilterExtensions.cs
@@ -122,6 +122,10 @@ public static class FilterExtensions
                     .Where(a => a.MediaInfo?.VideoStream is not null)
                     .Select(a => MediaInfoUtils.GetStandardResolution(Tuple.Create(a.MediaInfo!.VideoStream!.Width, a.MediaInfo!.VideoStream!.Height)))
                     .ToHashSet(),
+            ImportFolderIDsDelegate = () =>
+                series.VideoLocals.Select(a => a.FirstValidPlace?.ImportFolderID.ToString()).WhereNotNull().ToHashSet(),
+            ImportFolderNamesDelegate = () =>
+                series.VideoLocals.Select(a => a.FirstValidPlace?.ImportFolder?.ImportFolderName).WhereNotNull().ToHashSet(),
             FilePathsDelegate = () =>
                 series.VideoLocals.Select(a => a.FirstValidPlace?.FilePath).WhereNotNull().ToHashSet(),
         };
@@ -267,6 +271,10 @@ public static class FilterExtensions
                     .Where(a => a.MediaInfo?.VideoStream is not null)
                     .Select(a => MediaInfoUtils.GetStandardResolution(Tuple.Create(a.MediaInfo!.VideoStream!.Width, a.MediaInfo!.VideoStream!.Height)))
                     .ToHashSet(),
+            ImportFolderIDsDelegate = () =>
+                series.SelectMany(s => s.VideoLocals.Select(a => a.FirstValidPlace?.ImportFolderID.ToString())).WhereNotNull().ToHashSet(),
+            ImportFolderNamesDelegate = () =>
+                series.SelectMany(s => s.VideoLocals.Select(a => a.FirstValidPlace?.ImportFolder?.ImportFolderName)).WhereNotNull().ToHashSet(),
             FilePathsDelegate = () =>
                 series.SelectMany(s => s.VideoLocals.Select(a => a.FirstValidPlace?.FilePath)).WhereNotNull().ToHashSet(),
         };

--- a/Shoko.Server/Filters/Filterable.cs
+++ b/Shoko.Server/Filters/Filterable.cs
@@ -33,6 +33,8 @@ public class Filterable : IFilterable
     private readonly Lazy<IReadOnlySet<string>> _names;
     private readonly Lazy<IReadOnlySet<string>> _aniDbIds;
     private readonly Lazy<IReadOnlySet<string>> _resolutions;
+    private readonly Lazy<IReadOnlySet<string>> _importFolderIDs;
+    private readonly Lazy<IReadOnlySet<string>> _importFolderNames;
     private readonly Lazy<IReadOnlySet<string>> _filePaths;
     private readonly Lazy<IReadOnlySet<(int year, AnimeSeason season)>> _seasons;
     private readonly Lazy<int> _seriesCount;
@@ -305,6 +307,20 @@ public class Filterable : IFilterable
         {
             _resolutions = new Lazy<IReadOnlySet<string>>(value);
         }
+    }
+
+    public IReadOnlySet<string> ImportFolderIDs => _importFolderIDs.Value;
+
+    public Func<IReadOnlySet<string>> ImportFolderIDsDelegate
+    {
+        init => _importFolderIDs = new Lazy<IReadOnlySet<string>>(value);
+    }
+
+    public IReadOnlySet<string> ImportFolderNames => _importFolderNames.Value;
+
+    public Func<IReadOnlySet<string>> ImportFolderNamesDelegate
+    {
+        init => _importFolderNames = new Lazy<IReadOnlySet<string>>(value);
     }
 
     public IReadOnlySet<string> FilePaths => _filePaths.Value;

--- a/Shoko.Server/Filters/Interfaces/IFilterable.cs
+++ b/Shoko.Server/Filters/Interfaces/IFilterable.cs
@@ -192,6 +192,16 @@ public interface IFilterable
     IReadOnlySet<string> Resolutions { get; }
 
     /// <summary>
+    /// Import Folder IDs
+    /// </summary>
+    IReadOnlySet<string> ImportFolderIDs { get; }
+
+    /// <summary>
+    /// Import Folder Names
+    /// </summary>
+    IReadOnlySet<string> ImportFolderNames { get; }
+
+    /// <summary>
     /// Relative File Paths
     /// </summary>
     IReadOnlySet<string> FilePaths { get; }

--- a/Shoko.Server/Filters/Selectors/StringSetSelectors/ImportFolderIDsSelector.cs
+++ b/Shoko.Server/Filters/Selectors/StringSetSelectors/ImportFolderIDsSelector.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using Shoko.Server.Filters.Interfaces;
+
+namespace Shoko.Server.Filters.Selectors.StringSetSelectors;
+
+public class ImportFolderIDsSelector : FilterExpression<IReadOnlySet<string>>
+{
+    public override bool TimeDependent => false;
+    public override bool UserDependent => false;
+    public override string HelpDescription => "This returns a set of the import folder IDs in a filterable";
+    public override FilterExpressionGroup Group => FilterExpressionGroup.Selector;
+
+    public override IReadOnlySet<string> Evaluate(IFilterable filterable, IFilterableUserInfo userInfo)
+    {
+        return filterable.ImportFolderIDs;
+    }
+
+    protected bool Equals(ImportFolderIDsSelector other)
+    {
+        return base.Equals(other);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != this.GetType())
+        {
+            return false;
+        }
+
+        return Equals((ImportFolderIDsSelector)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return GetType().FullName!.GetHashCode();
+    }
+
+    public static bool operator ==(ImportFolderIDsSelector left, ImportFolderIDsSelector right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(ImportFolderIDsSelector left, ImportFolderIDsSelector right)
+    {
+        return !Equals(left, right);
+    }
+}

--- a/Shoko.Server/Filters/Selectors/StringSetSelectors/ImportFolderNamesSelector.cs
+++ b/Shoko.Server/Filters/Selectors/StringSetSelectors/ImportFolderNamesSelector.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using Shoko.Server.Filters.Interfaces;
+
+namespace Shoko.Server.Filters.Selectors.StringSetSelectors;
+
+public class ImportFolderNamesSelector : FilterExpression<IReadOnlySet<string>>
+{
+    public override bool TimeDependent => false;
+    public override bool UserDependent => false;
+    public override string HelpDescription => "This returns a set of the import folder names in a filterable";
+    public override FilterExpressionGroup Group => FilterExpressionGroup.Selector;
+
+    public override IReadOnlySet<string> Evaluate(IFilterable filterable, IFilterableUserInfo userInfo)
+    {
+        return filterable.ImportFolderNames;
+    }
+
+    protected bool Equals(ImportFolderNamesSelector other)
+    {
+        return base.Equals(other);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj))
+        {
+            return true;
+        }
+
+        if (obj.GetType() != this.GetType())
+        {
+            return false;
+        }
+
+        return Equals((ImportFolderNamesSelector)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return GetType().FullName!.GetHashCode();
+    }
+
+    public static bool operator ==(ImportFolderNamesSelector left, ImportFolderNamesSelector right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(ImportFolderNamesSelector left, ImportFolderNamesSelector right)
+    {
+        return !Equals(left, right);
+    }
+}

--- a/Shoko.Tests/Shoko.Tests/TestFilterable.cs
+++ b/Shoko.Tests/Shoko.Tests/TestFilterable.cs
@@ -44,5 +44,7 @@ public class TestFilterable : IFilterable
     public IReadOnlySet<string> SubtitleLanguages { get; init; }
     public IReadOnlySet<string> SharedSubtitleLanguages { get; init; }
     public IReadOnlySet<string> Resolutions { get; init; }
+    public IReadOnlySet<string> ImportFolderIDs { get; init; }
+    public IReadOnlySet<string> ImportFolderNames { get; init; }
     public IReadOnlySet<string> FilePaths { get; init; }
 }


### PR DESCRIPTION
Add two new filters to filter by import folder IDs or names. Both are implemented as string sets because I didn't want to add a new filter category for number sets for the IDs.

Fixes/Implements #958.

@da3dsoul if you're fine with it as-is, then please merge. Otherwise I'll be awaiting your review.