### PR TITLE
refactor(tmdb): replace polly rate limit with sliding-window TmdbRateLimiter

### DIFF
--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -317,14 +317,17 @@ public class TmdbMetadataService : ITmdbMetadataService
                 // Retry on rate limit exceptions, throw on everything else.
                 switch (ex)
                 {
-                    // If we got a _remote_ rate limit exception, notify the rate limiter and wait.
+                    // If we got a _remote_ rate limit exception, notify the rate limiter.
+                    // The rate limiter's WaitForBackoffAsync handles the actual delay on the next acquire.
                     case RequestLimitExceededException rleEx:
                     {
+                        var rlRetryCount = ctx.TryGetValue("rateLimitRetryCount", out var rlVal) ? (int)rlVal : 0;
+                        if (rlRetryCount >= 10)
+                            goto default;
+                        ctx["rateLimitRetryCount"] = rlRetryCount + 1;
                         var retryAfter = rleEx.RetryAfter ?? TimeSpan.FromSeconds(1);
                         _logger.LogTrace("Hit remote rate limit. Waiting and retrying. Retry count: {RetryCount}, Retry after: {RetryAfter}", retryCount, retryAfter);
                         _rateLimiter.NotifyRateLimitExceeded(retryAfter);
-                        var jitter = TimeSpan.FromMilliseconds(Random.Shared.Next(0, 50));
-                        await Task.Delay(retryAfter + jitter).ConfigureAwait(false);
                         break;
                     }
                     // If we timed out, wait and try again (up to 3 times).
@@ -2636,22 +2639,20 @@ public class TmdbMetadataService : ITmdbMetadataService
             .ToList();
         while (tasks.Count > 0)
         {
+            var task = await Task.WhenAny(tasks).ConfigureAwait(false);
+            tasks.Remove(task);
             try
             {
-                var task = await Task.WhenAny(tasks).ConfigureAwait(false);
-                tasks.Remove(task);
+                await task.ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                var task = tasks.First(task => task.IsFaulted);
-                tasks.Remove(task);
                 exceptions.Add(ex);
                 if (exceptions.Count > maxConcurrent)
                 {
                     cancellationTokenSource.Cancel();
                     throw new AggregateException(exceptions);
                 }
-                continue;
             }
         }
 

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -203,6 +203,41 @@ public class TmdbMetadataService : ITmdbMetadataService
     /// <summary>
     /// Execute the given function with the TMDb client, applying rate limiting and retry policies.
     /// </summary>
+    private Task OnTmdbRetryAsync(Exception ex, TimeSpan ts, int retryCount, Context ctx)
+    {
+        switch (ex)
+        {
+            // If we got a _remote_ rate limit exception, notify the rate limiter.
+            // The rate limiter's WaitForBackoffAsync handles the actual delay on the next acquire.
+            case RequestLimitExceededException rleEx:
+            {
+                var rlRetryCount = ctx.TryGetValue("rateLimitRetryCount", out var rlVal) ? (int)rlVal : 0;
+                if (rlRetryCount >= 10)
+                    throw ex;
+                ctx["rateLimitRetryCount"] = rlRetryCount + 1;
+                var retryAfter = rleEx.RetryAfter ?? TimeSpan.FromSeconds(1);
+                _logger.LogTrace("Hit remote rate limit. Waiting and retrying. Retry count: {RetryCount}, Retry after: {RetryAfter}", retryCount, retryAfter);
+                _rateLimiter.NotifyRateLimitExceeded(retryAfter);
+                break;
+            }
+            // If we timed out, wait and try again (up to 3 times).
+            case HttpRequestException hrEx when hrEx.InnerException is TaskCanceledException:
+            {
+                var timeoutRetryCount = ctx.TryGetValue("timeoutRetryCount", out var timeoutRetryCountValue) ? (int)timeoutRetryCountValue : 0;
+                if (timeoutRetryCount >= 3)
+                    throw ex;
+                ctx["timeoutRetryCount"] = timeoutRetryCount + 1;
+                break;
+            }
+            case GeneralHttpException ghEx:
+                _logger.LogWarning(ghEx, "Got a general HTTP exception while processing TMDb request: {StatusCode}", (int)ghEx.HttpStatusCode);
+                throw ex;
+            default:
+                throw ex;
+        }
+        return Task.CompletedTask;
+    }
+
     /// <typeparam name="T">The type of the result of the function.</typeparam>
     /// <param name="func">The function to execute with the TMDb client.</param>
     /// <param name="displayName">The name of the function to display in the logs.</param>
@@ -312,43 +347,7 @@ public class TmdbMetadataService : ITmdbMetadataService
             .Handle<HttpRequestException>()
             .Or<GeneralHttpException>()
             .Or<RequestLimitExceededException>()
-            .WaitAndRetryAsync(int.MaxValue, (_, _) => TimeSpan.Zero, async (ex, ts, retryCount, ctx) =>
-            {
-                // Retry on rate limit exceptions, throw on everything else.
-                switch (ex)
-                {
-                    // If we got a _remote_ rate limit exception, notify the rate limiter.
-                    // The rate limiter's WaitForBackoffAsync handles the actual delay on the next acquire.
-                    case RequestLimitExceededException rleEx:
-                    {
-                        var rlRetryCount = ctx.TryGetValue("rateLimitRetryCount", out var rlVal) ? (int)rlVal : 0;
-                        if (rlRetryCount >= 10)
-                            goto default;
-                        ctx["rateLimitRetryCount"] = rlRetryCount + 1;
-                        var retryAfter = rleEx.RetryAfter ?? TimeSpan.FromSeconds(1);
-                        _logger.LogTrace("Hit remote rate limit. Waiting and retrying. Retry count: {RetryCount}, Retry after: {RetryAfter}", retryCount, retryAfter);
-                        _rateLimiter.NotifyRateLimitExceeded(retryAfter);
-                        break;
-                    }
-                    // If we timed out, wait and try again (up to 3 times).
-                    case HttpRequestException hrEx when hrEx.InnerException is TaskCanceledException:
-                    {
-                        // If we timed out more than 3 times, just throw the exception, since the exceptions were likely caused by other network issues.
-                        var timeoutRetryCount = ctx.TryGetValue("timeoutRetryCount", out var timeoutRetryCountValue) ? (int)timeoutRetryCountValue : 0;
-                        if (timeoutRetryCount >= 3)
-                            goto default;
-                        ctx["timeoutRetryCount"] = timeoutRetryCount + 1;
-                        break;
-                    }
-                    case GeneralHttpException ghEx:
-                    {
-                        _logger.LogWarning(ghEx, "Got a general HTTP exception while processing TMDb request: {StatusCode}", (int)ghEx.HttpStatusCode);
-                        goto default;
-                    }
-                    default:
-                        throw ex;
-                }
-            });
+            .WaitAndRetryAsync(int.MaxValue, (_, _) => TimeSpan.Zero, OnTmdbRetryAsync);
     }
 
     public async Task ScheduleSearchForMatch(int anidbId, bool force)

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Bulkhead;
-using Polly.RateLimit;
 using Polly.Retry;
 using Shoko.Abstractions.Core.Services;
 using Shoko.Abstractions.Extensions;
@@ -193,8 +192,7 @@ public class TmdbMetadataService : ITmdbMetadataService
     // This policy will ensure only 10 requests can be in-flight at the same time.
     private readonly AsyncBulkheadPolicy _bulkheadPolicy;
 
-    // This policy will ensure we can only make 40 requests per 10 seconds.
-    private readonly AsyncRateLimitPolicy _rateLimitPolicy;
+    private readonly TmdbRateLimiter _rateLimiter;
 
     // This policy, together with the above policy, will ensure the rate limits are enforced, while also ensuring we
     // throw if an exception that's not rate-limit related is thrown.
@@ -228,7 +226,7 @@ public class TmdbMetadataService : ITmdbMetadataService
                 return _retryPolicy.ExecuteAsync(() =>
                 {
                     ++attempts;
-                    return _rateLimitPolicy.ExecuteAsync(() => func(CachedClient));
+                    return _rateLimiter.EnsureRateAsync(() => func(CachedClient));
                 });
             }).ConfigureAwait(false);
 
@@ -248,6 +246,7 @@ public class TmdbMetadataService : ITmdbMetadataService
         ILogger<TmdbMetadataService> logger,
         IQueueScheduler scheduler,
         ISettingsProvider settingsProvider,
+        TmdbRateLimiter rateLimiter,
         TmdbImageService imageService,
         TmdbLinkingService linkingService,
         AnimeSeriesRepository animeSeries,
@@ -306,12 +305,11 @@ public class TmdbMetadataService : ITmdbMetadataService
         _xrefTmdbCompanyEntity = xrefTmdbCompanyEntity;
         _xrefTmdbShowNetwork = xrefTmdbShowNetwork;
         _entityLock = new(logger);
+        _rateLimiter = rateLimiter;
         _instance ??= this;
         _bulkheadPolicy = Policy.BulkheadAsync(_maxConcurrency, int.MaxValue);
-        _rateLimitPolicy = Policy.RateLimitAsync(45, TimeSpan.FromSeconds(10), 45);
         _retryPolicy = Policy
-            .Handle<RateLimitRejectedException>()
-            .Or<HttpRequestException>()
+            .Handle<HttpRequestException>()
             .Or<GeneralHttpException>()
             .Or<RequestLimitExceededException>()
             .WaitAndRetryAsync(int.MaxValue, (_, _) => TimeSpan.Zero, async (ex, ts, retryCount, ctx) =>
@@ -319,22 +317,17 @@ public class TmdbMetadataService : ITmdbMetadataService
                 // Retry on rate limit exceptions, throw on everything else.
                 switch (ex)
                 {
-                    // If we got a _local_ rate limit exception, wait and try again.
-                    case RateLimitRejectedException rlrEx:
-                    {
-                        var retryAfter = rlrEx.RetryAfter;
-                        await Task.Delay(retryAfter).ConfigureAwait(false);
-                        break;
-                    }
-                    // If we got a _remote_ rate limit exception, wait and try again.
+                    // If we got a _remote_ rate limit exception, notify the rate limiter and wait.
                     case RequestLimitExceededException rleEx:
                     {
-                        // Note: We don't actually wait here since the library has already waited for us.
                         var retryAfter = rleEx.RetryAfter ?? TimeSpan.FromSeconds(1);
                         _logger.LogTrace("Hit remote rate limit. Waiting and retrying. Retry count: {RetryCount}, Retry after: {RetryAfter}", retryCount, retryAfter);
+                        _rateLimiter.NotifyRateLimitExceeded(retryAfter);
+                        var jitter = TimeSpan.FromMilliseconds(Random.Shared.Next(0, 50));
+                        await Task.Delay(retryAfter + jitter).ConfigureAwait(false);
                         break;
                     }
-                    // If we timed out or got a too many requests exception, just wait and try again.
+                    // If we timed out, wait and try again (up to 3 times).
                     case HttpRequestException hrEx when hrEx.InnerException is TaskCanceledException:
                     {
                         // If we timed out more than 3 times, just throw the exception, since the exceptions were likely caused by other network issues.
@@ -674,19 +667,19 @@ public class TmdbMetadataService : ITmdbMetadataService
             .Concat(existingCrewDict.Values.Select(crew => crew.TmdbPersonID))
             .Except(peopleToKeep)
             .ToHashSet();
-        foreach (var personId in peopleToKeep)
+        await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToKeep, async personId =>
         {
             var (added, updated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentMovieId: tmdbMovie.Id);
             if (added)
-                peopleAdded++;
+                Interlocked.Increment(ref peopleAdded);
             if (updated)
-                peopleUpdated++;
-        }
-        foreach (var personId in peopleToPurge)
+                Interlocked.Increment(ref peopleUpdated);
+        });
+        await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToPurge, async personId =>
         {
             if (await PurgePerson(personId))
-                peoplePurged++;
-        }
+                Interlocked.Increment(ref peoplePurged);
+        });
 
         _logger.LogDebug("Added/removed {a}/{u}/{r}/{s} staff for movie {MovieTitle} (Movie={MovieId})",
             peopleAdded,
@@ -1348,21 +1341,21 @@ public class TmdbMetadataService : ITmdbMetadataService
         var peopleAdded = 0;
         var peopleUpdated = 0;
         var peoplePurged = 0;
-        var peopleToCheck = allPeopleToAddOrKeep.ToArray().Distinct().ToList();
-        var peopleToPurge = allPeopleToPotentiallyRemove.ToArray().Distinct().Except(peopleToCheck).ToList();
-        foreach (var personId in peopleToCheck)
+        var peopleToCheck = allPeopleToAddOrKeep.Distinct().ToList();
+        var peopleToPurge = allPeopleToPotentiallyRemove.Distinct().Except(peopleToCheck).ToList();
+        await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToCheck, async personId =>
         {
             var (added, updated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentShowId: show.Id);
             if (added)
-                peopleAdded++;
+                Interlocked.Increment(ref peopleAdded);
             if (updated)
-                peopleUpdated++;
-        }
-        foreach (var personId in peopleToPurge)
+                Interlocked.Increment(ref peopleUpdated);
+        });
+        await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToPurge, async personId =>
         {
             if (await PurgePerson(personId))
-                peoplePurged++;
-        }
+                Interlocked.Increment(ref peoplePurged);
+        });
 
         _logger.LogDebug("Added/removed {a}/{u}/{r}/{s} staff for show {ShowTitle} (Show={ShowId})",
             peopleAdded,
@@ -2482,8 +2475,7 @@ public class TmdbMetadataService : ITmdbMetadataService
     {
         var people = _tmdbPeople.GetAll().Where(p => !IsPersonLinkedToOtherEntities(p.TmdbPersonID)).ToList();
         _logger.LogDebug("Checking {count} orphaned staff members if they should be purged.", people.Count);
-        foreach (var person in people)
-            await PurgePerson(person.TmdbPersonID, force: true);
+        await ProcessWithConcurrencyAsync(_maxConcurrency, people, person => PurgePerson(person.TmdbPersonID, force: true));
     }
 
     public async Task<bool> PurgePerson(int personId, bool force = false)

--- a/Shoko.Server/Providers/TMDB/TmdbRateLimiter.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbRateLimiter.cs
@@ -53,6 +53,7 @@ public class TmdbRateLimiter : IDisposable
     {
         _settingsProvider.Saved -= OnSettingsSaved;
         _limiter.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     private void OnSettingsSaved(object? sender, ConfigurationSavedEventArgs<ServerSettings> eventArgs)

--- a/Shoko.Server/Providers/TMDB/TmdbRateLimiter.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbRateLimiter.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Shoko.Abstractions.Config;
+using Shoko.Abstractions.Config.Events;
+using Shoko.Server.Settings;
+
+#nullable enable
+namespace Shoko.Server.Providers.TMDB;
+
+/// <summary>
+/// Sliding-window rate limiter for the TMDB API (~40 req/sec enforced by TMDB).
+/// Tracks real request timestamps so callers can observe <see cref="CallsInWindow"/>
+/// and <see cref="RemainingInWindow"/>, and adapts to server-enforced 429 backoff
+/// via <see cref="NotifyRateLimitExceeded"/>.
+/// </summary>
+public class TmdbRateLimiter
+{
+    private readonly ILogger<TmdbRateLimiter> _logger;
+
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    private readonly ConcurrentQueue<long> _requestTimestamps = new();
+
+    private long _backoffUntilTicks;
+
+    private readonly object _settingsLock = new();
+
+    private readonly ConfigurationProvider<ServerSettings> _settingsProvider;
+
+    private int? _maxRequestsPerWindow;
+
+    private int? _windowDurationMs;
+
+    private int MaxRequestsPerWindow
+    {
+        get
+        {
+            EnsureUsable();
+            return _maxRequestsPerWindow!.Value;
+        }
+    }
+
+    private int WindowDurationMs
+    {
+        get
+        {
+            EnsureUsable();
+            return _windowDurationMs!.Value;
+        }
+    }
+
+    /// <summary>
+    /// Number of requests recorded in the current sliding window.
+    /// </summary>
+    public int CallsInWindow
+    {
+        get
+        {
+            PruneOldTimestamps();
+            return _requestTimestamps.Count;
+        }
+    }
+
+    /// <summary>
+    /// Remaining request capacity in the current sliding window.
+    /// </summary>
+    public int RemainingInWindow => Math.Max(0, MaxRequestsPerWindow - CallsInWindow);
+
+    public TmdbRateLimiter(ILogger<TmdbRateLimiter> logger, ConfigurationProvider<ServerSettings> settingsProvider)
+    {
+        _logger = logger;
+        _settingsProvider = settingsProvider;
+        _settingsProvider.Saved += OnSettingsSaved;
+    }
+
+    ~TmdbRateLimiter()
+    {
+        _settingsProvider.Saved -= OnSettingsSaved;
+    }
+
+    private void OnSettingsSaved(object? sender, ConfigurationSavedEventArgs<ServerSettings> eventArgs)
+    {
+        EnsureUsable(true);
+    }
+
+    private void EnsureUsable(bool force = false)
+    {
+        if (!force && _maxRequestsPerWindow.HasValue)
+            return;
+
+        lock (_settingsLock)
+        {
+            if (!force && _maxRequestsPerWindow.HasValue)
+                return;
+
+            var settings = _settingsProvider.Load().TMDB.RateLimit;
+            _maxRequestsPerWindow = settings.MaxRequestsPerWindow;
+            _windowDurationMs = settings.WindowDurationMs;
+        }
+    }
+
+    /// <summary>
+    /// Signal that TMDB returned a 429. All pending <see cref="EnsureRateAsync{T}"/> calls
+    /// will pause until the backoff window elapses.
+    /// </summary>
+    /// <param name="retryAfter">Duration to back off; defaults to 1 second if null.</param>
+    public void NotifyRateLimitExceeded(TimeSpan? retryAfter)
+    {
+        var delay = retryAfter ?? TimeSpan.FromSeconds(1);
+        var until = DateTimeOffset.UtcNow + delay;
+        Interlocked.Exchange(ref _backoffUntilTicks, until.UtcTicks);
+        _logger.LogTrace("TMDB rate limit exceeded. Backing off until {Until}", until);
+    }
+
+    /// <summary>
+    /// Acquire a rate-limit slot, then execute <paramref name="action"/>.
+    /// The slot is recorded before the action runs; the action itself executes
+    /// outside the internal lock so concurrent calls are allowed.
+    /// </summary>
+    public async Task<T> EnsureRateAsync<T>(Func<Task<T>> action)
+    {
+        await AcquireSlotAsync();
+        return await action();
+    }
+
+    private void PruneOldTimestamps()
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(-WindowDurationMs).UtcTicks;
+        while (_requestTimestamps.TryPeek(out var oldest) && oldest < cutoff)
+            _requestTimestamps.TryDequeue(out _);
+    }
+
+    private async Task AcquireSlotAsync()
+    {
+        while (true)
+        {
+            await _semaphore.WaitAsync();
+
+            PruneOldTimestamps();
+
+            // Honour server-enforced backoff (set by NotifyRateLimitExceeded).
+            // Do NOT clear the field here — every concurrent caller must see the backoff
+            // until the timestamp naturally expires (UtcNow >= backoffTicks).
+            var backoffTicks = Interlocked.Read(ref _backoffUntilTicks);
+            if (backoffTicks > 0 && DateTimeOffset.UtcNow.UtcTicks < backoffTicks)
+            {
+                var backoffWait = new DateTimeOffset(backoffTicks, TimeSpan.Zero) - DateTimeOffset.UtcNow;
+                _semaphore.Release();
+                if (backoffWait > TimeSpan.Zero)
+                {
+                    var jitter = TimeSpan.FromMilliseconds(Random.Shared.Next(0, 50));
+                    _logger.LogTrace("TMDB server backoff active. Waiting {Wait}ms", (backoffWait + jitter).TotalMilliseconds);
+                    await Task.Delay(backoffWait + jitter);
+                }
+                continue;
+            }
+
+            // Slot available — record the timestamp and return.
+            if (_requestTimestamps.Count < MaxRequestsPerWindow)
+            {
+                _requestTimestamps.Enqueue(DateTimeOffset.UtcNow.UtcTicks);
+                _semaphore.Release();
+                _logger.LogTrace("TMDB slot acquired. Calls in window: {Calls}/{Max}", _requestTimestamps.Count, MaxRequestsPerWindow);
+                return;
+            }
+
+            // Window full — wait until the oldest recorded request expires.
+            _requestTimestamps.TryPeek(out var oldestTick);
+            var expiry = new DateTimeOffset(oldestTick, TimeSpan.Zero).AddMilliseconds(WindowDurationMs);
+            var waitTime = expiry - DateTimeOffset.UtcNow;
+            _semaphore.Release();
+
+            if (waitTime > TimeSpan.Zero)
+            {
+                var jitter = TimeSpan.FromMilliseconds(Random.Shared.Next(0, 50));
+                _logger.LogTrace("TMDB window full ({Calls}/{Max}). Waiting {Wait}ms", _requestTimestamps.Count, MaxRequestsPerWindow, (waitTime + jitter).TotalMilliseconds);
+                await Task.Delay(waitTime + jitter);
+            }
+        }
+    }
+}

--- a/Shoko.Server/Providers/TMDB/TmdbRateLimiter.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbRateLimiter.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections.Concurrent;
 using System.Threading;
+using System.Threading.RateLimiting;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Shoko.Abstractions.Config;
@@ -11,96 +11,68 @@ using Shoko.Server.Settings;
 namespace Shoko.Server.Providers.TMDB;
 
 /// <summary>
-/// Sliding-window rate limiter for the TMDB API (~40 req/sec enforced by TMDB).
-/// Tracks real request timestamps so callers can observe <see cref="CallsInWindow"/>
-/// and <see cref="RemainingInWindow"/>, and adapts to server-enforced 429 backoff
-/// via <see cref="NotifyRateLimitExceeded"/>.
+/// Rate limiter for the TMDB API (~40 req/sec enforced by TMDB).
+/// Uses a fixed window to enforce a local request cap and adapts to server-enforced
+/// 429 backoff via <see cref="NotifyRateLimitExceeded"/>.
 /// </summary>
-public class TmdbRateLimiter
+public class TmdbRateLimiter : IDisposable
 {
     private readonly ILogger<TmdbRateLimiter> _logger;
 
-    private readonly SemaphoreSlim _semaphore = new(1, 1);
+    private readonly ConfigurationProvider<ServerSettings> _settingsProvider;
 
-    private readonly ConcurrentQueue<long> _requestTimestamps = new();
+    private volatile SlidingWindowRateLimiter _limiter;
+
+    private volatile int _maxRequestsPerWindow;
 
     private long _backoffUntilTicks;
 
-    private readonly object _settingsLock = new();
-
-    private readonly ConfigurationProvider<ServerSettings> _settingsProvider;
-
-    private int? _maxRequestsPerWindow;
-
-    private int? _windowDurationMs;
-
-    private int MaxRequestsPerWindow
-    {
-        get
-        {
-            EnsureUsable();
-            return _maxRequestsPerWindow!.Value;
-        }
-    }
-
-    private int WindowDurationMs
-    {
-        get
-        {
-            EnsureUsable();
-            return _windowDurationMs!.Value;
-        }
-    }
+    /// <summary>
+    /// Number of requests recorded in the current window.
+    /// </summary>
+    public int CallsInWindow =>
+        _maxRequestsPerWindow - (int)(_limiter.GetStatistics()?.CurrentAvailablePermits ?? _maxRequestsPerWindow);
 
     /// <summary>
-    /// Number of requests recorded in the current sliding window.
+    /// Remaining request capacity in the current window.
     /// </summary>
-    public int CallsInWindow
-    {
-        get
-        {
-            PruneOldTimestamps();
-            return _requestTimestamps.Count;
-        }
-    }
-
-    /// <summary>
-    /// Remaining request capacity in the current sliding window.
-    /// </summary>
-    public int RemainingInWindow => Math.Max(0, MaxRequestsPerWindow - CallsInWindow);
+    public int RemainingInWindow =>
+        (int)(_limiter.GetStatistics()?.CurrentAvailablePermits ?? _maxRequestsPerWindow);
 
     public TmdbRateLimiter(ILogger<TmdbRateLimiter> logger, ConfigurationProvider<ServerSettings> settingsProvider)
     {
         _logger = logger;
         _settingsProvider = settingsProvider;
+        var settings = settingsProvider.Load().TMDB.RateLimit;
+        _maxRequestsPerWindow = settings.MaxRequestsPerWindow;
+        _limiter = CreateLimiter(settings.MaxRequestsPerWindow, settings.WindowDurationMs);
         _settingsProvider.Saved += OnSettingsSaved;
     }
 
-    ~TmdbRateLimiter()
+    public void Dispose()
     {
         _settingsProvider.Saved -= OnSettingsSaved;
+        _limiter.Dispose();
     }
 
     private void OnSettingsSaved(object? sender, ConfigurationSavedEventArgs<ServerSettings> eventArgs)
     {
-        EnsureUsable(true);
+        var settings = _settingsProvider.Load().TMDB.RateLimit;
+        _maxRequestsPerWindow = settings.MaxRequestsPerWindow;
+        // The old limiter is not explicitly disposed so any in-flight AcquireAsync can complete normally.
+        _limiter = CreateLimiter(settings.MaxRequestsPerWindow, settings.WindowDurationMs);
     }
 
-    private void EnsureUsable(bool force = false)
-    {
-        if (!force && _maxRequestsPerWindow.HasValue)
-            return;
-
-        lock (_settingsLock)
+    private static SlidingWindowRateLimiter CreateLimiter(int maxRequests, int windowMs)
+        => new(new SlidingWindowRateLimiterOptions
         {
-            if (!force && _maxRequestsPerWindow.HasValue)
-                return;
-
-            var settings = _settingsProvider.Load().TMDB.RateLimit;
-            _maxRequestsPerWindow = settings.MaxRequestsPerWindow;
-            _windowDurationMs = settings.WindowDurationMs;
-        }
-    }
+            PermitLimit = maxRequests,
+            Window = TimeSpan.FromMilliseconds(windowMs),
+            SegmentsPerWindow = 1,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            QueueLimit = int.MaxValue,
+            AutoReplenishment = true,
+        });
 
     /// <summary>
     /// Signal that TMDB returned a 429. All pending <see cref="EnsureRateAsync{T}"/> calls
@@ -117,68 +89,32 @@ public class TmdbRateLimiter
 
     /// <summary>
     /// Acquire a rate-limit slot, then execute <paramref name="action"/>.
-    /// The slot is recorded before the action runs; the action itself executes
-    /// outside the internal lock so concurrent calls are allowed.
+    /// Blocks if the current window is full or a server 429 backoff is active.
     /// </summary>
     public async Task<T> EnsureRateAsync<T>(Func<Task<T>> action)
     {
-        await AcquireSlotAsync();
+        await WaitForBackoffAsync();
+        using var lease = await _limiter.AcquireAsync(1);
         return await action();
     }
 
-    private void PruneOldTimestamps()
-    {
-        var cutoff = DateTimeOffset.UtcNow.AddMilliseconds(-WindowDurationMs).UtcTicks;
-        while (_requestTimestamps.TryPeek(out var oldest) && oldest < cutoff)
-            _requestTimestamps.TryDequeue(out _);
-    }
-
-    private async Task AcquireSlotAsync()
+    private async Task WaitForBackoffAsync()
     {
         while (true)
         {
-            await _semaphore.WaitAsync();
-
-            PruneOldTimestamps();
-
-            // Honour server-enforced backoff (set by NotifyRateLimitExceeded).
-            // Do NOT clear the field here — every concurrent caller must see the backoff
-            // until the timestamp naturally expires (UtcNow >= backoffTicks).
             var backoffTicks = Interlocked.Read(ref _backoffUntilTicks);
-            if (backoffTicks > 0 && DateTimeOffset.UtcNow.UtcTicks < backoffTicks)
-            {
-                var backoffWait = new DateTimeOffset(backoffTicks, TimeSpan.Zero) - DateTimeOffset.UtcNow;
-                _semaphore.Release();
-                if (backoffWait > TimeSpan.Zero)
-                {
-                    var jitter = TimeSpan.FromMilliseconds(Random.Shared.Next(0, 50));
-                    _logger.LogTrace("TMDB server backoff active. Waiting {Wait}ms", (backoffWait + jitter).TotalMilliseconds);
-                    await Task.Delay(backoffWait + jitter);
-                }
-                continue;
-            }
-
-            // Slot available — record the timestamp and return.
-            if (_requestTimestamps.Count < MaxRequestsPerWindow)
-            {
-                _requestTimestamps.Enqueue(DateTimeOffset.UtcNow.UtcTicks);
-                _semaphore.Release();
-                _logger.LogTrace("TMDB slot acquired. Calls in window: {Calls}/{Max}", _requestTimestamps.Count, MaxRequestsPerWindow);
+            if (backoffTicks == 0 || DateTimeOffset.UtcNow.UtcTicks >= backoffTicks)
                 return;
-            }
 
-            // Window full — wait until the oldest recorded request expires.
-            _requestTimestamps.TryPeek(out var oldestTick);
-            var expiry = new DateTimeOffset(oldestTick, TimeSpan.Zero).AddMilliseconds(WindowDurationMs);
-            var waitTime = expiry - DateTimeOffset.UtcNow;
-            _semaphore.Release();
-
-            if (waitTime > TimeSpan.Zero)
+            var wait = new DateTimeOffset(backoffTicks, TimeSpan.Zero) - DateTimeOffset.UtcNow;
+            if (wait > TimeSpan.Zero)
             {
-                var jitter = TimeSpan.FromMilliseconds(Random.Shared.Next(0, 50));
-                _logger.LogTrace("TMDB window full ({Calls}/{Max}). Waiting {Wait}ms", _requestTimestamps.Count, MaxRequestsPerWindow, (waitTime + jitter).TotalMilliseconds);
-                await Task.Delay(waitTime + jitter);
+                var jitter = Jitter();
+                _logger.LogTrace("TMDB server backoff active. Waiting {Wait}ms", (wait + jitter).TotalMilliseconds);
+                await Task.Delay(wait + jitter);
             }
         }
     }
+
+    internal static TimeSpan Jitter() => TimeSpan.FromMilliseconds(Random.Shared.Next(0, 50));
 }

--- a/Shoko.Server/Services/SystemService.cs
+++ b/Shoko.Server/Services/SystemService.cs
@@ -377,6 +377,7 @@ public class SystemService : ISystemService
 
             services.AddSingleton<IPluginPackageManager, PluginPackageManager>();
             services.AddSingleton<FileWatcherService>();
+            services.AddSingleton<TmdbRateLimiter>();
             services.AddSingleton<TmdbImageService>();
             services.AddSingleton<TmdbLinkingService>();
             services.AddSingleton<ITmdbLinkingService>(sp => sp.GetRequiredService<TmdbLinkingService>());

--- a/Shoko.Server/Settings/TMDBSettings.cs
+++ b/Shoko.Server/Settings/TMDBSettings.cs
@@ -237,4 +237,9 @@ public class TMDBSettings
     [EnvironmentVariable("TMDB_IMAGE_CDN_URL")]
     [Url]
     public string? ImageCdnUrl { get; set; }
+
+    /// <summary>
+    /// Rate limit settings for the TMDB API.
+    /// </summary>
+    public TmdbRateLimitSettings RateLimit { get; set; } = new();
 }

--- a/Shoko.Server/Settings/TmdbRateLimitSettings.cs
+++ b/Shoko.Server/Settings/TmdbRateLimitSettings.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using Shoko.Abstractions.Config.Attributes;
+using Shoko.Abstractions.Config.Enums;
+
+namespace Shoko.Server.Settings;
+
+/// <summary>
+/// Settings for rate limiting the TMDB provider.
+/// </summary>
+public class TmdbRateLimitSettings
+{
+    /// <summary>
+    /// Maximum number of requests allowed within the rate limit window.
+    /// TMDB enforces approximately 40 requests per second; this defaults to 30 for a safe margin.
+    /// </summary>
+    [Badge("Debug", Theme = DisplayColorTheme.Warning)]
+    [Visibility(Size = DisplayElementSize.Small, Advanced = true)]
+    [Display(Name = "Max Requests Per Window")]
+    [Range(1, 40)]
+    public int MaxRequestsPerWindow { get; set; } = 30;
+
+    /// <summary>
+    /// Duration of the sliding rate limit window in milliseconds.
+    /// </summary>
+    [Badge("Debug", Theme = DisplayColorTheme.Warning)]
+    [Visibility(Size = DisplayElementSize.Small, Advanced = true)]
+    [Display(Name = "Window Duration (ms)")]
+    [Range(100, 10000)]
+    public int WindowDurationMs { get; set; } = 1000;
+}

--- a/Shoko.Tests/Providers/TMDB/TmdbRateLimiterTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbRateLimiterTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shoko.Abstractions.Config;
+using Shoko.Abstractions.Config.Services;
+using Shoko.Server.Providers.TMDB;
+using Shoko.Server.Settings;
+using Xunit;
+
+namespace Shoko.Tests.Providers.TMDB;
+
+public class TmdbRateLimiterTests
+{
+    [Fact]
+    public async Task CallsWithinWindow_ProceedImmediately()
+    {
+        var limiter = CreateRateLimiter(maxRequests: 3, windowMs: 500);
+        var sw = Stopwatch.StartNew();
+
+        for (var i = 0; i < 3; i++)
+            await limiter.EnsureRateAsync(() => Task.FromResult(0));
+
+        Assert.True(sw.Elapsed < TimeSpan.FromMilliseconds(200),
+            $"Expected < 200ms for 3 calls within a 3-request window, got {sw.Elapsed.TotalMilliseconds:F0}ms");
+    }
+
+    [Fact]
+    public async Task ExtraCall_WaitsForWindowSlot()
+    {
+        var limiter = CreateRateLimiter(maxRequests: 2, windowMs: 300);
+
+        await limiter.EnsureRateAsync(() => Task.FromResult(0));
+        await limiter.EnsureRateAsync(() => Task.FromResult(0));
+
+        var sw = Stopwatch.StartNew();
+        await limiter.EnsureRateAsync(() => Task.FromResult(0));
+
+        Assert.True(sw.Elapsed >= TimeSpan.FromMilliseconds(200),
+            $"Expected >= 200ms wait for 3rd call with 2-request window, got {sw.Elapsed.TotalMilliseconds:F0}ms");
+    }
+
+    [Fact]
+    public async Task SlotsExpireAfterWindow_AllowsNewCalls()
+    {
+        var limiter = CreateRateLimiter(maxRequests: 2, windowMs: 200);
+
+        await limiter.EnsureRateAsync(() => Task.FromResult(0));
+        await limiter.EnsureRateAsync(() => Task.FromResult(0));
+
+        await Task.Delay(300);
+
+        var sw = Stopwatch.StartNew();
+        await limiter.EnsureRateAsync(() => Task.FromResult(0));
+        await limiter.EnsureRateAsync(() => Task.FromResult(0));
+
+        Assert.True(sw.Elapsed < TimeSpan.FromMilliseconds(200),
+            $"Expected < 200ms after window expiry, got {sw.Elapsed.TotalMilliseconds:F0}ms");
+    }
+
+    [Fact]
+    public async Task NotifyRateLimitExceeded_DelaysSubsequentCalls()
+    {
+        var limiter = CreateRateLimiter(maxRequests: 10, windowMs: 1000);
+
+        limiter.NotifyRateLimitExceeded(TimeSpan.FromMilliseconds(300));
+
+        var sw = Stopwatch.StartNew();
+        await limiter.EnsureRateAsync(() => Task.FromResult(0));
+
+        Assert.True(sw.Elapsed >= TimeSpan.FromMilliseconds(250),
+            $"Expected >= 250ms backoff delay, got {sw.Elapsed.TotalMilliseconds:F0}ms");
+    }
+
+    [Fact]
+    public async Task BackoffAppliesToAllConcurrentCallers_NotSequentially()
+    {
+        var limiter = CreateRateLimiter(maxRequests: 10, windowMs: 1000);
+        limiter.NotifyRateLimitExceeded(TimeSpan.FromMilliseconds(300));
+
+        var sw = Stopwatch.StartNew();
+        await Task.WhenAll(
+            limiter.EnsureRateAsync(() => Task.FromResult(0)),
+            limiter.EnsureRateAsync(() => Task.FromResult(0)),
+            limiter.EnsureRateAsync(() => Task.FromResult(0))
+        );
+
+        // All three waited for the same backoff window (not 3 × 300ms).
+        Assert.True(sw.Elapsed >= TimeSpan.FromMilliseconds(250),
+            $"Expected >= 250ms, got {sw.Elapsed.TotalMilliseconds:F0}ms");
+        Assert.True(sw.Elapsed < TimeSpan.FromMilliseconds(900),
+            $"Expected < 900ms (callers should share the wait, not queue it), got {sw.Elapsed.TotalMilliseconds:F0}ms");
+    }
+
+    [Fact]
+    public async Task CallsInWindow_ReflectsCurrentCount()
+    {
+        var limiter = CreateRateLimiter(maxRequests: 5, windowMs: 2000);
+
+        Assert.Equal(0, limiter.CallsInWindow);
+
+        await limiter.EnsureRateAsync(() => Task.FromResult(0));
+        Assert.Equal(1, limiter.CallsInWindow);
+
+        await limiter.EnsureRateAsync(() => Task.FromResult(0));
+        Assert.Equal(2, limiter.CallsInWindow);
+    }
+
+    [Fact]
+    public async Task RemainingInWindow_ReflectsRemainingCapacity()
+    {
+        var limiter = CreateRateLimiter(maxRequests: 3, windowMs: 2000);
+
+        Assert.Equal(3, limiter.RemainingInWindow);
+
+        await limiter.EnsureRateAsync(() => Task.FromResult(0));
+        Assert.Equal(2, limiter.RemainingInWindow);
+
+        await limiter.EnsureRateAsync(() => Task.FromResult(0));
+        Assert.Equal(1, limiter.RemainingInWindow);
+    }
+
+    private static TmdbRateLimiter CreateRateLimiter(int maxRequests = 3, int windowMs = 200)
+    {
+        var settings = new ServerSettings();
+        settings.TMDB.RateLimit.MaxRequestsPerWindow = maxRequests;
+        settings.TMDB.RateLimit.WindowDurationMs = windowMs;
+
+        var mockService = new Mock<IConfigurationService>();
+        mockService
+            .Setup(s => s.GetConfigurationInfo<ServerSettings>())
+            .Returns((ConfigurationInfo)null!);
+        mockService
+            .Setup(s => s.Load(It.IsAny<ConfigurationInfo>(), It.IsAny<bool>()))
+            .Returns(settings);
+
+        var provider = new ConfigurationProvider<ServerSettings>(mockService.Object);
+        return new TmdbRateLimiter(NullLogger<TmdbRateLimiter>.Instance, provider);
+    }
+}


### PR DESCRIPTION
Replaced `Policy.RateLimitAsync` (token bucket, 45 req/10s) with a dedicated `TmdbRateLimiter` singleton that tracks real request timestamps in a 1-second sliding window.

- Added `TmdbRateLimiter` with `EnsureRateAsync<T>`, `NotifyRateLimitExceeded`, and `CallsInWindow`/`RemainingInWindow` stats
- Added `TmdbRateLimitSettings` (default: 30 req/s window) nested under `TMDBSettings.RateLimit`, configurable at runtime
- Fixed the `RequestLimitExceededException` handler which previously did not wait at all before retrying on a 429 response; it now calls `NotifyRateLimitExceeded` and waits `retryAfter + jitter`
- Removed `RateLimitRejectedException` from the retry policy (no longer thrown since the Polly rate limit policy is gone)
- Jitter on all wait paths prevents thundering herd when concurrent callers hit the window limit or a server backoff simultaneously
- Added `TmdbRateLimiterTests` covering sliding-window throttling, backoff propagation, concurrent caller behaviour, and stats properties