### PR TITLE
fix(tmdb): add jitter to local rate-limit retry delay

### DIFF
--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -320,9 +320,11 @@ public class TmdbMetadataService : ITmdbMetadataService
                 switch (ex)
                 {
                     // If we got a _local_ rate limit exception, wait and try again.
+                    // Jitter is added so concurrent callers don't all wake up simultaneously
+                    // and compete for the same token (thundering herd).
                     case RateLimitRejectedException rlrEx:
                     {
-                        var retryAfter = rlrEx.RetryAfter;
+                        var retryAfter = rlrEx.RetryAfter + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 50));
                         await Task.Delay(retryAfter).ConfigureAwait(false);
                         break;
                     }


### PR DESCRIPTION
`UseClient` retries on `RateLimitRejectedException` by waiting `RetryAfter` then immediately re-attempting. With up to 6 concurrent callers (bulkhead limit), all competing callers wake up at nearly the same instant when `RetryAfter` is milliseconds-scale — only one wins the token, the rest get rejected and retry again. Observed result: a single call accumulating 60+ attempts before finally getting a slot.

Adds a random 0–50 ms jitter on top of `RetryAfter` so concurrent callers spread their wakeup times and stop competing for the same token simultaneously.