### PR TITLE
fix(search): apply NFKC normalisation before string comparison

### DIFF
--- a/Shoko.Server/Utilities/SeriesSearch.cs
+++ b/Shoko.Server/Utilities/SeriesSearch.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using F23.StringSimilarity;
 using F23.StringSimilarity.Interfaces;
 using Shoko.Abstractions.Extensions;
@@ -40,7 +41,8 @@ public static class SeriesSearch
     }
 
     private static string SanitizeSearchInput(this string value) =>
-        value.Replace('_', ' ')
+        value.Normalize(NormalizationForm.FormKC)
+            .Replace('_', ' ')
             .Replace('-', ' ')
             .CompactWhitespaces()
             .ToLowerInvariant();
@@ -48,7 +50,8 @@ public static class SeriesSearch
     // This forces ASCII, because it's faster to stop caring if ss and ß are the same
     // No it's not perfect, but it works better for those who just want to do lazy searching
     private static string ForceASCII(this string value) =>
-        value.FilterSearchCharacters()
+        value.Normalize(NormalizationForm.FormKC)
+            .FilterSearchCharacters()
             .CompactWhitespaces()
             .ToLowerInvariant();
 

--- a/Shoko.Tests/SeriesSearchNormalizationTest.cs
+++ b/Shoko.Tests/SeriesSearchNormalizationTest.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using Shoko.Server.Utilities;
+using Xunit;
+
+// ReSharper disable StringLiteralTypo
+
+namespace Shoko.Tests;
+
+public class SeriesSearchNormalizationTest
+{
+    public static IEnumerable<object[]> FullwidthAsciiData => new List<object[]>
+    {
+        // Fullwidth ASCII title matched by normal ASCII query
+        new object[] { "Ｇｉｎｔａｍａ", "gintama", true },
+        new object[] { "ＧＩＮＴＡＭＡ", "gintama", true },
+        new object[] { "ｇｉｎｔａｍａ", "GINTAMA", true },
+        // Normal ASCII title matched by fullwidth query
+        new object[] { "Gintama", "Ｇｉｎｔａｍａ", true },
+        // Unrelated titles should not match
+        new object[] { "Ｎａｒｕｔｏ", "gintama", false },
+    };
+
+    public static IEnumerable<object[]> HalfwidthKatakanaData => new List<object[]>
+    {
+        // Halfwidth katakana title matched by fullwidth katakana query
+        new object[] { "ｱｲｳｴｵ", "アイウエオ", true },
+        // Fullwidth katakana title matched by halfwidth query
+        new object[] { "アイウエオ", "ｱｲｳｴｵ", true },
+    };
+
+    public static IEnumerable<object[]> MixedData => new List<object[]>
+    {
+        // Mix of fullwidth and normal characters
+        new object[] { "Ｇｉｎtama", "gintama", true },
+        new object[] { "gintama", "Ｇｉｎtama", true },
+    };
+
+    [Theory, MemberData(nameof(FullwidthAsciiData))]
+    public void FullwidthAsciiNormalization(string title, string query, bool expectMatch)
+        => Assert.Equal(expectMatch, title.FuzzyMatch(query));
+
+    [Theory, MemberData(nameof(HalfwidthKatakanaData))]
+    public void HalfwidthKatakanaNormalization(string title, string query, bool expectMatch)
+        => Assert.Equal(expectMatch, title.FuzzyMatch(query));
+
+    public static IEnumerable<object[]> EllipsisData => new List<object[]>
+    {
+        // U+2026 ellipsis in title matched by three-period query
+        new object[] { "Fullmetal Alchemist…", "Fullmetal Alchemist...", true },
+        // Three-period title matched by U+2026 query
+        new object[] { "Fullmetal Alchemist...", "Fullmetal Alchemist…", true },
+        // Unrelated title should not match
+        new object[] { "Naruto…", "Fullmetal Alchemist...", false },
+    };
+
+    [Theory, MemberData(nameof(MixedData))]
+    public void MixedWidthNormalization(string title, string query, bool expectMatch)
+        => Assert.Equal(expectMatch, title.FuzzyMatch(query));
+
+    [Theory, MemberData(nameof(EllipsisData))]
+    public void EllipsisNormalization(string title, string query, bool expectMatch)
+        => Assert.Equal(expectMatch, title.FuzzyMatch(query));
+}


### PR DESCRIPTION
Thanks Revam for the idea -

Normalise search input and candidate titles to Unicode Normalization
Form KC before comparison so that fullwidth ASCII (e.g. Ｇｉｎｔａｍａ),
halfwidth katakana, and compatibility characters such as the horizontal
ellipsis (U+2026 → ...) are folded to their canonical equivalents.
This allows queries and stored titles to match regardless of which
Unicode representation was used, without altering any stored filenames
or paths.

Possibly Closes #1332
