### PR TITLE
Normalizes Hash Casing and Updates SQL Server Queries - NEEDS REVIEW BEFORE COMMIT

### DIFF
--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -185,7 +185,7 @@ public class SQLServer(SystemService systemService) : BaseDatabase<SqlConnection
 
     public override bool HasVersionsTable()
     {
-        const string Sql = "SELECT Count(1) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'Versions'";
+        const string Sql = "SELECT Count(1) FROM sys.tables WHERE name = 'Versions'";
         using var connection = new SqlConnection(GetConnectionString());
         var command = new SqlCommand(Sql, connection);
         connection.Open();
@@ -197,13 +197,13 @@ public class SQLServer(SystemService systemService) : BaseDatabase<SqlConnection
     {
         ConnectionWrapper(GetConnectionString(), myConn =>
         {
-            var create = ExecuteScalar(myConn, "Select count(*) from sysobjects where name = 'Versions'") is 0;
+            var create = ExecuteScalar(myConn, "SELECT count(*) FROM sys.objects WHERE name = 'Versions'") is 0;
             if (create)
             {
                 SystemService.StartupMessage = "Database - Creating Initial Schema...";
                 ExecuteWithException(myConn, _createVersionTable);
             }
-            var updateVersionTable = ExecuteScalar(myConn, "SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE [TABLE_NAME] = 'Versions' and [COLUMN_NAME]='VersionRevision'") is 0;
+            var updateVersionTable = ExecuteScalar(myConn, "SELECT count(*) FROM sys.columns WHERE object_id = OBJECT_ID('Versions') AND name = 'VersionRevision'") is 0;
             if (updateVersionTable)
             {
                 ExecuteWithException(myConn, _updateVersionTable);

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -953,6 +953,13 @@ public class SQLServer(SystemService systemService) : BaseDatabase<SqlConnection
         new(162,  2, "ALTER TABLE VideoLocal_User ADD LastAudioStreamIndex int NULL;"),
         new(162,  3, "ALTER TABLE VideoLocal_User ADD LastSubtitleStreamIndex int NULL;"),
         new(162,  4, "ALTER TABLE VideoLocal_User ADD ClientData nvarchar(max) NULL;"),
+        new(163,  1, "UPDATE VideoLocal SET Hash = UPPER(Hash)"),
+        new(163,  2, "UPDATE VideoLocal_HashDigest SET Type = UPPER(Type)"),
+        new(163,  3, "UPDATE VideoLocal_HashDigest SET Value = UPPER(CAST(Value AS NVARCHAR(MAX))) WHERE Type IN ('ED2K', 'CRC32', 'MD5', 'SHA1', 'SHA256', 'SHA512')"),
+        new(163,  4, "UPDATE CrossRef_File_Episode SET Hash = UPPER(Hash) WHERE Hash IS NOT NULL"),
+        new(163,  5, "UPDATE FileNameHash SET Hash = UPPER(Hash)"),
+        new(163,  6, "UPDATE StoredReleaseInfo SET ED2K = UPPER(ED2K)"),
+        new(163,  7, "UPDATE StoredReleaseInfo_MatchAttempt SET ED2K = UPPER(ED2K)"),
     ];
 
     #endregion


### PR DESCRIPTION
Addresses inconsistencies in hash value casing across the database and improves SQL Server metadata queries.

*   **Standardizes hash storage and lookups:**
    *   Introduces a database migration (163) that converts all existing hash values and hash types in relevant tables to uppercase. This establishes a consistent format for stored hashes.
    *   Updates repository lookup methods to normalize input hash values and types to uppercase. This ensures that queries and cache lookups correctly match the standardized uppercase values, regardless of the input casing.
*   **Refines SQL Server catalog queries:**
    *   Replaces older `INFORMATION_SCHEMA` and `sysobjects` views with `sys.*` catalog views in SQL Server for improved compatibility and efficiency when checking database schema.
*   **Enhances test coverage:**
    *   Adds new unit tests specifically for hash normalization within `VideoLocal_HashDigestRepository`, verifying the robustness of case-insensitive lookups after the changes.

Ongoing changes around https://github.com/ShokoAnime/ShokoServer/issues/1239