### PR TITLE
Increase SignalR timeout

### DIFF
--- a/Shoko.Server/API/APIExtensions.cs
+++ b/Shoko.Server/API/APIExtensions.cs
@@ -148,11 +148,12 @@ public static class APIExtensions
                 options.CustomSchemaIds(GetTypeName);
             });
         services.AddSwaggerGenNewtonsoftSupport();
-        services.AddSignalR(o => { 
-            o.EnableDetailedErrors = true;
-            o.ClientTimeoutInterval = TimeSpan.FromSeconds(60); // default timeout is 30 seconds
-        })
-        .AddNewtonsoftJsonProtocol(o => o.PayloadSerializerSettings.ContractResolver = new DefaultContractResolver());
+        services.AddSignalR(options => 
+            {
+                options.EnableDetailedErrors = true;
+                options.ClientTimeoutInterval = TimeSpan.FromSeconds(60); // default timeout is 30 seconds
+            })
+            .AddNewtonsoftJsonProtocol(o => o.PayloadSerializerSettings.ContractResolver = new DefaultContractResolver());
 
         // allow CORS calls from other both local and non-local hosts
         services.AddCors(options =>

--- a/Shoko.Server/API/APIExtensions.cs
+++ b/Shoko.Server/API/APIExtensions.cs
@@ -148,8 +148,11 @@ public static class APIExtensions
                 options.CustomSchemaIds(GetTypeName);
             });
         services.AddSwaggerGenNewtonsoftSupport();
-        services.AddSignalR(o => { o.EnableDetailedErrors = true; })
-            .AddNewtonsoftJsonProtocol(o => o.PayloadSerializerSettings.ContractResolver = new DefaultContractResolver());
+        services.AddSignalR(o => { 
+            o.EnableDetailedErrors = true;
+            o.ClientTimeoutInterval = TimeSpan.FromSeconds(60); // default timeout is 30 seconds
+        })
+        .AddNewtonsoftJsonProtocol(o => o.PayloadSerializerSettings.ContractResolver = new DefaultContractResolver());
 
         // allow CORS calls from other both local and non-local hosts
         services.AddCors(options =>


### PR DESCRIPTION
For cases mentioned by @harshithmohan "when the server gets too many API calls or it gets stuck processing a single big one, signalr disconnects"