### PR TITLE
fix(db): make queue migrations run on SQL Server and MySQL

### DIFF
--- a/Shoko.QueueProcessor.Tests/MultiProviderMigrationTests.cs
+++ b/Shoko.QueueProcessor.Tests/MultiProviderMigrationTests.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Shoko.QueueProcessor.Storage;
+using Xunit;
+
+namespace Shoko.QueueProcessor.Tests;
+
+/// <summary>
+/// Verifies that non-SQLite provider contexts expose the same migration set as
+/// <see cref="SqliteQueueDbContext"/> via <see cref="QueueMigrationsAssembly"/>.
+/// <para>
+/// The root cause this guards against: EF Core's default <c>IMigrationsAssembly</c>
+/// filters by exact <c>[DbContext]</c> type. All migration Designer files are tagged
+/// <c>[DbContext(typeof(SqliteQueueDbContext))]</c>, so without the override a
+/// <see cref="SqlServerQueueDbContext"/> would find zero migrations, skip schema
+/// creation, and crash on the first repository call.
+/// </para>
+/// These tests use <c>Database.GetMigrations()</c>, which reads assembly metadata and
+/// requires no live database connection.
+/// </summary>
+public class MultiProviderMigrationTests
+{
+    [Fact]
+    public void SqlServerContext_ExposesSameMigrationsAsSqlite()
+    {
+        using var sqliteCtx = new SqliteQueueDbContext("Data Source=:memory:");
+        using var sqlServerCtx = new SqlServerQueueDbContext("Server=.;Database=_migrations_test;Trusted_Connection=false;");
+
+        var expected = sqliteCtx.Database.GetMigrations().ToList();
+        var actual = sqlServerCtx.Database.GetMigrations().ToList();
+
+        Assert.NotEmpty(expected);
+        Assert.Equal(expected, actual);
+    }
+}

--- a/Shoko.QueueProcessor/Migrations/20260528013231_InitialCreate.cs
+++ b/Shoko.QueueProcessor/Migrations/20260528013231_InitialCreate.cs
@@ -15,14 +15,14 @@ namespace Shoko.QueueProcessor.Migrations
                 name: "Jobs",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
-                    JobType = table.Column<string>(type: "TEXT", maxLength: 256, nullable: false),
-                    JobKey = table.Column<string>(type: "TEXT", maxLength: 512, nullable: false),
-                    JobDataJson = table.Column<string>(type: "TEXT", maxLength: 4096, nullable: true),
-                    Priority = table.Column<int>(type: "INTEGER", nullable: false, defaultValue: 0),
-                    QueuedAt = table.Column<long>(type: "INTEGER", nullable: false),
-                    ScheduledAt = table.Column<long>(type: "INTEGER", nullable: true),
-                    RetryCount = table.Column<int>(type: "INTEGER", nullable: false, defaultValue: 0)
+                    Id = table.Column<Guid>(nullable: false),
+                    JobType = table.Column<string>(maxLength: 256, nullable: false),
+                    JobKey = table.Column<string>(maxLength: 512, nullable: false),
+                    JobDataJson = table.Column<string>(maxLength: 4096, nullable: true),
+                    Priority = table.Column<int>(nullable: false, defaultValue: 0),
+                    QueuedAt = table.Column<long>(nullable: false),
+                    ScheduledAt = table.Column<long>(nullable: true),
+                    RetryCount = table.Column<int>(nullable: false, defaultValue: 0)
                 },
                 constraints: table =>
                 {

--- a/Shoko.QueueProcessor/Migrations/20260601154911_AddJobChainContext.cs
+++ b/Shoko.QueueProcessor/Migrations/20260601154911_AddJobChainContext.cs
@@ -13,33 +13,30 @@ namespace Shoko.QueueProcessor.Migrations
             migrationBuilder.AddColumn<Guid>(
                 name: "ChainId",
                 table: "Jobs",
-                type: "TEXT",
                 nullable: true);
 
             migrationBuilder.AddColumn<bool>(
                 name: "IsChainFinally",
                 table: "Jobs",
-                type: "INTEGER",
                 nullable: false,
                 defaultValue: false);
 
             migrationBuilder.AddColumn<Guid>(
                 name: "ParentJobId",
                 table: "Jobs",
-                type: "TEXT",
                 nullable: true);
 
             migrationBuilder.CreateTable(
                 name: "JobChains",
                 columns: table => new
                 {
-                    ChainId = table.Column<Guid>(type: "TEXT", nullable: false),
-                    Status = table.Column<int>(type: "INTEGER", nullable: false),
-                    DataJson = table.Column<string>(type: "TEXT", nullable: true),
-                    ResultsJson = table.Column<string>(type: "TEXT", nullable: true),
-                    OutcomesJson = table.Column<string>(type: "TEXT", nullable: true),
-                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
-                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+                    ChainId = table.Column<Guid>(nullable: false),
+                    Status = table.Column<int>(nullable: false),
+                    DataJson = table.Column<string>(nullable: true),
+                    ResultsJson = table.Column<string>(nullable: true),
+                    OutcomesJson = table.Column<string>(nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(nullable: false)
                 },
                 constraints: table =>
                 {

--- a/Shoko.QueueProcessor/Storage/MySqlQueueDbContext.cs
+++ b/Shoko.QueueProcessor/Storage/MySqlQueueDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Shoko.QueueProcessor.Storage;
 
@@ -15,6 +16,8 @@ public class MySqlQueueDbContext : QueueDbContext
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         if (!optionsBuilder.IsConfigured)
-            optionsBuilder.UseMySql(_connectionString, ServerVersion.AutoDetect(_connectionString));
+            optionsBuilder
+                .UseMySql(_connectionString, ServerVersion.AutoDetect(_connectionString))
+                .ReplaceService<IMigrationsAssembly, QueueMigrationsAssembly>();
     }
 }

--- a/Shoko.QueueProcessor/Storage/QueueMigrationsAssembly.cs
+++ b/Shoko.QueueProcessor/Storage/QueueMigrationsAssembly.cs
@@ -2,13 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
-#pragma warning disable EF1001 // MigrationsAssembly is EF Core internal API — intentional subclass for migration discovery re-routing
-using Microsoft.EntityFrameworkCore.Migrations.Internal;
 
 namespace Shoko.QueueProcessor.Storage;
 
@@ -24,26 +20,48 @@ namespace Shoko.QueueProcessor.Storage;
 /// provider's SQL generator still produces provider-appropriate DDL from the untyped columns.
 /// </para>
 /// </summary>
-internal sealed class QueueMigrationsAssembly : MigrationsAssembly
+internal sealed class QueueMigrationsAssembly : IMigrationsAssembly
 {
-    private IReadOnlyDictionary<string, TypeInfo>? _migrations;
+    private readonly Lazy<IReadOnlyDictionary<string, TypeInfo>> _migrations = new(BuildMigrations);
+    private readonly Lazy<ModelSnapshot?> _modelSnapshot = new(BuildModelSnapshot);
 
-    public QueueMigrationsAssembly(
-        ICurrentDbContext currentContext,
-        IDbContextOptions options,
-        IMigrationsIdGenerator idGenerator,
-        IDiagnosticsLogger<DbLoggerCategory.Migrations> logger)
-        : base(currentContext, options, idGenerator, logger) { }
+    public Assembly Assembly => typeof(SqliteQueueDbContext).Assembly;
 
-    public override IReadOnlyDictionary<string, TypeInfo> Migrations
-        => LazyInitializer.EnsureInitialized(ref _migrations, GetQueueMigrations)!;
+    public ModelSnapshot? ModelSnapshot => _modelSnapshot.Value;
 
-    private IReadOnlyDictionary<string, TypeInfo> GetQueueMigrations()
-        => Assembly.DefinedTypes
+    public IReadOnlyDictionary<string, TypeInfo> Migrations => _migrations.Value;
+
+    public string? FindMigrationId(string nameOrId)
+    {
+        var id = nameOrId.TrimStart('[').TrimEnd(']');
+        return Migrations.Keys.FirstOrDefault(k =>
+            string.Equals(k, id, StringComparison.OrdinalIgnoreCase) ||
+            k.EndsWith("_" + id, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public Migration CreateMigration(TypeInfo migrationClass, string activeProvider)
+    {
+        var migration = (Migration)Activator.CreateInstance(migrationClass.AsType())!;
+        migration.ActiveProvider = activeProvider;
+        return migration;
+    }
+
+    private static ModelSnapshot? BuildModelSnapshot()
+        => typeof(SqliteQueueDbContext).Assembly.GetExportedTypes()
             .Where(t =>
-                t.IsSubclassOf(typeof(Migration))
-                && t.GetCustomAttribute<DbContextAttribute>()?.ContextType == typeof(SqliteQueueDbContext))
-            .OrderBy(t => t.GetCustomAttribute<MigrationAttribute>()?.Id)
+                t.IsSubclassOf(typeof(ModelSnapshot)) &&
+                t.GetCustomAttribute<DbContextAttribute>()?.ContextType == typeof(SqliteQueueDbContext))
+            .FirstOrDefault()
+            ?.GetConstructor([])
+            ?.Invoke(null) as ModelSnapshot;
+
+    private static IReadOnlyDictionary<string, TypeInfo> BuildMigrations()
+        => typeof(SqliteQueueDbContext).Assembly.DefinedTypes
+            .Where(t =>
+                t.IsSubclassOf(typeof(Migration)) &&
+                t.GetCustomAttribute<MigrationAttribute>() is not null &&
+                t.GetCustomAttribute<DbContextAttribute>()?.ContextType == typeof(SqliteQueueDbContext))
+            .OrderBy(t => t.GetCustomAttribute<MigrationAttribute>()!.Id)
             .ToDictionary(
                 t => t.GetCustomAttribute<MigrationAttribute>()!.Id,
                 t => t,

--- a/Shoko.QueueProcessor/Storage/QueueMigrationsAssembly.cs
+++ b/Shoko.QueueProcessor/Storage/QueueMigrationsAssembly.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+#pragma warning disable EF1001 // MigrationsAssembly is EF Core internal API — intentional subclass for migration discovery re-routing
+using Microsoft.EntityFrameworkCore.Migrations.Internal;
+
+namespace Shoko.QueueProcessor.Storage;
+
+/// <summary>
+/// Custom <see cref="IMigrationsAssembly"/> that returns migrations tagged for
+/// <see cref="SqliteQueueDbContext"/> regardless of the current provider context type.
+/// <para>
+/// EF Core's default implementation filters migrations by exact DbContext type match
+/// (<c>[DbContext(typeof(T))]</c> must equal the runtime context type). Since all
+/// migrations are generated against <see cref="SqliteQueueDbContext"/>, non-SQLite contexts
+/// would find zero migrations and silently skip schema creation. This override re-routes the
+/// lookup to always match <see cref="SqliteQueueDbContext"/>-tagged migrations, while each
+/// provider's SQL generator still produces provider-appropriate DDL from the untyped columns.
+/// </para>
+/// </summary>
+internal sealed class QueueMigrationsAssembly : MigrationsAssembly
+{
+    private IReadOnlyDictionary<string, TypeInfo>? _migrations;
+
+    public QueueMigrationsAssembly(
+        ICurrentDbContext currentContext,
+        IDbContextOptions options,
+        IMigrationsIdGenerator idGenerator,
+        IDiagnosticsLogger<DbLoggerCategory.Migrations> logger)
+        : base(currentContext, options, idGenerator, logger) { }
+
+    public override IReadOnlyDictionary<string, TypeInfo> Migrations
+        => LazyInitializer.EnsureInitialized(ref _migrations, GetQueueMigrations)!;
+
+    private IReadOnlyDictionary<string, TypeInfo> GetQueueMigrations()
+        => Assembly.DefinedTypes
+            .Where(t =>
+                t.IsSubclassOf(typeof(Migration))
+                && t.GetCustomAttribute<DbContextAttribute>()?.ContextType == typeof(SqliteQueueDbContext))
+            .OrderBy(t => t.GetCustomAttribute<MigrationAttribute>()?.Id)
+            .ToDictionary(
+                t => t.GetCustomAttribute<MigrationAttribute>()!.Id,
+                t => t,
+                StringComparer.OrdinalIgnoreCase);
+}

--- a/Shoko.QueueProcessor/Storage/SqlServerQueueDbContext.cs
+++ b/Shoko.QueueProcessor/Storage/SqlServerQueueDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Shoko.QueueProcessor.Storage;
 
@@ -15,6 +16,8 @@ public class SqlServerQueueDbContext : QueueDbContext
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         if (!optionsBuilder.IsConfigured)
-            optionsBuilder.UseSqlServer(_connectionString);
+            optionsBuilder
+                .UseSqlServer(_connectionString)
+                .ReplaceService<IMigrationsAssembly, QueueMigrationsAssembly>();
     }
 }


### PR DESCRIPTION
EF Core filters migrations by exact DbContext type via [DbContext] attribute. All migration Designer files are tagged with [DbContext(typeof(SqliteQueueDbContext))], so SqlServerQueueDbContext and MySqlQueueDbContext found zero applicable migrations — MigrateAsync silently no-oped, Jobs table was never created, and WorkerPoolManager crashed on LoadAllAsync.

Secondary issue: migration files hard-coded SQLite affinity type strings (TEXT, INTEGER). SQL Server rejects TEXT as a PRIMARY KEY type, so even if migrations were discovered they would have failed at CREATE TABLE.

- Add QueueMigrationsAssembly: extends MigrationsAssembly, overrides Migrations to find SqliteQueueDbContext-tagged migrations regardless of the current provider context
- Register via ReplaceService in SqlServerQueueDbContext and MySqlQueueDbContext
- Remove explicit type strings from InitialCreate and AddJobChainContext migrations; EF Core now infers provider-appropriate DDL (uniqueidentifier/nvarchar/bigint on SQL Server, char(36)/varchar/bigint on MySQL, TEXT/INTEGER on SQLite unchanged)