### PR TITLE
add GHA Docker layer cache to all three build workflows

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -673,6 +673,8 @@ jobs:
             ghcr.io/${{ secrets.DOCKER_REPO }}:daily-${{ matrix.arch }}
             ${{ secrets.DOCKER_REPO }}:daily-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
           build-args: |
             version=${{ needs.current_info.outputs.version }}
             channel=dev

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -546,6 +546,8 @@ jobs:
             ${{ secrets.DOCKER_REPO }}:${{ needs.current_info.outputs.tag_major }}-${{ matrix.arch }}
             ${{ secrets.DOCKER_REPO }}:${{ needs.current_info.outputs.tag_minor }}-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
           build-args: |
             version=${{ needs.current_info.outputs.version }}
             channel=stable

--- a/.github/workflows/docker-manual.yml
+++ b/.github/workflows/docker-manual.yml
@@ -128,6 +128,8 @@ jobs:
             ghcr.io/${{ secrets.DOCKER_REPO }}:${{ github.event.inputs.tag }}-${{ matrix.arch }}
             ${{ secrets.DOCKER_REPO }}:${{ github.event.inputs.tag }}-${{ matrix.arch }}
           platforms: linux/${{ matrix.arch }}
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
           build-args: |
             version=${{ github.event.inputs.version }}
             channel=${{ github.event.inputs.release }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,14 @@ ENV PUID=1000 \
     LC_CTYPE=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-RUN apt-get update && apt-get install -y gnupg curl
-
-RUN curl --retry 3 -O https://mediaarea.net/repo/deb/debian/pubkey.gpg
-# This converts the old format gpg key to the new format. The old format cannot be used with [signed-by] in the apt sources.list file.
-RUN gpg --no-default-keyring --keyring ./temp-keyring.gpg --import pubkey.gpg && gpg --no-default-keyring --keyring ./temp-keyring.gpg --export --output /usr/share/keyrings/mediainfo.gpg && rm pubkey.gpg
-RUN echo "deb [signed-by=/usr/share/keyrings/mediainfo.gpg] https://mediaarea.net/repo/deb/debian/ bookworm main" | tee -a /etc/apt/sources.list
-
-RUN apt-get update && apt-get install -y apt-utils gosu mediainfo librhash-dev
+RUN apt-get update && apt-get install -y gnupg curl \
+    && curl --retry 3 -O https://mediaarea.net/repo/deb/debian/pubkey.gpg \
+    # This converts the old format gpg key to the new format. The old format cannot be used with [signed-by] in the apt sources.list file.
+    && gpg --no-default-keyring --keyring ./temp-keyring.gpg --import pubkey.gpg \
+    && gpg --no-default-keyring --keyring ./temp-keyring.gpg --export --output /usr/share/keyrings/mediainfo.gpg \
+    && rm pubkey.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/mediainfo.gpg] https://mediaarea.net/repo/deb/debian/ bookworm main" | tee -a /etc/apt/sources.list \
+    && apt-get update && apt-get install -y apt-utils gosu mediainfo librhash-dev
 
 WORKDIR /usr/src/app/build
 COPY --from=build /usr/src/app/build .

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -22,14 +22,14 @@ ENV PUID=1000 \
     LC_CTYPE=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-RUN apt-get update && apt-get install -y gnupg curl
-
-RUN curl --retry 3 -O https://mediaarea.net/repo/deb/debian/pubkey.gpg
-# This converts the old format gpg key to the new format. The old format cannot be used with [signed-by] in the apt sources.list file.
-RUN gpg --no-default-keyring --keyring ./temp-keyring.gpg --import pubkey.gpg && gpg --no-default-keyring --keyring ./temp-keyring.gpg --export --output /usr/share/keyrings/mediainfo.gpg && rm pubkey.gpg
-RUN echo "deb [signed-by=/usr/share/keyrings/mediainfo.gpg] https://mediaarea.net/repo/deb/debian/ bookworm main" | tee -a /etc/apt/sources.list
-
-RUN apt-get update && apt-get install -y apt-utils gosu mediainfo librhash-dev
+RUN apt-get update && apt-get install -y gnupg curl \
+    && curl --retry 3 -O https://mediaarea.net/repo/deb/debian/pubkey.gpg \
+    # This converts the old format gpg key to the new format. The old format cannot be used with [signed-by] in the apt sources.list file.
+    && gpg --no-default-keyring --keyring ./temp-keyring.gpg --import pubkey.gpg \
+    && gpg --no-default-keyring --keyring ./temp-keyring.gpg --export --output /usr/share/keyrings/mediainfo.gpg \
+    && rm pubkey.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/mediainfo.gpg] https://mediaarea.net/repo/deb/debian/ bookworm main" | tee -a /etc/apt/sources.list \
+    && apt-get update && apt-get install -y apt-utils gosu mediainfo librhash-dev
 
 WORKDIR /usr/src/app/build
 COPY --from=build /usr/src/app/build .


### PR DESCRIPTION
Add cache-from and cache-to with type=gha to the docker/build-push-action step in build-daily.yml, build-release.yml, and docker-manual.yml. All three use scope=docker-${{ matrix.arch }} to keep amd64 and arm64 caches separate while sharing the same cache pool across workflows — daily builds warm the cache for release and manual builds. Runtime stage layers (apt, GPG key setup, mediainfo install) will always be cache hits; the build stage will hit when no source files changed
