### PR TITLE
fix: add DB migration & endpoint to download missing TMDB People

### DIFF
--- a/Shoko.Server/API/v3/Controllers/ActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/ActionController.cs
@@ -193,6 +193,16 @@ public class ActionController : BaseController
     }
 
     /// <summary>
+    /// Download any missing TMDB People.
+    /// </summary>
+    [HttpGet("DownloadMissingTmdbPeople")]
+    public ActionResult DownloadMissingTmdbPeople()
+    {
+        Task.Factory.StartNew(() => _tmdbService.RepairMissingPeople());
+        return Ok();
+    }
+
+    /// <summary>
     /// Purge all unused TMDB Shows that are not linked to any AniDB anime.
     /// </summary>
     /// <returns></returns>

--- a/Shoko.Server/API/v3/Controllers/TmdbController.cs
+++ b/Shoko.Server/API/v3/Controllers/TmdbController.cs
@@ -1478,6 +1478,48 @@ public partial class TmdbController : BaseController
         return NoContent();
     }
 
+    /// <summary>
+    /// Download any missing TMDB Persons.
+    /// </summary>
+    /// <param name="removeErrors">Removes all references to the bad TMDB Person if unable to successfully download the person</param>
+    /// <returns> <see cref="OkResult"/> with a summary of found/updated/skipped/deleted actions. </returns>
+    [HttpGet("Person/DownloadMissing")]
+    public async Task<ActionResult> RepairMissingTmdbPersons([FromQuery] bool removeErrors = false)
+    {
+        var personIds = new HashSet<int>();
+        var (errorCount, removedCount) = (0, 0);
+        
+        var people = RepoFactory.TMDB_Person.GetAll().Select(person => person.TmdbPersonID).ToList();
+
+        RepoFactory.TMDB_Episode_Cast.GetAll().AsParallel().Where(p =>
+            !people.Contains(p.TmdbPersonID)).ForEach(p => personIds.Add(p.TmdbPersonID));
+        RepoFactory.TMDB_Episode_Crew.GetAll().AsParallel().Where(p => 
+            !people.Contains(p.TmdbPersonID)).ForEach(p => personIds.Add(p.TmdbPersonID));
+        
+        RepoFactory.TMDB_Movie_Cast.GetAll().AsParallel().Where(p => 
+            !people.Contains(p.TmdbPersonID)).ForEach(p => personIds.Add(p.TmdbPersonID));
+        RepoFactory.TMDB_Movie_Crew.GetAll().AsParallel().Where(p => 
+            !people.Contains(p.TmdbPersonID)).ForEach(p => personIds.Add(p.TmdbPersonID));
+        
+        foreach (var id in personIds)
+            try
+            {
+                await _tmdbMetadataService.UpdatePerson(id, forceRefresh: true);
+            }
+            catch (NullReferenceException)
+            {
+                _logger.LogInformation("Unable to find TMDB Person record {@Id} on TMDB", id);
+                errorCount++;
+                if (removeErrors && await _tmdbMetadataService.PurgePerson(id, forceRemoval: true))
+                    removedCount++;
+            }
+        
+        var updateCount = personIds.Count - errorCount;
+        var skippedCount = errorCount - removedCount;
+
+        return Ok($"(Found/Updated/Skipped/Deleted) ({personIds.Count}/{updateCount}/{skippedCount}/{removedCount}) missing TMDB person(s).");
+    }
+    
     #endregion
 
     #region Online (Search / Bulk / Single)

--- a/Shoko.Server/API/v3/Controllers/TmdbController.cs
+++ b/Shoko.Server/API/v3/Controllers/TmdbController.cs
@@ -1479,17 +1479,15 @@ public partial class TmdbController : BaseController
     }
 
     /// <summary>
-    /// Download any missing TMDB Persons.
+    /// Download any missing TMDB Person records.
     /// </summary>
-    /// <param name="removeErrors">Removes all references to the bad TMDB Person if unable to successfully download the person</param>
-    /// <returns> <see cref="OkResult"/> with a summary of found/updated/skipped/deleted actions. </returns>
     [HttpGet("Person/DownloadMissing")]
-    public async Task<ActionResult> RepairMissingTmdbPersons([FromQuery] bool removeErrors = false)
+    public ActionResult RepairMissingTmdbPersonRecords()
     {
-        var result = await _tmdbMetadataService.RepairMissingPersons();
-        return Ok($"(Found/Updated/Skipped/Deleted) ({result.Found}/{result.Updated}/{result.Skipped}/{result.Removed}) missing TMDB person(s).");
+        Task.Run(() => _tmdbMetadataService.RepairMissingPersonRecords()).ConfigureAwait(false);
+        return Ok();
     }
-    
+
     #endregion
 
     #region Online (Search / Bulk / Single)

--- a/Shoko.Server/API/v3/Controllers/TmdbController.cs
+++ b/Shoko.Server/API/v3/Controllers/TmdbController.cs
@@ -1479,12 +1479,12 @@ public partial class TmdbController : BaseController
     }
 
     /// <summary>
-    /// Download any missing TMDB Person records.
+    /// Download any missing TMDB People.
     /// </summary>
     [HttpGet("Person/DownloadMissing")]
-    public ActionResult RepairMissingTmdbPersonRecords()
+    public ActionResult RepairMissingTmdbPeople()
     {
-        Task.Run(() => _tmdbMetadataService.RepairMissingPersonRecords()).ConfigureAwait(false);
+        Task.Run(() => _tmdbMetadataService.RepairMissingPeople()).ConfigureAwait(false);
         return Ok();
     }
 

--- a/Shoko.Server/API/v3/Controllers/TmdbController.cs
+++ b/Shoko.Server/API/v3/Controllers/TmdbController.cs
@@ -1478,16 +1478,6 @@ public partial class TmdbController : BaseController
         return NoContent();
     }
 
-    /// <summary>
-    /// Download any missing TMDB People.
-    /// </summary>
-    [HttpGet("Person/DownloadMissing")]
-    public ActionResult RepairMissingTmdbPeople()
-    {
-        Task.Run(() => _tmdbMetadataService.RepairMissingPeople()).ConfigureAwait(false);
-        return Ok();
-    }
-
     #endregion
 
     #region Online (Search / Bulk / Single)

--- a/Shoko.Server/Databases/DatabaseFixes.cs
+++ b/Shoko.Server/Databases/DatabaseFixes.cs
@@ -841,6 +841,6 @@ public class DatabaseFixes
     public static void RepairMissingTMDBPersons()
     {
         var service = Utils.ServiceContainer.GetRequiredService<TmdbMetadataService>();
-        service.RepairMissingPersonRecords().ConfigureAwait(false).GetAwaiter().GetResult();
+        service.RepairMissingPeople().ConfigureAwait(false).GetAwaiter().GetResult();
     }
 }

--- a/Shoko.Server/Databases/DatabaseFixes.cs
+++ b/Shoko.Server/Databases/DatabaseFixes.cs
@@ -837,4 +837,10 @@ public class DatabaseFixes
         var queueHandler = Utils.ServiceContainer.GetRequiredService<QueueHandler>();
         queueHandler.Clear().ConfigureAwait(false).GetAwaiter().GetResult();
     }
+
+    public static void RepairMissingTMDBPersons()
+    {
+        var service = Utils.ServiceContainer.GetRequiredService<TmdbMetadataService>();
+        service.RepairMissingPersons(true).ConfigureAwait(false).GetAwaiter().GetResult();
+    }
 }

--- a/Shoko.Server/Databases/DatabaseFixes.cs
+++ b/Shoko.Server/Databases/DatabaseFixes.cs
@@ -841,6 +841,6 @@ public class DatabaseFixes
     public static void RepairMissingTMDBPersons()
     {
         var service = Utils.ServiceContainer.GetRequiredService<TmdbMetadataService>();
-        service.RepairMissingPersons(true).ConfigureAwait(false).GetAwaiter().GetResult();
+        service.RepairMissingPersonRecords().ConfigureAwait(false).GetAwaiter().GetResult();
     }
 }

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -27,7 +27,7 @@ namespace Shoko.Server.Databases;
 public class MySQL : BaseDatabase<MySqlConnection>
 {
     public override string Name { get; } = "MySQL";
-    public override int RequiredVersion { get; } = 139;
+    public override int RequiredVersion { get; } = 140;
 
     private List<DatabaseCommand> createVersionTable = new()
     {
@@ -849,6 +849,7 @@ public class MySQL : BaseDatabase<MySqlConnection>
         new(139, 10, "ALTER TABLE Trakt_Show ADD COLUMN TmdbShowID INT NULL;"),
         new(139, 11, DatabaseFixes.CleanupAfterRemovingTvDB),
         new(139, 12, DatabaseFixes.ClearQuartzQueue),
+        new (140, 1, DatabaseFixes.RepairMissingTMDBPersons)
     };
 
     private DatabaseCommand linuxTableVersionsFix = new("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -849,7 +849,7 @@ public class MySQL : BaseDatabase<MySqlConnection>
         new(139, 10, "ALTER TABLE Trakt_Show ADD COLUMN TmdbShowID INT NULL;"),
         new(139, 11, DatabaseFixes.CleanupAfterRemovingTvDB),
         new(139, 12, DatabaseFixes.ClearQuartzQueue),
-        new (140, 1, DatabaseFixes.RepairMissingTMDBPersons)
+        new(140, 1, DatabaseFixes.RepairMissingTMDBPersons)
     };
 
     private DatabaseCommand linuxTableVersionsFix = new("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -28,7 +28,7 @@ namespace Shoko.Server.Databases;
 public class SQLServer : BaseDatabase<SqlConnection>
 {
     public override string Name { get; } = "SQLServer";
-    public override int RequiredVersion { get; } = 131;
+    public override int RequiredVersion { get; } = 132;
 
     public override void BackupDatabase(string fullfilename)
     {
@@ -779,6 +779,7 @@ public class SQLServer : BaseDatabase<SqlConnection>
         new DatabaseCommand(131, 10, "ALTER TABLE Trakt_Show ADD TmdbShowID INT NULL;"),
         new DatabaseCommand(131, 11, DatabaseFixes.CleanupAfterRemovingTvDB),
         new DatabaseCommand(131, 12, DatabaseFixes.ClearQuartzQueue),
+        new DatabaseCommand(132, 1, DatabaseFixes.RepairMissingTMDBPersons)
     };
 
     private static void AlterImdbMovieIDType()

--- a/Shoko.Server/Databases/SQLite.cs
+++ b/Shoko.Server/Databases/SQLite.cs
@@ -774,7 +774,7 @@ public class SQLite : BaseDatabase<SqliteConnection>
         new(123, 10, "ALTER TABLE Trakt_Show ADD COLUMN TmdbShowID INTEGER NULL;"),
         new(123, 11, DatabaseFixes.CleanupAfterRemovingTvDB),
         new(123, 12, DatabaseFixes.ClearQuartzQueue),
-        new (124, 1, DatabaseFixes.RepairMissingTMDBPersons)
+        new(124, 1, DatabaseFixes.RepairMissingTMDBPersons)
     };
 
     private static Tuple<bool, string> MigrateRenamers(object connection)

--- a/Shoko.Server/Databases/SQLite.cs
+++ b/Shoko.Server/Databases/SQLite.cs
@@ -28,7 +28,7 @@ public class SQLite : BaseDatabase<SqliteConnection>
 {
     public override string Name => "SQLite";
 
-    public override int RequiredVersion => 123;
+    public override int RequiredVersion => 124;
 
     public override void BackupDatabase(string fullfilename)
     {
@@ -774,6 +774,7 @@ public class SQLite : BaseDatabase<SqliteConnection>
         new(123, 10, "ALTER TABLE Trakt_Show ADD COLUMN TmdbShowID INTEGER NULL;"),
         new(123, 11, DatabaseFixes.CleanupAfterRemovingTvDB),
         new(123, 12, DatabaseFixes.ClearQuartzQueue),
+        new (124, 1, DatabaseFixes.RepairMissingTMDBPersons)
     };
 
     private static Tuple<bool, string> MigrateRenamers(object connection)

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -2034,7 +2034,8 @@ public class TmdbMetadataService
     public async Task RepairMissingPeople()
     {
         var missingIds = new HashSet<int>();
-        var (updateCount, skippedCount) = (0, 0);
+        var updateCount = 0;
+        var skippedCount = 0;
         
         var peopleIds = _tmdbPeople.GetAll().Select(person => person.TmdbPersonID).ToHashSet();
 

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -2104,20 +2104,20 @@ public class TmdbMetadataService
     {
         var showIds = new HashSet<int>();
         var movieIds = new HashSet<int>();
-        
+
         foreach (var staff in _tmdbEpisodeCast.GetByTmdbPersonID(tmdbPersonId))
             showIds.Add(staff.TmdbShowID);
         foreach (var staff in _tmdbEpisodeCrew.GetByTmdbPersonID(tmdbPersonId))
             showIds.Add(staff.TmdbShowID);
-        
+
         foreach (var staff in _tmdbMovieCast.GetByTmdbPersonID(tmdbPersonId))
             movieIds.Add(staff.TmdbMovieID);
         foreach (var staff in _tmdbMovieCrew.GetByTmdbPersonID(tmdbPersonId))
             movieIds.Add(staff.TmdbMovieID);
-        
+
         foreach (var showId in showIds)
             await ScheduleUpdateOfShow(showId, downloadCrewAndCast: true, forceRefresh: true);
-        
+
         foreach (var movieId in movieIds)
             await ScheduleUpdateOfMovie(movieId, downloadCrewAndCast: true, forceRefresh: true);
     }

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -2031,7 +2031,7 @@ public class TmdbMetadataService
 
     #region People
 
-    public async Task RepairMissingPersonRecords()
+    public async Task RepairMissingPeople()
     {
         var missingIds = new HashSet<int>();
         var (updateCount, skippedCount) = (0, 0);
@@ -2048,7 +2048,7 @@ public class TmdbMetadataService
         foreach (var person in _tmdbMovieCrew.GetAll())
             if (!peopleIds.Contains(person.TmdbPersonID)) missingIds.Add(person.TmdbPersonID);
 
-        _logger.LogDebug("Found {@Count} unique missing TMDB Person record(s) for Episode & Movie staff", missingIds.Count);
+        _logger.LogDebug("Found {@Count} unique missing TMDB People for Episode & Movie staff", missingIds.Count);
         
         foreach (var personId in missingIds)
         {

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -2072,11 +2072,11 @@ public class TmdbMetadataService
         await _imageService.DownloadImagesByType(images.Profiles, ImageEntityType.Person, ForeignEntityType.Person, personId, settings.TMDB.MaxAutoStaffImages, [], forceDownload);
     }
 
-    public async Task<bool> PurgePerson(int personId, bool removeImageFiles = true)
+    public async Task<bool> PurgePerson(int personId, bool removeImageFiles = true, bool forceRemoval = false)
     {
         using (await GetLockForEntity(ForeignEntityType.Person, personId, "metadata & images", "Purge"))
         {
-            if (IsPersonLinkedToOtherEntities(personId))
+            if (!forceRemoval && IsPersonLinkedToOtherEntities(personId))
                 return false;
 
             var person = _tmdbPeople.GetByTmdbPersonID(personId);


### PR DESCRIPTION
Optionally allows for the complete removal of the person/cast/crew entry if unable to update it.

This allows for a user-driven resolution to the problems that issue #1202 demonstrate.