### PR TITLE
fix(hashing): normalize SHA512 to uppercase in `CalculateHashesRhash`

### DIFF
--- a/Shoko.Server/Hashing/CoreHashProvider.cs
+++ b/Shoko.Server/Hashing/CoreHashProvider.cs
@@ -340,7 +340,7 @@ public class CoreHashProvider(ILogger<CoreHashProvider> logger, ConfigurationPro
         {
             Native.rhash_print(output, ctx, RHashIds.RHASH_SHA512, RhashPrintSumFlags.RHPR_DEFAULT);
             var sha512 = Marshal.PtrToStringAnsi(output)!;
-            hashes.Add(new HashDigest { Type = "SHA512", Value = sha512 });
+            hashes.Add(new HashDigest { Type = "SHA512", Value = sha512.ToUpperInvariant() });
         }
 
         Marshal.FreeHGlobal(output);


### PR DESCRIPTION
`SHA512` was the only hash type in the RHash path missing `.ToUpperInvariant()`.
All other types (ED2K, CRC32, MD5, SHA1, SHA256) already normalized their
output; this brings SHA512 in line.
