### PR TITLE
change mysql and sqlserver tmdb keyword to text equivalent

### DIFF
--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -26,7 +26,7 @@ namespace Shoko.Server.Databases;
 public class MySQL : BaseDatabase<MySqlConnection>
 {
     public override string Name { get; } = "MySQL";
-    public override int RequiredVersion { get; } = 153;
+    public override int RequiredVersion { get; } = 154;
 
     private List<DatabaseCommand> createVersionTable = new()
     {
@@ -943,6 +943,8 @@ public class MySQL : BaseDatabase<MySqlConnection>
         new(152, 02, DatabaseFixes.MoveTmdbImagesOnDisc),
         new(153, 01, "DROP TABLE IF EXISTS DuplicateFile;"),
         new(153, 02, "DROP TABLE IF EXISTS AnimeCharacter;"),
+        new(154, 01, "ALTER TABLE `TMDB_Show` MODIFY COLUMN `Keywords` TEXT NULL;"),
+        new(154, 02, "ALTER TABLE `TMDB_Movie` MODIFY COLUMN `Keywords` TEXT NULL;"),
     };
 
     private DatabaseCommand linuxTableVersionsFix = new("RENAME TABLE versions TO Versions;");

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -27,7 +27,7 @@ namespace Shoko.Server.Databases;
 public class SQLServer : BaseDatabase<SqlConnection>
 {
     public override string Name { get; } = "SQLServer";
-    public override int RequiredVersion { get; } = 145;
+    public override int RequiredVersion { get; } = 146;
 
     public override void BackupDatabase(string fullfilename)
     {
@@ -895,6 +895,8 @@ public class SQLServer : BaseDatabase<SqlConnection>
         new DatabaseCommand(144, 02, DatabaseFixes.MoveTmdbImagesOnDisc),
         new DatabaseCommand(145, 01, "DROP TABLE IF EXISTS DuplicateFile;"),
         new DatabaseCommand(145, 02, "DROP TABLE IF EXISTS AnimeCharacter;"),
+        new DatabaseCommand(146, 01, "ALTER TABLE TMDB_Show ALTER COLUMN Keywords NVARCHAR(MAX) NULL;"),
+        new DatabaseCommand(146, 02, "ALTER TABLE TMDB_Movie ALTER COLUMN Keywords NVARCHAR(MAX) NULL;"),
     };
 
     private static void AlterImdbMovieIDType()


### PR DESCRIPTION
SQLite already has this column as their text equivalent, so it was left untouched. [Lord of Mysteries](https://www.themoviedb.org/tv/232230?language=en-US) has too many keywords that it would not make sense to keep expanding and expanding varchar when new release come out with even more keywords.

This is related to this specific error message:

```
11:45:39| AnimeSeriesRepository --- Saving Series Guimi Zhi Zhu
11:45:39| AnimeSeriesRepository --- Saving Series Guimi Zhi Zhu | Waiting for Database Lock
11:45:39| AnimeSeriesRepository --- Saving Series Guimi Zhi Zhu | Got Database Lock in 0.00001s
11:45:39| AnimeSeriesRepository --- Saving Series Guimi Zhi Zhu | Got Series from Database in 0.00144s
11:45:39| AnimeSeriesRepository --- Saving Series Guimi Zhi Zhu | Saving Series to Database
11:45:39| AnimeSeriesRepository --- Saving Series Guimi Zhi Zhu | Saved Series to Database in 0.00887s
11:45:39| AnimeSeriesRepository --- Saving Series Guimi Zhi Zhu | Finished Saving in 0.01051s
11:45:39| TmdbLinkingService --- Removing TMDB show link: AniDB anime (AnimeID=19357) → TMDB show (ID=232230)
11:45:39| TmdbLinkingService --- Removing 0 episodes cross-references for AniDB anime (AnimeID=19357) and TMDB show (ID=232230)
11:45:39| AnimeGroupService --- Starting Updating STATS for GROUP Lord of Mysteries from Top Level (recursively) - Watched Stats: False, Missing Episodes: False
11:45:39| AnimeGroupService --- Starting Updating STATS for GROUP Lord of Mysteries - Watched Stats: False, Missing Episodes: False
11:45:39| AnimeGroupService --- Finished Updating STATS for GROUP Lord of Mysteries in 0.8625ms
11:45:39| AnimeGroupService --- Finished Updating STATS for GROUP Lord of Mysteries from Top Level (recursively) in 0.9102ms
11:45:41| TmdbMetadataService --- Scheduled call: Searching shows for "诡秘之主" at year 2025
11:45:41| TmdbMetadataService --- Executing call: Searching shows for "诡秘之主" at year 2025 (Waited 0.0433ms)
11:45:41| TmdbMetadataService --- Completed call: Searching shows for "诡秘之主" at year 2025 (Waited 0.0433ms, Executed: 191.6682ms, 1 attempts)
11:45:41| TmdbMetadataService --- Scheduled call: Searching shows for "诡秘之主" at year 2025
11:45:41| TmdbMetadataService --- Executing call: Searching shows for "诡秘之主" at year 2025 (Waited 0.0132ms)
11:45:41| TmdbMetadataService --- Completed call: Searching shows for "诡秘之主" at year 2025 (Waited 0.0132ms, Executed: 6.2909ms, 1 attempts)
11:45:41| TmdbSearchService --- Got 1 shows from 1 total shows at indexes 0-1 across 1 actual page.
11:45:41| TmdbSearchService --- Found 1 show results for search on 诡秘之主, best match; 诡秘之主 (232230)
11:45:42| TmdbMetadataService --- Acquiring lock 'metadata' for Show 232230. (Reason: Update)
11:45:42| TmdbMetadataService --- Acquired lock 'metadata' for Show 232230. (Reason: Update)
11:45:42| TmdbMetadataService --- Scheduled call: Get Show 232230
11:45:42| TmdbMetadataService --- Executing call: Get Show 232230 (Waited 0.0403ms)
11:45:42| TmdbMetadataService --- Completed call: Get Show 232230 (Waited 0.0403ms, Executed: 114.5345ms, 1 attempts)
11:45:42| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/5 titles and 0/0/0/1 overviews for show 诡秘之主 (Show=232230)
11:45:42| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/4 company cross-references for show 诡秘之主 (Show=232230)
11:45:42| TmdbMetadataService --- Checking season 1 for show Lord of Mysteries (Show=232230)
11:45:42| TmdbMetadataService --- Scheduled call: Get season 1 for show 232230 "Lord of Mysteries"
11:45:42| TmdbMetadataService --- Executing call: Get season 1 for show 232230 "Lord of Mysteries" (Waited 0.0144ms)
11:45:43| TmdbMetadataService --- Completed call: Get season 1 for show 232230 "Lord of Mysteries" (Waited 0.0144ms, Executed: 40.3619ms, 1 attempts)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/0 overviews for season The Clown (Season=351951)
11:45:43| TmdbMetadataService --- Checking episode 13 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Checking episode 2 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Checking episode 1 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Checking episode 4 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Checking episode 6 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Checking episode 3 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/0 overviews for episode Episode 13 (Episode=6342385)
11:45:43| TmdbMetadataService --- Checking episode 7 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/1 overviews for episode The Fool (Episode=4634823)
11:45:43| TmdbMetadataService --- Checking episode 5 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/1 overviews for episode Magic Mirror (Episode=6342375)
11:45:43| TmdbMetadataService --- Checking episode 8 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/1 overviews for episode Beyonder (Episode=6286922)
11:45:43| TmdbMetadataService --- Checking episode 11 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/0 overviews for episode Episode 8 (Episode=6342379)
11:45:43| TmdbMetadataService --- Checking episode 9 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/0 overviews for episode Episode 5 (Episode=6342376)
11:45:43| TmdbMetadataService --- Checking episode 12 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/0 overviews for episode Episode 7 (Episode=6342378)
11:45:43| TmdbMetadataService --- Checking episode 10 in season 1 for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/0 overviews for episode Episode 6 (Episode=6342377)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/1 overviews for episode The Notebook (Episode=6286924)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/0 overviews for episode Episode 11 (Episode=6342383)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/0 overviews for episode Episode 9 (Episode=6342380)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/0 overviews for episode Episode 10 (Episode=6342381)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 titles and 0/0/0/0 overviews for episode Episode 12 (Episode=6342384)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/0/0/1 seasons for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Added/updated/removed/skipped 0/1/0/12 episodes for show Lord of Mysteries (Show=232230)
11:45:43| TmdbMetadataService --- Released lock 'metadata' for Show 232230 after 00:00:00.2161236. (Reason: Update)
11:45:43| SentryMiddleware --- Sending event 'Sentry.SentryEvent' to Sentry.
11:45:43| SentryMiddleware --- Event '00000000000000000000000000000000' queued.
11:45:43| Kestrel --- Connection id "0HNE303GH7J56", Request id "0HNE303GH7J56:0000000B": An unhandled exception was thrown by the application.: NHibernate.Exceptions.GenericADOException: could not insert: [Shoko.Server.Models.TMDB.TMDB_Show][SQL: INSERT INTO TMDB_Show (TmdbShowID, TvdbShowID, PosterPath, BackdropPath, EnglishTitle, EnglishOverview, OriginalTitle, OriginalLanguageCode, IsRestricted, Genres, Keywords, ContentRatings, ProductionCountries, EpisodeCount, HiddenEpisodeCount, SeasonCount, AlternateOrderingCount, UserRating, UserVotes, FirstAiredAt, LastAiredAt, CreatedAt, LastUpdatedAt, PreferredAlternateOrderingID) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)]
 ---> MySqlConnector.MySqlException (0x80004005): Data too long for column 'Keywords' at row 1
   at MySqlConnector.Core.ServerSession.ReceiveReplyAsync(IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/Core/ServerSession.cs:line 1081
   at MySqlConnector.Core.ResultSet.ReadResultSetHeaderAsync(IOBehavior ioBehavior) in /_/src/MySqlConnector/Core/ResultSet.cs:line 37
   at MySqlConnector.MySqlDataReader.ActivateResultSet(CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlDataReader.cs:line 131
   at MySqlConnector.MySqlDataReader.InitAsync(CommandListPosition commandListPosition, ICommandPayloadCreator payloadCreator, IDictionary`2 cachedProcedures, IMySqlCommand command, CommandBehavior behavior, Activity activity, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlDataReader.cs:line 487
   at MySqlConnector.Core.CommandExecutor.ExecuteReaderAsync(CommandListPosition commandListPosition, ICommandPayloadCreator payloadCreator, CommandBehavior behavior, Activity activity, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/Core/CommandExecutor.cs:line 56
   at MySqlConnector.MySqlCommand.ExecuteNonQueryAsync(IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlCommand.cs:line 309
   at NHibernate.AdoNet.AbstractBatcher.ExecuteNonQuery(DbCommand cmd)
   at NHibernate.Id.Insert.AbstractSelectingDelegate.PerformInsert(SqlCommandInfo insertSql, ISessionImplementor session, IBinder binder)
   --- End of inner exception stack trace ---
   at NHibernate.Id.Insert.AbstractSelectingDelegate.PerformInsert(SqlCommandInfo insertSql, ISessionImplementor session, IBinder binder)
   at NHibernate.Persister.Entity.AbstractEntityPersister.Insert(Object[] fields, Boolean[] notNull, SqlCommandInfo sql, Object obj, ISessionImplementor session)
   at NHibernate.Persister.Entity.AbstractEntityPersister.Insert(Object[] fields, Object obj, ISessionImplementor session)
   at NHibernate.Action.EntityIdentityInsertAction.Execute()
   at NHibernate.Engine.ActionQueue.InnerExecute(IExecutable executable)
   at NHibernate.Engine.ActionQueue.Execute(IExecutable executable)
   at NHibernate.Event.Default.AbstractSaveEventListener.PerformSaveOrReplicate(Object entity, EntityKey key, IEntityPersister persister, Boolean useIdentityColumn, Object anything, IEventSource source, Boolean requiresImmediateIdAccess)
   at NHibernate.Event.Default.AbstractSaveEventListener.PerformSave(Object entity, Object id, IEntityPersister persister, Boolean useIdentityColumn, Object anything, IEventSource source, Boolean requiresImmediateIdAccess)
   at NHibernate.Event.Default.AbstractSaveEventListener.SaveWithGeneratedId(Object entity, String entityName, Object anything, IEventSource source, Boolean requiresImmediateIdAccess)
   at NHibernate.Event.Default.DefaultSaveOrUpdateEventListener.SaveWithGeneratedOrRequestedId(SaveOrUpdateEvent event)
   at NHibernate.Event.Default.DefaultSaveOrUpdateEventListener.EntityIsTransient(SaveOrUpdateEvent event)
   at NHibernate.Impl.SessionImpl.FireSaveOrUpdate(SaveOrUpdateEvent event)
   at NHibernate.Impl.SessionImpl.SaveOrUpdate(Object obj)
   at Shoko.Server.Repositories.BaseCachedRepository`2.<>c__DisplayClass47_0.<Save>b__0() in /usr/src/app/source/Shoko.Server/Repositories/BaseCachedRepository.cs:line 222
   at Shoko.Server.Repositories.BaseRepository.Lock(Action action) in /usr/src/app/source/Shoko.Server/Repositories/BaseRepository.cs:line 17
   at Shoko.Server.Repositories.BaseCachedRepository`2.Save(T obj) in /usr/src/app/source/Shoko.Server/Repositories/BaseCachedRepository.cs:line 218
   at Shoko.Server.Providers.TMDB.TmdbMetadataService.UpdateShow(Int32 showId, Boolean forceRefresh, Boolean downloadImages, Boolean downloadCrewAndCast, Boolean downloadAlternateOrdering, Boolean quickRefresh) in /usr/src/app/source/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs:line 1090
   at Shoko.Server.API.v3.Controllers.TmdbController.RefreshTmdbShowByShowID(Int32 showID, TmdbRefreshShowBody body) in /usr/src/app/source/Shoko.Server/API/v3/Controllers/TmdbController.cs:line 1705
   at lambda_method187033(Closure, Object)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.TaskOfActionResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeInnerFilterAsync>g__Awaited|13_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeFilterPipelineAsync>g__Awaited|20_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
   at Sentry.AspNetCore.SentryTracingMiddleware.InvokeAsync(HttpContext context)
   at Sentry.AspNetCore.SentryTracingMiddleware.InvokeAsync(HttpContext context)
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)
   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
   at Shoko.Server.API.APIExtensions.<>c.<<UseAPI>b__5_0>d.MoveNext() in /usr/src/app/source/Shoko.Server/API/APIExtensions.cs:line 339
--- End of stack trace from previous location ---
   at Sentry.AspNetCore.SentryMiddleware.InvokeAsync(HttpContext context, RequestDelegate next)
   at Sentry.AspNetCore.SentryMiddleware.InvokeAsync(HttpContext context, RequestDelegate next)
   at Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.InterfaceMiddlewareBinder.<>c__DisplayClass2_0.<<CreateMiddleware>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)
```

I directly modified my maridb DB with the changes below and it worked. Can't test for the other DB. I got a C+ in my DBs class, so if this breaks something, it wasn't my fault