### PR TITLE
Fixes for new Trakt collection limits

### DIFF
--- a/Shoko.Server/Providers/TraktTV/TraktConstants.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktConstants.cs
@@ -49,7 +49,10 @@ public static class TraktStatusCodes
     public const int Conflict = 409;
 
     public const int Precondition_Failed = 412;
+    public const int Account_Limit_Exceeded = 420;
+    public const int Account_Locked = 423;
     public const int Unprocessable_Entity = 422;
+    public const int VIP_Only = 426;
     public const int Rate_Limit_Exceeded = 429;
 
     public const int Server_Error = 500;

--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -1269,7 +1269,7 @@ public class TraktTVHelper
     public List<TraktV2ShowCollectedResult> GetCollectedShows(ref int traktCode)
     {
         var settings = _settingsProvider.GetSettings();
-        if (!settings.TraktTv.Enabled || string.IsNullOrEmpty(settings.TraktTv.AuthToken))
+        if (!settings.TraktTv.Enabled || string.IsNullOrEmpty(settings.TraktTv.AuthToken) || !settings.TraktTv.VipStatus)
         {
             return new List<TraktV2ShowCollectedResult>();
         }
@@ -1376,7 +1376,7 @@ public class TraktTVHelper
         try
         {
             var settings = _settingsProvider.GetSettings();
-            if (!settings.TraktTv.Enabled || string.IsNullOrEmpty(settings.TraktTv.AuthToken))
+            if (!settings.TraktTv.Enabled || string.IsNullOrEmpty(settings.TraktTv.AuthToken) || !settings.TraktTv.VipStatus)
             {
                 return;
             }
@@ -1935,7 +1935,7 @@ public class TraktTVHelper
         try
         {
             var settings = _settingsProvider.GetSettings();
-            if (!settings.TraktTv.Enabled || string.IsNullOrEmpty(settings.TraktTv.AuthToken))
+            if (!settings.TraktTv.Enabled || string.IsNullOrEmpty(settings.TraktTv.AuthToken) || !settings.TraktTv.VipStatus)
             {
                 return false;
             }

--- a/Shoko.Server/Settings/TraktSettings.cs
+++ b/Shoko.Server/Settings/TraktSettings.cs
@@ -17,4 +17,6 @@ public class TraktSettings
     public ScheduledUpdateFrequency UpdateFrequency { get; set; } = ScheduledUpdateFrequency.Daily;
 
     public ScheduledUpdateFrequency SyncFrequency { get; set; } = ScheduledUpdateFrequency.Daily;
+
+    public bool VipStatus { get; set; } = false;
 }


### PR DESCRIPTION
Add Setting for VipStatus, added some constants for later use, changed TraktTVHelper to not update collections if user doesn't have VIP status because of new ridiculously low collection limits introduced in January 25