### PR TITLE
Remove heading for unpopulated column from TMDB Export

### DIFF
--- a/Shoko.Server/API/v3/Controllers/TmdbController.cs
+++ b/Shoko.Server/API/v3/Controllers/TmdbController.cs
@@ -2785,7 +2785,7 @@ public partial class TmdbController : BaseController
 
     private const string MovieCrossReferenceWithIdHeader = "AnidbAnimeId,AnidbEpisodeId,TmdbMovieId,IsAutomatic";
 
-    private const string EpisodeCrossReferenceWithIdHeader = "AnidbAnimeId,AnidbEpisodeType,AnidbEpisodeId,TmdbShowId,TmdbEpisodeId,Rating";
+    private const string EpisodeCrossReferenceWithIdHeader = "AnidbAnimeId,AnidbEpisodeId,TmdbShowId,TmdbEpisodeId,Rating";
 
     private string MapAnimeType(AbstractAnimeType? type) =>
         type switch


### PR DESCRIPTION
Removes 'AnidbEpisodeType' heading from the exported TMDB xrefs csv for shows, as it is not populated.
This is to prevent misalignments when parsing the CSV with other tools