### PR TITLE
Extend ProductionCountries Column length

### DIFF
--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -855,8 +855,8 @@ public class MySQL : BaseDatabase<MySqlConnection>
         new(141, 3, "ALTER TABLE `TMDB_Show` ADD COLUMN `Keywords` VARCHAR(512) NULL DEFAULT NULL;"),
         new(141, 4, "ALTER TABLE `TMDB_Show` ADD COLUMN `ProductionCountries` VARCHAR(32) NULL DEFAULT NULL;"),
         new(142, 1, "ALTER TABLE `AniDB_Anime_Relation` ADD INDEX `IX_AniDB_Anime_Relation_RelatedAnimeID` (`RelatedAnimeID` ASC);"),
-        new(143, 1, "ALTER TABLE `TMDB_Movie` ALTER COLUMN `ProductionCountries` VARCHAR(128) NULL DEFAULT NULL;"),
-        new(143, 2, "ALTER TABLE `TMDB_Show` ALTER COLUMN `ProductionCountries` VARCHAR(128) NULL DEFAULT NULL;"),
+        new(143, 1, "ALTER TABLE `TMDB_Movie` CHANGE COLUMN `ProductionCountries` `ProductionCountries` VARCHAR(128) NULL DEFAULT NULL;"),
+        new(143, 2, "ALTER TABLE `TMDB_Show` CHANGE COLUMN `ProductionCountries` `ProductionCountries` VARCHAR(128) NULL DEFAULT NULL;"),
     };
 
     private DatabaseCommand linuxTableVersionsFix = new("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -855,8 +855,8 @@ public class MySQL : BaseDatabase<MySqlConnection>
         new(141, 3, "ALTER TABLE `TMDB_Show` ADD COLUMN `Keywords` VARCHAR(512) NULL DEFAULT NULL;"),
         new(141, 4, "ALTER TABLE `TMDB_Show` ADD COLUMN `ProductionCountries` VARCHAR(32) NULL DEFAULT NULL;"),
         new(142, 1, "ALTER TABLE `AniDB_Anime_Relation` ADD INDEX `IX_AniDB_Anime_Relation_RelatedAnimeID` (`RelatedAnimeID` ASC);"),
-        new(143, 1, "ALTER TABLE `TMDB_Movie` CHANGE COLUMN `ProductionCountries` `ProductionCountries` VARCHAR(128) NULL DEFAULT NULL;"),
-        new(143, 2, "ALTER TABLE `TMDB_Show` CHANGE COLUMN `ProductionCountries` `ProductionCountries` VARCHAR(128) NULL DEFAULT NULL;"),
+        new(143, 1, "ALTER TABLE `TMDB_Movie` CHANGE COLUMN `ProductionCountries` `ProductionCountries` VARCHAR(255) NULL DEFAULT NULL;"),
+        new(143, 2, "ALTER TABLE `TMDB_Show` CHANGE COLUMN `ProductionCountries` `ProductionCountries` VARCHAR(255) NULL DEFAULT NULL;"),
     };
 
     private DatabaseCommand linuxTableVersionsFix = new("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -27,7 +27,7 @@ namespace Shoko.Server.Databases;
 public class MySQL : BaseDatabase<MySqlConnection>
 {
     public override string Name { get; } = "MySQL";
-    public override int RequiredVersion { get; } = 142;
+    public override int RequiredVersion { get; } = 143;
 
     private List<DatabaseCommand> createVersionTable = new()
     {
@@ -855,6 +855,8 @@ public class MySQL : BaseDatabase<MySqlConnection>
         new(141, 3, "ALTER TABLE `TMDB_Show` ADD COLUMN `Keywords` VARCHAR(512) NULL DEFAULT NULL;"),
         new(141, 4, "ALTER TABLE `TMDB_Show` ADD COLUMN `ProductionCountries` VARCHAR(32) NULL DEFAULT NULL;"),
         new(142, 1, "ALTER TABLE `AniDB_Anime_Relation` ADD INDEX `IX_AniDB_Anime_Relation_RelatedAnimeID` (`RelatedAnimeID` ASC);"),
+        new(143, 1, "ALTER TABLE `TMDB_Movie` ALTER COLUMN `ProductionCountries` VARCHAR(128) NULL DEFAULT NULL;"),
+        new(143, 2, "ALTER TABLE `TMDB_Show` ALTER COLUMN `ProductionCountries` VARCHAR(128) NULL DEFAULT NULL;"),
     };
 
     private DatabaseCommand linuxTableVersionsFix = new("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -28,7 +28,7 @@ namespace Shoko.Server.Databases;
 public class SQLServer : BaseDatabase<SqlConnection>
 {
     public override string Name { get; } = "SQLServer";
-    public override int RequiredVersion { get; } = 134;
+    public override int RequiredVersion { get; } = 135;
 
     public override void BackupDatabase(string fullfilename)
     {
@@ -785,6 +785,8 @@ public class SQLServer : BaseDatabase<SqlConnection>
         new DatabaseCommand(133, 3, "ALTER TABLE TMDB_Show ADD Keywords NVARCHAR(512) NULL DEFAULT NULL;"),
         new DatabaseCommand(133, 4, "ALTER TABLE TMDB_Show ADD ProductionCountries NVARCHAR(32) NULL DEFAULT NULL;"),
         new DatabaseCommand(134, 1, "CREATE INDEX IX_AniDB_Anime_Relation_RelatedAnimeID on AniDB_Anime_Relation(RelatedAnimeID);"),
+        new DatabaseCommand(135, 1, "ALTER TABLE TMDB_Movie ALTER COLUMN ProductionCountries NVARCHAR(128) NULL DEFAULT NULL;"),
+        new DatabaseCommand(135, 2, "ALTER TABLE TMDB_Show ALTER COLUMN ProductionCountries NVARCHAR(128) NULL DEFAULT NULL;"),
     };
 
     private static void AlterImdbMovieIDType()

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -785,8 +785,8 @@ public class SQLServer : BaseDatabase<SqlConnection>
         new DatabaseCommand(133, 3, "ALTER TABLE TMDB_Show ADD Keywords NVARCHAR(512) NULL DEFAULT NULL;"),
         new DatabaseCommand(133, 4, "ALTER TABLE TMDB_Show ADD ProductionCountries NVARCHAR(32) NULL DEFAULT NULL;"),
         new DatabaseCommand(134, 1, "CREATE INDEX IX_AniDB_Anime_Relation_RelatedAnimeID on AniDB_Anime_Relation(RelatedAnimeID);"),
-        new DatabaseCommand(135, 1, "ALTER TABLE TMDB_Movie ALTER COLUMN ProductionCountries NVARCHAR(128) NULL DEFAULT NULL;"),
-        new DatabaseCommand(135, 2, "ALTER TABLE TMDB_Show ALTER COLUMN ProductionCountries NVARCHAR(128) NULL DEFAULT NULL;"),
+        new DatabaseCommand(135, 1, "ALTER TABLE TMDB_Movie ALTER COLUMN ProductionCountries NVARCHAR(255) NULL DEFAULT NULL;"),
+        new DatabaseCommand(135, 2, "ALTER TABLE TMDB_Show ALTER COLUMN ProductionCountries NVARCHAR(255) NULL DEFAULT NULL;"),
     };
 
     private static void AlterImdbMovieIDType()


### PR DESCRIPTION
on MySQL and MSSQL Server to a (hopefully) long enough value.

Should fix error: _String or binary data would be truncated in table 'shokodb.dbo.TMDB_Show', column 'ProductionCountries'_