### PR TITLE
fix: removing one of multiple TMDB show links also deleted episodes from surviving links

### DIFF
--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -327,8 +327,11 @@ public class TmdbLinkingService : ITmdbLinkingService
         _xrefAnidbTmdbShows.Delete(xref);
 
         var xrefs = _xrefAnidbTmdbEpisodes.GetOnlyByAnidbAnimeAndTmdbShowIDs(xref.AnidbAnimeID, xref.TmdbShowID).ToList();
-        if (_xrefAnidbTmdbShows.GetByAnidbAnimeID(xref.AnidbAnimeID).Count > 0 && _xrefAnidbTmdbEpisodes.GetByAnidbAnimeID(xref.AnidbAnimeID) is { Count: > 0 } extraXrefs)
-            xrefs.AddRange(extraXrefs);
+        // When removing the last show link, also remove floating episode xrefs (TmdbShowID=0)
+        // created by ResetAllEpisodeLinks. Only do this when no links remain so we don't
+        // accidentally delete xrefs that still belong to surviving show links.
+        if (_xrefAnidbTmdbShows.GetByAnidbAnimeID(xref.AnidbAnimeID).Count == 0)
+            xrefs.AddRange(_xrefAnidbTmdbEpisodes.GetOnlyByAnidbAnimeAndTmdbShowIDs(xref.AnidbAnimeID, 0));
         _logger.LogInformation("Removing {XRefsCount} episodes cross-references for AniDB anime (AnimeID={AnidbID}) and TMDB show (ID={TmdbID})", xrefs.Count, xref.AnidbAnimeID, xref.TmdbShowID);
         _xrefAnidbTmdbEpisodes.Delete(xrefs);
         if (purge)


### PR DESCRIPTION
The condition added in 01795b03 to clean up floating episode xrefs (TmdbShowID=0) when the last show link is removed had two bugs:

1. The guard was `Count > 0` (other links still exist) instead of `Count == 0` (no links remain), so it fired precisely when it should have been a no-op.

2. `GetByAnidbAnimeID` returns every episode xref for the anime, including those owned by surviving show links, causing all of them to be deleted alongside the removed link.

Fix: invert the condition to `Count == 0` and use
`GetOnlyByAnidbAnimeAndTmdbShowIDs(animeId, 0)` so only the floating xrefs (the ones ResetAllEpisodeLinks sets TmdbShowID=0 on) are cleaned up, and only when no show links remain.

Related to https://github.com/ShokoAnime/ShokoServer/issues/1314