### PR TITLE
Move CheckTraktToken to a Job

### DIFF
--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -235,7 +235,7 @@ public class TraktTVHelper
 
     #region Authorization
 
-    public void RefreshAuthToken()
+    public bool RefreshAuthToken()
     {
         var settings = _settingsProvider.GetSettings();
         try
@@ -248,7 +248,7 @@ public class TraktTVHelper
                 settings.TraktTv.RefreshToken = string.Empty;
                 settings.TraktTv.TokenExpirationDate = string.Empty;
 
-                return;
+                return false;
             }
 
             var token = new TraktV2RefreshToken { refresh_token = settings.TraktTv.RefreshToken };
@@ -272,7 +272,7 @@ public class TraktTVHelper
 
                 settings.TraktTv.TokenExpirationDate = expireDate.ToString();
 
-                return;
+                return true;
             }
 
             settings.TraktTv.AuthToken = string.Empty;
@@ -286,11 +286,13 @@ public class TraktTVHelper
             settings.TraktTv.TokenExpirationDate = string.Empty;
 
             _logger.LogError(ex, "Error in TraktTVHelper.RefreshAuthToken");
+            return false;
         }
         finally
         {
             Utils.SettingsProvider.SaveSettings();
         }
+        return false;
     }
 
     #endregion

--- a/Shoko.Server/Scheduling/Jobs/Trakt/CheckTraktTokenJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Trakt/CheckTraktTokenJob.cs
@@ -23,8 +23,6 @@ public class CheckTraktTokenJob : BaseJob
     public override string TypeName => "Check and Refresh Trakt Token";
     public override string Title => "Checking and Refreshing Trakt Token";
 
-    public override Dictionary<string, object> Details => new() { { "Action", "Check and Refresh Trakt Token" } };
-
     public override Task Process()
     {
         try

--- a/Shoko.Server/Scheduling/Jobs/Trakt/CheckTraktTokenJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Trakt/CheckTraktTokenJob.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Shoko.Server.Scheduling.Acquisition.Attributes;
+using Shoko.Server.Scheduling.Attributes;
+using Shoko.Server.Scheduling.Concurrency;
+using Shoko.Server.Settings;
+using Shoko.Server.Providers.TraktTV;
+
+namespace Shoko.Server.Scheduling.Jobs.Trakt;
+
+[DatabaseRequired]
+[NetworkRequired]
+[DisallowConcurrencyGroup(ConcurrencyGroups.Trakt)]
+[JobKeyGroup(JobKeyGroup.Trakt)]
+public class CheckTraktTokenJob : BaseJob
+{
+    private readonly ISettingsProvider _settingsProvider;
+    private readonly TraktTVHelper _traktHelper;
+
+    public bool ForceRefresh;
+    public override string TypeName => "Check and Refresh Trakt Token";
+    public override string Title => "Checking and Refreshing Trakt Token";
+
+    public override Dictionary<string, object> Details => new() { { "Action", "Check and Refresh Trakt Token" } };
+
+    public override Task Process()
+    {
+        try
+        {
+            _logger.LogInformation("Processing {Job}", nameof(CheckTraktTokenJob));
+            var settings = _settingsProvider.GetSettings();
+            if (!settings.TraktTv.Enabled || string.IsNullOrEmpty(settings.TraktTv.TokenExpirationDate))
+            {
+                _logger.LogInformation("Trakt is not enabled or no token expiration date is set");
+                return Task.CompletedTask;
+            }
+
+            // Convert the Unix timestamp to DateTime
+            var expirationDate = DateTimeOffset.FromUnixTimeSeconds(long.Parse(settings.TraktTv.TokenExpirationDate)).DateTime;
+
+            // Check if the token needs refreshing
+            if (ForceRefresh || DateTime.Now.Add(TimeSpan.FromDays(45)) >= expirationDate)
+            {
+                _traktHelper.RefreshAuthToken();
+                var newExpirationDate = DateTimeOffset.FromUnixTimeSeconds(long.Parse(settings.TraktTv.TokenExpirationDate)).DateTime;
+                _logger.LogInformation("Trakt token refreshed successfully. New expiry date: {Date}", newExpirationDate);
+            }
+            else
+            {
+                _logger.LogInformation("Trakt token is still valid. Expiry date: {Date}", expirationDate);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in {Job}: {Ex}", nameof(CheckTraktTokenJob), ex);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public CheckTraktTokenJob(ISettingsProvider settingsProvider, TraktTVHelper traktHelper)
+    {
+        _settingsProvider = settingsProvider;
+        _traktHelper = traktHelper;
+    }
+
+    protected CheckTraktTokenJob() { }
+}

--- a/Shoko.Server/Scheduling/Jobs/Trakt/CheckTraktTokenJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Trakt/CheckTraktTokenJob.cs
@@ -27,7 +27,7 @@ public class CheckTraktTokenJob : BaseJob
     {
         try
         {
-            _logger.LogInformation("Processing {Job}", nameof(CheckTraktTokenJob));
+            _logger.LogInformation("Processing {Job} (ForceRefresh: {ForceRefresh})", nameof(CheckTraktTokenJob), ForceRefresh);
             var settings = _settingsProvider.GetSettings();
             if (!settings.TraktTv.Enabled || string.IsNullOrEmpty(settings.TraktTv.TokenExpirationDate))
             {
@@ -41,9 +41,11 @@ public class CheckTraktTokenJob : BaseJob
             // Check if the token needs refreshing
             if (ForceRefresh || DateTime.Now.Add(TimeSpan.FromDays(45)) >= expirationDate)
             {
-                _traktHelper.RefreshAuthToken();
-                var newExpirationDate = DateTimeOffset.FromUnixTimeSeconds(long.Parse(settings.TraktTv.TokenExpirationDate)).DateTime;
-                _logger.LogInformation("Trakt token refreshed successfully. New expiry date: {Date}", newExpirationDate);
+                if (_traktHelper.RefreshAuthToken())
+                {
+                    var newExpirationDate = DateTimeOffset.FromUnixTimeSeconds(long.Parse(settings.TraktTv.TokenExpirationDate)).DateTime;
+                    _logger.LogInformation("Trakt token refreshed successfully. New expiry date: {Date}", newExpirationDate);
+                }
             }
             else
             {

--- a/Shoko.Server/Scheduling/QuartzStartup.cs
+++ b/Shoko.Server/Scheduling/QuartzStartup.cs
@@ -17,6 +17,7 @@ using Shoko.Server.Scheduling.GenericJobBuilder;
 using Shoko.Server.Scheduling.Jobs;
 using Shoko.Server.Scheduling.Jobs.Actions;
 using Shoko.Server.Scheduling.Jobs.Shoko;
+using Shoko.Server.Scheduling.Jobs.Trakt;
 using Shoko.Server.Server;
 using Shoko.Server.Utilities;
 
@@ -31,6 +32,8 @@ public static class QuartzStartup
         // StartJobNow gives a priority of 10. We'll give it 20 to be even higher priority
         await ScheduleRecurringJob<CheckNetworkAvailabilityJob>(
             triggerConfig: t => t.WithPriority(20).WithSimpleSchedule(tr => tr.WithIntervalInMinutes(30).RepeatForever()).StartNow(), replace: true, keepSchedule: false);
+        await ScheduleRecurringJob<CheckTraktTokenJob>(
+            triggerConfig: t => t.WithPriority(20).WithSimpleSchedule(tr => tr.WithIntervalInMinutes(720).RepeatForever()).StartNow(), replace: true, keepSchedule: false);
 
         // TODO the other schedule-based jobs that are on timers
     }

--- a/Shoko.Server/Server/ShokoServer.cs
+++ b/Shoko.Server/Server/ShokoServer.cs
@@ -412,7 +412,6 @@ public class ShokoServer
         actionService.CheckForAnimeUpdate().GetAwaiter().GetResult();
         actionService.CheckForMyListSyncUpdate(false).GetAwaiter().GetResult();
         actionService.CheckForTraktAllSeriesUpdate(false).GetAwaiter().GetResult();
-        actionService.CheckForTraktTokenUpdate(false);
         actionService.CheckForAniDBFileUpdate(false).GetAwaiter().GetResult();
     }
 

--- a/Shoko.Server/Services/ActionService.cs
+++ b/Shoko.Server/Services/ActionService.cs
@@ -1018,41 +1018,6 @@ public class ActionService
         _traktHelper.ScanForMatches();
     }
 
-    public void CheckForTraktTokenUpdate(bool forceRefresh)
-    {
-        try
-        {
-            var settings = _settingsProvider.GetSettings();
-            if (!settings.TraktTv.Enabled || string.IsNullOrEmpty(settings.TraktTv.TokenExpirationDate)) return;
-
-            // Convert the Unix timestamp to DateTime directly
-            var expirationDate = DateTimeOffset.FromUnixTimeSeconds(long.Parse(settings.TraktTv.TokenExpirationDate)).DateTime;
-
-            // Check if force refresh is requested or the token is expired
-            if (forceRefresh || DateTime.Now.Add(TimeSpan.FromDays(45)) >= expirationDate)
-            {
-                _traktHelper.RefreshAuthToken();
-
-                // Update the last token refresh timestamp
-                var schedule = RepoFactory.ScheduledUpdate.GetByUpdateType((int)ScheduledUpdateType.TraktToken)
-                            ?? new ScheduledUpdate { UpdateType = (int)ScheduledUpdateType.TraktToken, UpdateDetails = string.Empty };
-
-                schedule.LastUpdate = DateTime.Now;
-                RepoFactory.ScheduledUpdate.Save(schedule);
-
-                _logger.LogInformation("Trakt token refreshed successfully. Expiry date: {Date}", expirationDate);
-            }
-            else
-            {
-                _logger.LogInformation("Trakt token is still valid. Expiry date: {Date}", expirationDate);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error in CheckForTraktTokenUpdate: {Ex}", ex);
-        }
-    }
-
     public async Task CheckForAniDBFileUpdate(bool forceRefresh)
     {
         var settings = _settingsProvider.GetSettings();


### PR DESCRIPTION
Move CheckTraktToken to a Job that runs every 12h instead of spamming the log every few minutes.

The refresh of a fairly old token worked on my dev machine, but I'd be happy if someone else could check