### PR TITLE
fix(trakt): improve invalid token handling and token check scheduling

### DIFF
--- a/Shoko.Server/Providers/TraktTV/TraktConstants.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktConstants.cs
@@ -34,6 +34,7 @@ public static class TraktStatusCodes
     public const int Conflict = 409;
 
     public const int Precondition_Failed = 412;
+    public const int Denied = 418;
     public const int Account_Limit_Exceeded = 420;
     public const int Account_Locked = 423;
     public const int Unprocessable_Entity = 422;

--- a/Shoko.Server/Providers/TraktTV/TraktConstants.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktConstants.cs
@@ -14,6 +14,13 @@ public enum TraktSyncType
     HistoryRemove = 2
 }
 
+public enum TraktAuthTokenValidationResult
+{
+    Valid = 1,
+    Invalid = 2,
+    Unknown = 3
+}
+
 public static class TraktStatusCodes
 {
     // http://docs.trakt.apiary.io/#introduction/status-codes

--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -59,28 +59,22 @@ public class TraktTVHelper
             }
 
             // post to trakt
-            var postStream = request.GetRequestStream();
+            using var postStream = request.GetRequestStream();
             postStream.Write(data, 0, data.Length);
 
             // get the response
-            var response = (HttpWebResponse)request.GetResponse();
+            using var response = (HttpWebResponse)request.GetResponse();
+            using var responseStream = response.GetResponseStream();
 
-            var responseStream = response.GetResponseStream();
             if (responseStream == null)
             {
                 return ret;
             }
 
-            var reader = new StreamReader(responseStream);
+            using var reader = new StreamReader(responseStream);
             var strResponse = reader.ReadToEnd();
 
             var statusCode = (int)response.StatusCode;
-
-            // cleanup
-            postStream.Close();
-            responseStream.Close();
-            reader.Close();
-            response.Close();
 
             webResponse = strResponse;
             _logger.LogTrace("Trakt SEND Data - Response\nStatus Code: {StatusCode}\nResponse: {Response}", statusCode,
@@ -90,33 +84,49 @@ public class TraktTVHelper
         }
         catch (WebException webEx)
         {
-            if (webEx.Status == WebExceptionStatus.ProtocolError)
+            if (webEx.Status == WebExceptionStatus.ProtocolError &&
+                webEx.Response is HttpWebResponse response)
             {
-                if (webEx.Response is HttpWebResponse response)
-                    if (response.ResponseUri.AbsoluteUri != TraktURIs.OAuthDeviceToken && response.StatusCode == HttpStatusCode.BadRequest)
-                    {
-                        {
-                            _logger.LogError(webEx, "Error in SendData: {StatusCode}", (int)response.StatusCode);
-                            ret = (int)response.StatusCode;
-                        }
-                        try
-                        {
-                            var responseStream2 = response.GetResponseStream();
-                            if (responseStream2 == null)
-                            {
-                                return ret;
-                            }
+                ret = (int)response.StatusCode;
 
-                            var reader2 = new StreamReader(responseStream2);
-                            webResponse = reader2.ReadToEnd();
-                            _logger.LogError("Error in SendData: {Response}", webResponse);
-                        }
-                        catch
+                if (response.ResponseUri.AbsoluteUri != TraktURIs.OAuthDeviceToken &&
+                    response.StatusCode == HttpStatusCode.BadRequest)
+                {
+                    try
+                    {
+                        using var responseStream = response.GetResponseStream();
+                        if (responseStream == null)
                         {
-                            // ignore
+                            return ret;
                         }
+
+                        using var reader = new StreamReader(responseStream);
+                        webResponse = reader.ReadToEnd();
+
+                        if (webResponse.Contains("\"error\":\"invalid_grant\"", StringComparison.OrdinalIgnoreCase))
+                        {
+                            _logger.LogWarning("Trakt token is invalid, expired, or revoked.");
+                            return ret;
+                        }
+
+                        _logger.LogError("Error in SendData: {Response}", webResponse);
                     }
+                    catch
+                    {
+                        // ignore
+                    }
+
+                    return ret;
+                }
+
+                if (response.ResponseUri.AbsoluteUri != TraktURIs.OAuthDeviceToken)
+                {
+                    _logger.LogError(webEx, "{Ex}", webEx.ToString());
+                }
+
+                return ret;
             }
+
             if (webEx.Response != null && webEx.Response.ResponseUri.AbsoluteUri != TraktURIs.OAuthDeviceToken)
             {
                 _logger.LogError(webEx, "{Ex}", webEx.ToString());
@@ -209,6 +219,8 @@ public class TraktTVHelper
     public bool RefreshAuthToken()
     {
         var settings = _settingsProvider.GetSettings();
+        var shouldSaveSettings = false;
+
         try
         {
             if (!settings.TraktTv.Enabled ||
@@ -218,6 +230,8 @@ public class TraktTVHelper
                 settings.TraktTv.AuthToken = string.Empty;
                 settings.TraktTv.RefreshToken = string.Empty;
                 settings.TraktTv.TokenExpirationDate = string.Empty;
+                settings.TraktTv.Enabled = false;
+                shouldSaveSettings = true;
 
                 return false;
             }
@@ -229,11 +243,11 @@ public class TraktTVHelper
             var retData = string.Empty;
             TraktTVRateLimiter.Instance.EnsureRate();
             var response = SendData(TraktURIs.Oauth, json, "POST", headers, ref retData);
+
             if (response is TraktStatusCodes.Success or TraktStatusCodes.Success_Post)
             {
                 var loginResponse = retData.FromJSON<TraktAuthToken>();
 
-                // save the token to the config file to use for subsequent API calls
                 settings.TraktTv.AuthToken = loginResponse.AccessToken;
                 settings.TraktTv.RefreshToken = loginResponse.RefreshToken;
 
@@ -242,28 +256,46 @@ public class TraktTVHelper
                 var expireDate = createdAt + validity;
 
                 settings.TraktTv.TokenExpirationDate = expireDate.ToString();
+                shouldSaveSettings = true;
 
                 return true;
+            }
+
+            if (retData.Contains("invalid_grant", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning("Trakt refresh token is invalid, expired, or revoked. Disabling Trakt until it is re-authenticated.");
+                settings.TraktTv.Enabled = false;
+            }
+            else
+            {
+                _logger.LogWarning("Failed to refresh Trakt auth token. Response code: {ResponseCode}. Response: {Response}", response, retData);
             }
 
             settings.TraktTv.AuthToken = string.Empty;
             settings.TraktTv.RefreshToken = string.Empty;
             settings.TraktTv.TokenExpirationDate = string.Empty;
+            shouldSaveSettings = true;
+
+            return false;
         }
         catch (Exception ex)
         {
             settings.TraktTv.AuthToken = string.Empty;
             settings.TraktTv.RefreshToken = string.Empty;
             settings.TraktTv.TokenExpirationDate = string.Empty;
+            settings.TraktTv.Enabled = false;
+            shouldSaveSettings = true;
 
             _logger.LogError(ex, "Error in TraktTVHelper.RefreshAuthToken");
             return false;
         }
         finally
         {
-            Utils.SettingsProvider.SaveSettings();
+            if (shouldSaveSettings)
+            {
+                _settingsProvider.SaveSettings();
+            }
         }
-        return false;
     }
 
     #endregion

--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Shoko.Abstractions.Extensions;
 using Shoko.Abstractions.User.Services;
 using Shoko.Server.Models.Shoko;
@@ -35,6 +36,25 @@ public class TraktTVHelper
     }
 
     #region Helpers
+
+    private static bool IsInvalidGrantResponse(string response)
+    {
+        if (string.IsNullOrWhiteSpace(response))
+            return false;
+
+        try
+        {
+            var json = JObject.Parse(response);
+            return string.Equals(
+                (string?)json["error"],
+                "invalid_grant",
+                StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     private int SendData(string uri, string json, string verb, Dictionary<string, string> headers, ref string webResponse)
     {
@@ -89,39 +109,36 @@ public class TraktTVHelper
             {
                 ret = (int)response.StatusCode;
 
-                if (response.ResponseUri.AbsoluteUri != TraktURIs.OAuthDeviceToken &&
-                    response.StatusCode == HttpStatusCode.BadRequest)
+                try
                 {
-                    try
+                    using var responseStream = response.GetResponseStream();
+                    if (responseStream is not null)
                     {
-                        using var responseStream = response.GetResponseStream();
-                        if (responseStream == null)
-                        {
-                            return ret;
-                        }
-
                         using var reader = new StreamReader(responseStream);
                         webResponse = reader.ReadToEnd();
-
-                        if (webResponse.Contains("\"error\":\"invalid_grant\"", StringComparison.OrdinalIgnoreCase))
-                        {
-                            _logger.LogWarning("Trakt token is invalid, expired, or revoked.");
-                            return ret;
-                        }
-
-                        _logger.LogError("Error in SendData: {Response}", webResponse);
                     }
-                    catch
-                    {
-                        // ignore
-                    }
-
-                    return ret;
+                }
+                catch
+                {
+                    // ignore response body read failures
                 }
 
-                if (response.ResponseUri.AbsoluteUri != TraktURIs.OAuthDeviceToken)
+                var isDeviceTokenPolling = response.ResponseUri.AbsoluteUri == TraktURIs.OAuthDeviceToken;
+                var isInvalidGrant = response.StatusCode == HttpStatusCode.BadRequest &&
+                                     IsInvalidGrantResponse(webResponse);
+
+                if (isInvalidGrant)
                 {
-                    _logger.LogError(webEx, "{Ex}", webEx.ToString());
+                    _logger.LogWarning(
+                        "Trakt OAuth token request failed with invalid_grant. The token is invalid, expired, or revoked and must be re-authenticated.");
+                }
+                else if (!isDeviceTokenPolling || response.StatusCode != HttpStatusCode.BadRequest)
+                {
+                    _logger.LogError(
+                        webEx,
+                        "Error in SendData: {StatusCode}. Response: {Response}",
+                        ret,
+                        webResponse);
                 }
 
                 return ret;
@@ -261,7 +278,7 @@ public class TraktTVHelper
                 return true;
             }
 
-            if (retData.Contains("invalid_grant", StringComparison.OrdinalIgnoreCase))
+            if (IsInvalidGrantResponse(retData))
             {
                 _logger.LogWarning("Trakt refresh token is invalid, expired, or revoked. Disabling Trakt until it is re-authenticated.");
                 settings.TraktTv.Enabled = false;

--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -56,6 +56,15 @@ public class TraktTVHelper
         }
     }
 
+    private static bool IsExpectedDeviceTokenPollingStatus(HttpStatusCode statusCode)
+        => (int)statusCode is
+            TraktStatusCodes.Awaiting_Auth or
+            TraktStatusCodes.Not_Found or
+            TraktStatusCodes.Conflict or
+            TraktStatusCodes.Token_Expired or
+            TraktStatusCodes.Denied or
+            TraktStatusCodes.Rate_Limit_Exceeded;
+
     private int SendData(string uri, string json, string verb, Dictionary<string, string> headers, ref string webResponse)
     {
         var ret = 400;
@@ -132,7 +141,7 @@ public class TraktTVHelper
                     _logger.LogWarning(
                         "Trakt OAuth token request failed with invalid_grant. The token is invalid, expired, or revoked and must be re-authenticated.");
                 }
-                else if (!isDeviceTokenPolling || response.StatusCode != HttpStatusCode.BadRequest)
+                else if (!isDeviceTokenPolling || !IsExpectedDeviceTokenPollingStatus(response.StatusCode))
                 {
                     _logger.LogError(
                         webEx,
@@ -300,7 +309,6 @@ public class TraktTVHelper
             settings.TraktTv.AuthToken = string.Empty;
             settings.TraktTv.RefreshToken = string.Empty;
             settings.TraktTv.TokenExpirationDate = string.Empty;
-            settings.TraktTv.Enabled = false;
             shouldSaveSettings = true;
 
             _logger.LogError(ex, "Error in TraktTVHelper.RefreshAuthToken");

--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -268,7 +268,7 @@ public class TraktTVHelper
             }
             else
             {
-                _logger.LogWarning("Failed to refresh Trakt auth token. Response code: {ResponseCode}. Response: {Response}", response, retData);
+                _logger.LogWarning("Failed to refresh Trakt auth token. Response code: {ResponseCode}. Response data: {ResponseData}", response, retData);
             }
 
             settings.TraktTv.AuthToken = string.Empty;

--- a/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktTVHelper.cs
@@ -242,6 +242,49 @@ public class TraktTVHelper
 
     #region Authorization
 
+    public TraktAuthTokenValidationResult ValidateAuthToken()
+    {
+        var request = (HttpWebRequest)WebRequest.Create(TraktURIs.UserSettings);
+
+        _logger.LogTrace("Trakt token validation\nuri: {Uri}", TraktURIs.UserSettings);
+
+        request.KeepAlive = true;
+        request.Method = "GET";
+        request.ContentLength = 0;
+        request.Timeout = 120000;
+        request.ContentType = "application/json";
+        request.UserAgent = "JMM";
+        foreach (var header in BuildRequestHeaders())
+        {
+            request.Headers.Add(header.Key, header.Value);
+        }
+
+        try
+        {
+            using var response = (HttpWebResponse)request.GetResponse();
+            return (int)response.StatusCode == TraktStatusCodes.Success
+                ? TraktAuthTokenValidationResult.Valid
+                : TraktAuthTokenValidationResult.Unknown;
+        }
+        catch (WebException ex) when (ex.Response is HttpWebResponse response)
+        {
+            var statusCode = (int)response.StatusCode;
+            if (statusCode is TraktStatusCodes.Unauthorized or TraktStatusCodes.Forbidden)
+            {
+                _logger.LogWarning("Trakt auth token validation failed with {StatusCode}.", statusCode);
+                return TraktAuthTokenValidationResult.Invalid;
+            }
+
+            _logger.LogError(ex, "Error validating Trakt auth token: {StatusCode}", statusCode);
+            return TraktAuthTokenValidationResult.Unknown;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error validating Trakt auth token");
+            return TraktAuthTokenValidationResult.Unknown;
+        }
+    }
+
     public bool RefreshAuthToken()
     {
         var settings = _settingsProvider.GetSettings();

--- a/Shoko.Server/Providers/TraktTV/TraktURIs.cs
+++ b/Shoko.Server/Providers/TraktTV/TraktURIs.cs
@@ -6,6 +6,7 @@ public static class TraktURIs
 
     public const string OAuthDeviceCode = TraktConstants.BaseAPIURL + @"/oauth/device/code";
     public const string OAuthDeviceToken = TraktConstants.BaseAPIURL + @"/oauth/device/token";
+    public const string UserSettings = TraktConstants.BaseAPIURL + @"/users/settings";
 
     // add to history (mark as watched)
     // used for movies, series, episodes

--- a/Shoko.Server/Scheduling/Jobs/Trakt/CheckTraktTokenJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Trakt/CheckTraktTokenJob.cs
@@ -34,6 +34,24 @@ public class CheckTraktTokenJob : BaseJob
                 return Task.CompletedTask;
             }
 
+            var validationResult = _traktHelper.ValidateAuthToken();
+            if (validationResult == TraktAuthTokenValidationResult.Invalid)
+            {
+                _logger.LogInformation("Trakt auth token is no longer valid. Refreshing token.");
+                if (_traktHelper.RefreshAuthToken())
+                {
+                    var newExpirationDate = DateTimeOffset.FromUnixTimeSeconds(long.Parse(settings.TraktTv.TokenExpirationDate)).DateTime;
+                    _logger.LogInformation("Trakt token refreshed successfully. New expiry date: {Date}", newExpirationDate);
+                }
+
+                return Task.CompletedTask;
+            }
+
+            if (validationResult == TraktAuthTokenValidationResult.Unknown)
+            {
+                _logger.LogWarning("Unable to validate Trakt auth token. Falling back to stored expiry date.");
+            }
+
             // Convert the Unix timestamp to DateTime
             var expirationDate = DateTimeOffset.FromUnixTimeSeconds(long.Parse(settings.TraktTv.TokenExpirationDate)).DateTime;
 

--- a/Shoko.Server/Scheduling/QuartzStartup.cs
+++ b/Shoko.Server/Scheduling/QuartzStartup.cs
@@ -29,13 +29,22 @@ public static class QuartzStartup
 {
     public static async Task ScheduleRecurringJobs(bool replace)
     {
+        var settings = Utils.SettingsProvider.GetSettings();
+
         // this needs to run immediately upon scheduling, so it replaces always. Others will run on other schedules
         // Also give it a high priority, since it affects Acquisition Filters
         // StartJobNow gives a priority of 10. We'll give it 20 to be even higher priority
         await ScheduleRecurringJob<CheckNetworkAvailabilityJob>(
             triggerConfig: t => t.WithPriority(20).WithSimpleSchedule(tr => tr.WithIntervalInMinutes(30).RepeatForever()).StartNow(), replace: true, keepSchedule: false);
-        await ScheduleRecurringJob<CheckTraktTokenJob>(
-            triggerConfig: t => t.WithPriority(20).WithSimpleSchedule(tr => tr.WithIntervalInMinutes(60).RepeatForever()).StartNow(), replace: true, keepSchedule: false);
+        if (settings.TraktTv.Enabled)
+        {
+            await ScheduleRecurringJob<CheckTraktTokenJob>(
+                triggerConfig: t => t.WithPriority(20).WithSimpleSchedule(tr => tr.WithIntervalInMinutes(60).RepeatForever()).StartNow(), replace: true, keepSchedule: false);
+        }
+        else
+        {
+            await RemoveRecurringJob<CheckTraktTokenJob>();
+        }
 
         // TODO the other schedule-based jobs that are on timers
     }
@@ -84,6 +93,19 @@ public static class QuartzStartup
                 await scheduler.DeleteJob(jobKey);
                 await scheduler.ScheduleJob(JobBuilder<T>.Create().UsingJobData(jobConfig).WithIdentity(jobKey).Build(), trigger.Build());
             }
+        }
+    }
+
+    private static async Task RemoveRecurringJob<T>() where T : class, IJob
+    {
+        var groupName = typeof(T).GetCustomAttribute<JobKeyGroupAttribute>()?.GroupName;
+        var jobKey = JobKeyBuilder<T>.Create().WithGroup(groupName).Build();
+        var scheduler = await Utils.ServiceContainer.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        using var _ = await QuartzExtensions.SchedulerLock.WriterLockAsync();
+        if (await scheduler.CheckExists(jobKey))
+        {
+            await scheduler.DeleteJob(jobKey);
         }
     }
 

--- a/Shoko.Server/Services/Configuration/ShokoJsonSchemaValidator.cs
+++ b/Shoko.Server/Services/Configuration/ShokoJsonSchemaValidator.cs
@@ -129,20 +129,9 @@ public partial class ShokoJsonSchemaValidator<TConfig>(ILogger logger, Configura
                     else if (_saveValidation && !string.Equals(tuple.Original, tuple.Override, StringComparison.Ordinal))
                     {
                         if (tuple.Original is null)
-                        {
                             ((JObject)parentToken!).Remove(propertyName!);
-                        }
-                        else if (string.IsNullOrWhiteSpace(tuple.Original))
-                        {
-                            if (token is not null)
-                                token.Replace(JValue.CreateString(string.Empty));
-                            else
-                                ((JObject)parentToken!).Add(propertyName!, JValue.CreateString(string.Empty));
-                        }
                         else
-                        {
                             token!.Replace(JToken.Parse(tuple.Original));
-                        }
                     }
                 }
 

--- a/Shoko.Server/Services/Configuration/ShokoJsonSchemaValidator.cs
+++ b/Shoko.Server/Services/Configuration/ShokoJsonSchemaValidator.cs
@@ -129,9 +129,20 @@ public partial class ShokoJsonSchemaValidator<TConfig>(ILogger logger, Configura
                     else if (_saveValidation && !string.Equals(tuple.Original, tuple.Override, StringComparison.Ordinal))
                     {
                         if (tuple.Original is null)
+                        {
                             ((JObject)parentToken!).Remove(propertyName!);
+                        }
+                        else if (string.IsNullOrWhiteSpace(tuple.Original))
+                        {
+                            if (token is not null)
+                                token.Replace(JValue.CreateString(string.Empty));
+                            else
+                                ((JObject)parentToken!).Add(propertyName!, JValue.CreateString(string.Empty));
+                        }
                         else
+                        {
                             token!.Replace(JToken.Parse(tuple.Original));
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

This PR improves Trakt OAuth failure handling and recurring token-check behavior when Trakt credentials are revoked, expired, or otherwise become invalid.

Previously, revoked or expired Trakt auth could still leave Shoko relying on the stored Unix expiry timestamp, continue scheduling the recurring token-check job even when Trakt was disabled, and produce noisy error logging during expected OAuth/device-auth failure paths.

## Changes

### Trakt refresh handling

- Detect `invalid_grant` responses during Trakt token refresh
- Treat revoked or expired refresh tokens as expected deauthorization
- Disable Trakt automatically when refresh tokens are revoked or expired
- Clear invalid auth state safely
- Prevent repeated refresh attempts with permanently invalid refresh tokens
- Reduce noisy logging for expected OAuth revoke flows

### Token validity check

- Validate the current Trakt access token with a lightweight authenticated API call before trusting the stored expiry timestamp
- Refresh immediately if the current access token is no longer valid, even if the saved Unix expiry has not elapsed
- Fall back to the stored expiry timestamp only when token validity cannot be confirmed

### Scheduling

- Only schedule the recurring `CheckTraktTokenJob` when Trakt is enabled
- Remove the persisted recurring Trakt token-check job when Trakt is disabled, so old Quartz state does not keep firing it

### Cleanup

- Refactor `SendData()` stream handling to use `using` declarations for safer disposal
- Replace brittle raw OAuth error string matching with JSON parsing
- Use named Trakt status constants consistently for expected device-auth polling statuses

## Result

Revoked or expired Trakt tokens now:

- fail gracefully
- disable Trakt until re-authenticated
- are detected even if the stored expiry timestamp has not elapsed
- avoid repeated retry/error loops
- avoid noisy expected OAuth/device-auth error logging

When Trakt is disabled:

- the recurring token-check job is no longer scheduled
- previously persisted recurring token-check jobs are removed