### PR TITLE
perf(data): allow concurrent direct repository reads

### DIFF
--- a/Shoko.Server/Repositories/BaseCachedRepository.cs
+++ b/Shoko.Server/Repositories/BaseCachedRepository.cs
@@ -377,7 +377,7 @@ public abstract class BaseCachedRepository<T, S> : BaseRepository, ICachedReposi
         }
     }
 
-    protected T5 ReadLock<T5>(Func<T5> action)
+    protected new T5 ReadLock<T5>(Func<T5> action)
     {
         _lock.EnterReadLock();
         try
@@ -390,7 +390,7 @@ public abstract class BaseCachedRepository<T, S> : BaseRepository, ICachedReposi
         }
     }
 
-    protected void WriteLock(Action action)
+    protected new void WriteLock(Action action)
     {
         _lock.EnterWriteLock();
         try
@@ -403,7 +403,7 @@ public abstract class BaseCachedRepository<T, S> : BaseRepository, ICachedReposi
         }
     }
 
-    protected T5 WriteLock<T5>(Func<T5> action)
+    protected new T5 WriteLock<T5>(Func<T5> action)
     {
         _lock.EnterWriteLock();
         try

--- a/Shoko.Server/Repositories/BaseDirectRepository.cs
+++ b/Shoko.Server/Repositories/BaseDirectRepository.cs
@@ -27,7 +27,7 @@ public class BaseDirectRepository<T, S> : BaseRepository, IDirectRepository, IRe
 
     public virtual T GetByID(S id)
     {
-        return Lock(() =>
+        return ReadLock(() =>
         {
             using var session = _databaseFactory.SessionFactory.OpenSession();
             return session.Get<T>(id);
@@ -36,17 +36,17 @@ public class BaseDirectRepository<T, S> : BaseRepository, IDirectRepository, IRe
 
     public virtual T GetByID(ISession session, S id)
     {
-        return Lock(() => session.Get<T>(id));
+        return ReadLock(() => session.Get<T>(id));
     }
 
     public virtual T GetByID(ISessionWrapper session, S id)
     {
-        return Lock(() => session.Get<T>(id));
+        return ReadLock(() => session.Get<T>(id));
     }
 
     public virtual IReadOnlyList<T> GetAll()
     {
-        return Lock(() =>
+        return ReadLock(() =>
         {
             using var session = _databaseFactory.SessionFactory.OpenSession();
             return session.CreateCriteria(typeof(T)).List<T>().ToList();
@@ -55,12 +55,12 @@ public class BaseDirectRepository<T, S> : BaseRepository, IDirectRepository, IRe
 
     public virtual IReadOnlyList<T> GetAll(ISession session)
     {
-        return Lock(() => session.CreateCriteria(typeof(T)).List<T>().ToList());
+        return ReadLock(() => session.CreateCriteria(typeof(T)).List<T>().ToList());
     }
 
     public virtual IReadOnlyList<T> GetAll(ISessionWrapper session)
     {
-        return Lock(() => session.CreateCriteria(typeof(T)).List<T>().ToList());
+        return ReadLock(() => session.CreateCriteria(typeof(T)).List<T>().ToList());
     }
 
 

--- a/Shoko.Server/Repositories/BaseRepository.cs
+++ b/Shoko.Server/Repositories/BaseRepository.cs
@@ -13,6 +13,41 @@ public class BaseRepository
         WriteLock(action);
     }
 
+    public static void Lock<T>(T arg, Action<T> action)
+    {
+        WriteLock(() => action(arg));
+    }
+
+    public static void Lock<T, T1>(T arg, T1 arg2, Action<T, T1> action)
+    {
+        WriteLock(() => action(arg, arg2));
+    }
+
+    public static void Lock<T, T1, T2>(T arg, T1 arg2, T2 arg3, Action<T, T1, T2> action)
+    {
+        WriteLock(() => action(arg, arg2, arg3));
+    }
+
+    public static T Lock<T>(Func<T> action)
+    {
+        return WriteLock(action);
+    }
+
+    public static T Lock<T, T1>(T1 arg, Func<T1, T> action)
+    {
+        return WriteLock(() => action(arg));
+    }
+
+    public static T Lock<T, T1, T2>(T1 arg, T2 arg2, Func<T1, T2, T> action)
+    {
+        return WriteLock(() => action(arg, arg2));
+    }
+
+    public static T Lock<T, T1, T2, T3>(T1 arg, T2 arg2, T3 arg3, Func<T1, T2, T3, T> action)
+    {
+        return WriteLock(() => action(arg, arg2, arg3));
+    }
+
     public static void ReadLock(Action action)
     {
         var useLock = Utils.SettingsProvider.GetSettings().Database.UseDatabaseLock;
@@ -101,40 +136,5 @@ public class BaseRepository
         }
 
         return result;
-    }
-
-    public static void Lock<T>(T arg, Action<T> action)
-    {
-        WriteLock(() => action(arg));
-    }
-
-    public static void Lock<T, T1>(T arg, T1 arg2, Action<T, T1> action)
-    {
-        WriteLock(() => action(arg, arg2));
-    }
-
-    public static void Lock<T, T1, T2>(T arg, T1 arg2, T2 arg3, Action<T, T1, T2> action)
-    {
-        WriteLock(() => action(arg, arg2, arg3));
-    }
-
-    public static T Lock<T>(Func<T> action)
-    {
-        return WriteLock(action);
-    }
-
-    public static T Lock<T, T1>(T1 arg, Func<T1, T> action)
-    {
-        return WriteLock(() => action(arg));
-    }
-
-    public static T Lock<T, T1, T2>(T1 arg, T2 arg2, Func<T1, T2, T> action)
-    {
-        return WriteLock(() => action(arg, arg2));
-    }
-
-    public static T Lock<T, T1, T2, T3>(T1 arg, T2 arg2, T3 arg3, Func<T1, T2, T3, T> action)
-    {
-        return WriteLock(() => action(arg, arg2, arg3));
     }
 }

--- a/Shoko.Server/Repositories/BaseRepository.cs
+++ b/Shoko.Server/Repositories/BaseRepository.cs
@@ -1,20 +1,31 @@
 ﻿using System;
+using System.Threading;
 using Shoko.Server.Utilities;
 
 namespace Shoko.Server.Repositories;
 
 public class BaseRepository
 {
-    private static readonly object s_lock = new();
+    private static readonly ReaderWriterLockSlim s_lock = new(LockRecursionPolicy.SupportsRecursion);
 
     public static void Lock(Action action)
+    {
+        WriteLock(action);
+    }
+
+    public static void ReadLock(Action action)
     {
         var useLock = Utils.SettingsProvider.GetSettings().Database.UseDatabaseLock;
         if (useLock)
         {
-            lock (s_lock)
+            s_lock.EnterReadLock();
+            try
             {
                 action.Invoke();
+            }
+            finally
+            {
+                s_lock.ExitReadLock();
             }
         }
         else
@@ -23,63 +34,20 @@ public class BaseRepository
         }
     }
 
-    public static void Lock<T>(T arg, Action<T> action)
-    {
-        var useLock = Utils.SettingsProvider.GetSettings().Database.UseDatabaseLock;
-        if (useLock)
-        {
-            lock (s_lock)
-            {
-                action.Invoke(arg);
-            }
-        }
-        else
-        {
-            action(arg);
-        }
-    }
-
-    public static void Lock<T, T1>(T arg, T1 arg2, Action<T, T1> action)
-    {
-        var useLock = Utils.SettingsProvider.GetSettings().Database.UseDatabaseLock;
-        if (useLock)
-        {
-            lock (s_lock)
-            {
-                action.Invoke(arg, arg2);
-            }
-        }
-        else
-        {
-            action(arg, arg2);
-        }
-    }
-
-    public static void Lock<T, T1, T2>(T arg, T1 arg2, T2 arg3, Action<T, T1, T2> action)
-    {
-        var useLock = Utils.SettingsProvider.GetSettings().Database.UseDatabaseLock;
-        if (useLock)
-        {
-            lock (s_lock)
-            {
-                action.Invoke(arg, arg2, arg3);
-            }
-        }
-        else
-        {
-            action(arg, arg2, arg3);
-        }
-    }
-
-    public static T Lock<T>(Func<T> action)
+    public static T ReadLock<T>(Func<T> action)
     {
         var useLock = Utils.SettingsProvider.GetSettings().Database.UseDatabaseLock;
         T result;
         if (useLock)
         {
-            lock (s_lock)
+            s_lock.EnterReadLock();
+            try
             {
                 result = action();
+            }
+            finally
+            {
+                s_lock.ExitReadLock();
             }
         }
         else
@@ -90,60 +58,83 @@ public class BaseRepository
         return result;
     }
 
-    public static T Lock<T, T1>(T1 arg, Func<T1, T> action)
+    public static void WriteLock(Action action)
+    {
+        var useLock = Utils.SettingsProvider.GetSettings().Database.UseDatabaseLock;
+        if (useLock)
+        {
+            s_lock.EnterWriteLock();
+            try
+            {
+                action.Invoke();
+            }
+            finally
+            {
+                s_lock.ExitWriteLock();
+            }
+        }
+        else
+        {
+            action();
+        }
+    }
+
+    public static T WriteLock<T>(Func<T> action)
     {
         var useLock = Utils.SettingsProvider.GetSettings().Database.UseDatabaseLock;
         T result;
         if (useLock)
         {
-            lock (s_lock)
+            s_lock.EnterWriteLock();
+            try
             {
-                result = action(arg);
+                result = action();
+            }
+            finally
+            {
+                s_lock.ExitWriteLock();
             }
         }
         else
         {
-            result = action(arg);
+            result = action();
         }
 
         return result;
+    }
+
+    public static void Lock<T>(T arg, Action<T> action)
+    {
+        WriteLock(() => action(arg));
+    }
+
+    public static void Lock<T, T1>(T arg, T1 arg2, Action<T, T1> action)
+    {
+        WriteLock(() => action(arg, arg2));
+    }
+
+    public static void Lock<T, T1, T2>(T arg, T1 arg2, T2 arg3, Action<T, T1, T2> action)
+    {
+        WriteLock(() => action(arg, arg2, arg3));
+    }
+
+    public static T Lock<T>(Func<T> action)
+    {
+        return WriteLock(action);
+    }
+
+    public static T Lock<T, T1>(T1 arg, Func<T1, T> action)
+    {
+        return WriteLock(() => action(arg));
     }
 
     public static T Lock<T, T1, T2>(T1 arg, T2 arg2, Func<T1, T2, T> action)
     {
-        var useLock = Utils.SettingsProvider.GetSettings().Database.UseDatabaseLock;
-        T result;
-        if (useLock)
-        {
-            lock (s_lock)
-            {
-                result = action(arg, arg2);
-            }
-        }
-        else
-        {
-            result = action(arg, arg2);
-        }
-
-        return result;
+        return WriteLock(() => action(arg, arg2));
     }
 
     public static T Lock<T, T1, T2, T3>(T1 arg, T2 arg2, T3 arg3, Func<T1, T2, T3, T> action)
     {
-        var useLock = Utils.SettingsProvider.GetSettings().Database.UseDatabaseLock;
-        T result;
-        if (useLock)
-        {
-            lock (s_lock)
-            {
-                result = action(arg, arg2, arg3);
-            }
-        }
-        else
-        {
-            result = action(arg, arg2, arg3);
-        }
-
-        return result;
+        return WriteLock(() => action(arg, arg2, arg3));
     }
 }

--- a/Shoko.Tests/RepositoryLockingTests.cs
+++ b/Shoko.Tests/RepositoryLockingTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Server.Server;
+using Shoko.Server.Settings;
+using Shoko.Server.Repositories;
+using Shoko.Server.Utilities;
+using Xunit;
+
+namespace Shoko.Tests;
+
+public class RepositoryLockingTests
+{
+    [Fact]
+    public async Task ReadLock_AllowsConcurrentReaders()
+    {
+        using var settingsScope = new SettingsScope(CreateServerSettings());
+        using var firstEntered = new ManualResetEventSlim(false);
+        using var secondEntered = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        var first = Task.Run(() =>
+        {
+            BaseRepository.ReadLock(() =>
+            {
+                firstEntered.Set();
+                Assert.True(release.Wait(TimeSpan.FromSeconds(5)));
+            });
+        });
+
+        Assert.True(firstEntered.Wait(TimeSpan.FromSeconds(5)));
+
+        var second = Task.Run(() => BaseRepository.ReadLock(() => secondEntered.Set()));
+
+        Assert.True(secondEntered.Wait(TimeSpan.FromSeconds(5)));
+        release.Set();
+
+        await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task WriteLock_SerializesReadersAndWriters()
+    {
+        using var settingsScope = new SettingsScope(CreateServerSettings());
+        using var writerEntered = new ManualResetEventSlim(false);
+        using var releaseWriter = new ManualResetEventSlim(false);
+        using var readerEntered = new ManualResetEventSlim(false);
+        using var secondWriterEntered = new ManualResetEventSlim(false);
+
+        var writer = Task.Run(() =>
+        {
+            BaseRepository.WriteLock(() =>
+            {
+                writerEntered.Set();
+                Assert.True(releaseWriter.Wait(TimeSpan.FromSeconds(5)));
+            });
+        });
+
+        Assert.True(writerEntered.Wait(TimeSpan.FromSeconds(5)));
+
+        var reader = Task.Run(() => BaseRepository.ReadLock(() => readerEntered.Set()));
+        var secondWriter = Task.Run(() => BaseRepository.WriteLock(() => secondWriterEntered.Set()));
+
+        Assert.False(readerEntered.Wait(TimeSpan.FromMilliseconds(200)));
+        Assert.False(secondWriterEntered.Wait(TimeSpan.FromMilliseconds(200)));
+
+        releaseWriter.Set();
+
+        Assert.True(readerEntered.Wait(TimeSpan.FromSeconds(5)));
+        Assert.True(secondWriterEntered.Wait(TimeSpan.FromSeconds(5)));
+        await Task.WhenAll(writer, reader, secondWriter).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task MixedReadWriteLoad_CompletesWithoutDeadlock()
+    {
+        using var settingsScope = new SettingsScope(CreateServerSettings());
+        using var releaseWriter = new ManualResetEventSlim(false);
+        using var writerEntered = new ManualResetEventSlim(false);
+        using var readerEntered = new ManualResetEventSlim(false);
+
+        var writer = Task.Run(() =>
+        {
+            BaseRepository.WriteLock(() =>
+            {
+                writerEntered.Set();
+                Assert.True(releaseWriter.Wait(TimeSpan.FromSeconds(5)));
+            });
+        });
+
+        Assert.True(writerEntered.Wait(TimeSpan.FromSeconds(5)));
+
+        var reader = Task.Run(() => BaseRepository.ReadLock(() => readerEntered.Set()));
+        var secondWriter = Task.Run(() => BaseRepository.WriteLock(() => { }));
+
+        Assert.False(readerEntered.Wait(TimeSpan.FromMilliseconds(200)));
+
+        releaseWriter.Set();
+
+        Assert.True(readerEntered.Wait(TimeSpan.FromSeconds(5)));
+        await Task.WhenAll(writer, reader, secondWriter).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private static ServerSettings CreateServerSettings()
+    {
+        return new ServerSettings
+        {
+            Database =
+            {
+                UseDatabaseLock = true,
+                Type = Constants.DatabaseType.SQLite,
+            },
+        };
+    }
+
+    private sealed class SettingsScope : IDisposable
+    {
+        private readonly ISettingsProvider _previous;
+
+        public SettingsScope(IServerSettings settings)
+        {
+            _previous = Utils.SettingsProvider;
+            Utils.SettingsProvider = new TestSettingsProvider(settings);
+        }
+
+        public void Dispose()
+        {
+            Utils.SettingsProvider = _previous;
+        }
+    }
+
+    private sealed class TestSettingsProvider : ISettingsProvider
+    {
+        private readonly IServerSettings _settings;
+
+        public TestSettingsProvider(IServerSettings settings)
+        {
+            _settings = settings;
+        }
+
+        public IServerSettings GetSettings(bool copy = false)
+        {
+            return _settings;
+        }
+
+        public void SaveSettings(IServerSettings settings)
+        {
+        }
+
+        public void SaveSettings()
+        {
+        }
+
+        public void DebugSettingsToLog()
+        {
+        }
+    }
+}


### PR DESCRIPTION
### Summary
This replaces the global repository lock with reader/writer semantics for database access.

Previously, enabling UseDatabaseLock serialized all repository operations, including read-only queries. With this change, direct repository reads can run concurrently, while writes remain exclusive.

### Changes

- add ReadLock(...) and WriteLock(...) to BaseRepository
- route existing Lock(...) calls through WriteLock(...)
- update BaseDirectRepository read methods to use ReadLock(...)
- keep BaseCachedRepository’s existing per-repository read/write locking behavior

### Result

- concurrent reads are now allowed
- writes still block reads and other writes
- behavior is unchanged when UseDatabaseLock is disabled
- generally much faster responsiveness with SQLite database in WebUI

### Tests
Added tests to verify concurrent readers, exclusive writers, and no deadlocks under mixed read/write load.

Verified working with @Baine