### PR TITLE
WebAOM %epn and %epr wrong way around

### DIFF
--- a/Shoko.Models/Constants.cs
+++ b/Shoko.Models/Constants.cs
@@ -75,9 +75,9 @@ namespace Shoko.Models
             public static readonly string AnimeNameRomaji = "%ann";
             public static readonly string AnimeNameKanji = "%kan";
             public static readonly string AnimeNameEnglish = "%eng";
-            public static readonly string EpisodeNameRomaji = "%epn";
+            public static readonly string EpisodeNameRomaji = "%epr";
             //public static readonly string EpisodeNameKanji = "%epk";
-            public static readonly string EpisodeNameEnglish = "%epr";
+            public static readonly string EpisodeNameEnglish = "%epn";
             public static readonly string EpisodeNumber = "%enr";
             public static readonly string GroupShortName = "%grp";
             public static readonly string GroupLongName = "%grl";

--- a/Shoko.Server/Server/Constants.cs
+++ b/Shoko.Server/Server/Constants.cs
@@ -36,8 +36,8 @@ public static class Constants
         public static readonly string AnimeNameMain = "%ann";
         public static readonly string AnimeNameKanji = "%kan";
         public static readonly string AnimeNameEnglish = "%eng";
-        public static readonly string EpisodeNameRomaji = "%epn";
-        public static readonly string EpisodeNameEnglish = "%epr";
+        public static readonly string EpisodeNameRomaji = "%epr";
+        public static readonly string EpisodeNameEnglish = "%epn";
         public static readonly string EpisodeNumber = "%enr";
         public static readonly string GroupShortName = "%grp";
         public static readonly string GroupLongName = "%grl";


### PR DESCRIPTION
The %epn and %epr are the wrong way around, causing null returns with I(eng) checks etc, and incorrectly renaming files with episode names.

https://wiki.anidb.net/WebAOM#Tags

%epn 	Episode name; english
%epr 	Episode name; romaji 

