### PR TITLE
chore(tmdb): add inline comments, fix cast/crew orphan purge, skip unchanged seasons/episodes

### DIFF
--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Polly;
@@ -1255,12 +1256,9 @@ public class TmdbMetadataService : ITmdbMetadataService
 
             seasonsToSkip.Add(tmdbSeason.Id);
 
-            var episodeBag = new ConcurrentBag<TMDB_Episode>();
-            var hiddenEpisodeBag = new ConcurrentBag<TMDB_Episode>();
-            // Concurrency 1: episode tasks run inside the outer season loop which already runs at
-            // _maxConcurrency. Allowing episode parallelism too would produce _maxConcurrency² API
-            // calls in flight simultaneously, overwhelming the rate limiter.
-            await ProcessWithConcurrencyAsync(1, season.Episodes!, async (reducedEpisode) =>
+            var episodeBag = new List<TMDB_Episode>();
+            var hiddenEpisodeBag = new List<TMDB_Episode>();
+            foreach (var reducedEpisode in season.Episodes!)
             {
                 _logger.LogDebug("Checking episode {EpisodeNumber} in season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedEpisode.EpisodeNumber, reducedSeason.SeasonNumber, show.Name, show.Id);
                 if (!existingEpisodes.TryGetValue(reducedEpisode.Id, out var tmdbEpisode))
@@ -1317,7 +1315,7 @@ public class TmdbMetadataService : ITmdbMetadataService
                     hiddenEpisodeBag.Add(tmdbEpisode);
                 else
                     episodeBag.Add(tmdbEpisode);
-            });
+            }
 
             var episodeCount = episodeBag.Count;
             var hiddenEpisodeCount = hiddenEpisodeBag.Count;
@@ -1410,7 +1408,7 @@ public class TmdbMetadataService : ITmdbMetadataService
                     Interlocked.Increment(ref peopleUpdated);
             });
         }
-        catch (AggregateException ex)
+        catch (Exception ex)
         {
             // Partial cast/crew failures are non-fatal: a missing person record does not invalidate
             // the show. Log and continue so a transient API error doesn't abort the entire show update.
@@ -1447,7 +1445,7 @@ public class TmdbMetadataService : ITmdbMetadataService
                     Interlocked.Increment(ref peoplePurged);
             });
         }
-        catch (AggregateException ex)
+        catch (Exception ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to purge one or more people during show cast/crew update (Show={ShowId})", show.Id);
         }
@@ -2716,57 +2714,21 @@ public class TmdbMetadataService : ITmdbMetadataService
         if (maxConcurrent < 1)
             throw new ArgumentOutOfRangeException(nameof(maxConcurrent), "Concurrency level must be at least 1.");
 
-        var semaphore = new SemaphoreSlim(maxConcurrent);
-        var exceptions = new List<Exception>();
-        var cancellationTokenSource = new CancellationTokenSource();
-        var tasks = enumerable
-            .Select(item => Task.Run(async () =>
+        // Workers catch individually so the block never faults — all items complete before exceptions surface.
+        var exceptions = new ConcurrentBag<Exception>();
+        var block = new ActionBlock<T>(
+            async item =>
             {
-                // The semaphore is acquired inside the Task.Run lambda so all tasks are started
-                // immediately but only maxConcurrent proceed at a time. Tasks that haven't acquired
-                // the semaphore yet are cancelled cleanly when cancellationTokenSource fires.
-                await semaphore.WaitAsync(cancellationTokenSource.Token).ConfigureAwait(false);
-                try
-                {
-                    await processAsync(item).ConfigureAwait(false);
-                }
-                finally
-                {
-                    semaphore.Release();
-                }
-            }))
-            // HashSet gives O(1) removal after Task.WhenAny; a List would scan the whole set each time.
-            .ToHashSet();
-        while (tasks.Count > 0)
-        {
-            var task = await Task.WhenAny(tasks).ConfigureAwait(false);
-            tasks.Remove(task);
-            try
-            {
-                await task.ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Task was cancelled (internal failure or external shutdown) — not counted as an error.
-            }
-            catch (Exception ex)
-            {
-                exceptions.Add(ex);
-                // Abort once failures fill all concurrency slots: a systemic error would keep piling
-                // up exceptions with no successful work happening. Cancel remaining tasks and surface
-                // everything at once via AggregateException.
-                if (exceptions.Count >= maxConcurrent)
-                {
-                    cancellationTokenSource.Cancel();
-                    throw new AggregateException(exceptions);
-                }
-            }
-        }
-
-        cancellationTokenSource.Dispose();
-        semaphore.Dispose();
-
-        if (exceptions.Count > 0)
+                try { await processAsync(item); }
+                catch (Exception ex) { exceptions.Add(ex); }
+            },
+            new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = maxConcurrent }
+        );
+        foreach (var item in enumerable)
+            block.Post(item);
+        block.Complete();
+        await block.Completion.ConfigureAwait(false);
+        if (!exceptions.IsEmpty)
             throw new AggregateException(exceptions);
     }
 

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -194,8 +194,10 @@ public class TmdbMetadataService : ITmdbMetadataService
 
     private readonly TmdbRateLimiter _rateLimiter;
 
-    // This policy, together with the above policy, will ensure the rate limits are enforced, while also ensuring we
-    // throw if an exception that's not rate-limit related is thrown.
+    // Retries on HTTP/rate-limit/general HTTP exceptions. The zero-delay between retries is intentional —
+    // actual rate-limit pausing happens inside TmdbRateLimiter.EnsureRateAsync. int.MaxValue retries are
+    // safe because OnTmdbRetryAsync enforces per-type caps (10 for 429s, 3 for timeouts) and re-throws
+    // immediately for all other exception types.
     private readonly AsyncRetryPolicy _retryPolicy;
 
     private readonly KeyedEntityLockHelper _entityLock;
@@ -682,6 +684,8 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
         catch (AggregateException ex)
         {
+            // Partial cast/crew failures are non-fatal: a missing person record does not invalidate the
+            // movie. Log and continue so a transient API error doesn't abort the entire movie update.
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
         }
         try
@@ -694,6 +698,7 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
         catch (AggregateException ex)
         {
+            // Same reasoning: a purge failure for one person should not block cleanup of the rest.
             _logger.LogWarning(ex, "TMDB: Failed to purge one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
         }
 
@@ -832,6 +837,7 @@ public class TmdbMetadataService : ITmdbMetadataService
     {
         var toKeep = _xrefAnidbTmdbMovies.GetAll().Select(xref => xref.TmdbMovieID).ToHashSet();
         // Seeded with toKeep so AllCount in the log includes xref-linked IDs that have no TMDB_Movie row yet.
+        // UnionWith calls each GetAll() exactly once; a Concat chain would re-enumerate the same sources.
         var allMovies = new HashSet<int>(toKeep);
         allMovies.UnionWith(_tmdbMovies.GetAll().Select(m => m.TmdbMovieID));
         allMovies.UnionWith(_shokoImageXrefRepository.GetByEntity(DataSource.TMDB, DataEntityType.Movie).Select(xref => int.Parse(xref.EntityID)));
@@ -1215,6 +1221,9 @@ public class TmdbMetadataService : ITmdbMetadataService
 
             var episodeBag = new ConcurrentBag<TMDB_Episode>();
             var hiddenEpisodeBag = new ConcurrentBag<TMDB_Episode>();
+            // Concurrency 1: episode tasks run inside the outer season loop which already runs at
+            // _maxConcurrency. Allowing episode parallelism too would produce _maxConcurrency² API
+            // calls in flight simultaneously, overwhelming the rate limiter.
             await ProcessWithConcurrencyAsync(1, season.Episodes!, async (reducedEpisode) =>
             {
                 _logger.LogDebug("Checking episode {EpisodeNumber} in season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedEpisode.EpisodeNumber, reducedSeason.SeasonNumber, show.Name, show.Id);
@@ -1367,6 +1376,8 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
         catch (AggregateException ex)
         {
+            // Partial cast/crew failures are non-fatal: a missing person record does not invalidate
+            // the show. Log and continue so a transient API error doesn't abort the entire show update.
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during show cast/crew update (Show={ShowId})", show.Id);
         }
         try
@@ -1379,6 +1390,7 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
         catch (AggregateException ex)
         {
+            // Same reasoning: a purge failure for one person should not block cleanup of the rest.
             _logger.LogWarning(ex, "TMDB: Failed to purge one or more people during show cast/crew update (Show={ShowId})", show.Id);
         }
 
@@ -1925,6 +1937,7 @@ public class TmdbMetadataService : ITmdbMetadataService
     {
         var toKeep = _xrefAnidbTmdbShows.GetAll().Select(xref => xref.TmdbShowID).ToHashSet();
         // Seeded with toKeep so AllCount in the log includes xref-linked IDs that have no TMDB_Show row yet.
+        // UnionWith calls each GetAll() exactly once; a Concat chain would re-enumerate the same sources.
         var allShows = new HashSet<int>(toKeep);
         allShows.UnionWith(_tmdbShows.GetAll().Select(s => s.TmdbShowID));
         allShows.UnionWith(_shokoImageXrefRepository.GetByEntity(DataSource.TMDB, DataEntityType.Show).Select(xref => int.Parse(xref.EntityID)));
@@ -2013,6 +2026,8 @@ public class TmdbMetadataService : ITmdbMetadataService
 
     public async Task PurgeUnlinkedShowNetworks()
     {
+        // Build the linked-network set once before iterating. Checking inside the loop would
+        // issue a DB query per network; precomputing keeps the snapshot consistent and avoids N queries.
         var linkedNetworkIds = _xrefTmdbShowNetwork.GetAll().Select(x => x.TmdbNetworkID).ToHashSet();
         var networks = _tmdbNetwork.GetAll().Where(p => !linkedNetworkIds.Contains(p.TmdbNetworkID)).ToList();
         _logger.LogDebug("Checking {Count} orphaned networks if they should be purged.", networks.Count);
@@ -2594,6 +2609,12 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
     }
 
+    /// <summary>
+    /// Returns the set of all person IDs currently referenced by at least one cast or crew record
+    /// across movies and episodes. Used as the single source of truth when deciding which
+    /// <see cref="TMDB_Person"/> records are safe to purge, avoiding the old pattern of issuing
+    /// up to 4 DB queries per person to check linkage.
+    /// </summary>
     private HashSet<int> GetLinkedPersonIds()
     {
         var ids = new HashSet<int>();
@@ -2646,6 +2667,9 @@ public class TmdbMetadataService : ITmdbMetadataService
         var tasks = enumerable
             .Select(item => Task.Run(async () =>
             {
+                // The semaphore is acquired inside the Task.Run lambda so all tasks are started
+                // immediately but only maxConcurrent proceed at a time. Tasks that haven't acquired
+                // the semaphore yet are cancelled cleanly when cancellationTokenSource fires.
                 await semaphore.WaitAsync(cancellationTokenSource.Token).ConfigureAwait(false);
                 try
                 {
@@ -2656,6 +2680,7 @@ public class TmdbMetadataService : ITmdbMetadataService
                     semaphore.Release();
                 }
             }))
+            // HashSet gives O(1) removal after Task.WhenAny; a List would scan the whole set each time.
             .ToHashSet();
         while (tasks.Count > 0)
         {
@@ -2672,6 +2697,9 @@ public class TmdbMetadataService : ITmdbMetadataService
             catch (Exception ex)
             {
                 exceptions.Add(ex);
+                // Abort once failures fill all concurrency slots: a systemic error would keep piling
+                // up exceptions with no successful work happening. Cancel remaining tasks and surface
+                // everything at once via AggregateException.
                 if (exceptions.Count >= maxConcurrent)
                 {
                     cancellationTokenSource.Cancel();

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -29,12 +29,15 @@ using Shoko.Server.Scheduling.Jobs.TMDB;
 using Shoko.Server.Server;
 using Shoko.Server.Settings;
 using Shoko.Server.Utilities;
+using Newtonsoft.Json.Linq;
 using TMDbLib.Client;
+using TMDbLib.Objects.Changes;
 using TMDbLib.Objects.Collections;
 using TMDbLib.Objects.Exceptions;
 using TMDbLib.Objects.General;
 using TMDbLib.Objects.Movies;
 using TMDbLib.Objects.People;
+using TMDbLib.Objects.Search;
 using TMDbLib.Objects.TvShows;
 
 using MovieCredits = TMDbLib.Objects.Movies.Credits;
@@ -51,6 +54,8 @@ namespace Shoko.Server.Providers.TMDB;
 public class TmdbMetadataService : ITmdbMetadataService
 {
     private static readonly int _maxConcurrency = Math.Min(6, Environment.ProcessorCount);
+
+    private const int TmdbChangesWindowDays = 14;
 
     private static TmdbMetadataService? _instance = null;
 
@@ -492,6 +497,12 @@ public class TmdbMetadataService : ITmdbMetadataService
                 return false;
             }
 
+            if (!forceRefresh && !newlyAdded && !await HasMovieChangedSinceAsync(movieId, tmdbMovie.LastUpdatedAt).ConfigureAwait(false))
+            {
+                _logger.LogInformation("Skipping update of movie {MovieID} as no changes were detected on TMDB since {LastUpdatedAt}.", movieId, tmdbMovie.LastUpdatedAt);
+                return false;
+            }
+
             // Abort if we couldn't find the movie by id.
             var methods = MovieMethods.Translations | MovieMethods.ReleaseDates | MovieMethods.ExternalIds | MovieMethods.Keywords;
             if (downloadCrewAndCast)
@@ -683,7 +694,7 @@ public class TmdbMetadataService : ITmdbMetadataService
                     Interlocked.Increment(ref peopleUpdated);
             });
         }
-        catch (AggregateException ex)
+        catch (Exception ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
             // Cast/crew rows were already written above. Any person ID whose fetch failed leaves a
@@ -718,7 +729,7 @@ public class TmdbMetadataService : ITmdbMetadataService
                     Interlocked.Increment(ref peoplePurged);
             });
         }
-        catch (AggregateException ex)
+        catch (Exception ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to purge one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
         }
@@ -1117,6 +1128,15 @@ public class TmdbMetadataService : ITmdbMetadataService
             if (show is null)
                 return false;
 
+            // Query the TMDB Changes API to determine which seasons and episodes changed since the
+            // last sync. A null result (window exceeds 14 days or API failure) causes
+            // UpdateShowSeasonsAndEpisodes to fall back to a full refresh of all seasons and episodes.
+            // Applied on forced updates too: the most common forced-update trigger is a newly aired
+            // episode, which will appear in the changes list and only requires fetching that episode.
+            (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? changedItems = null;
+            if (!newlyAdded && !forceRefresh)
+                changedItems = await GetShowChangedItemsAsync(showId, tmdbShow.LastUpdatedAt).ConfigureAwait(false);
+
             var preferredTitleLanguages = settings.TMDB.DownloadAllTitles ? null : Languages.PreferredNamingLanguages.Select(a => a.Language).ToHashSet();
             var preferredOverviewLanguages = settings.TMDB.DownloadAllOverviews ? null : Languages.PreferredDescriptionNamingLanguages.Select(a => a.Language).ToHashSet();
             var contentRatingLanguages = settings.TMDB.DownloadAllContentRatings
@@ -1131,7 +1151,7 @@ public class TmdbMetadataService : ITmdbMetadataService
             updated = titlesUpdated || overviewsUpdated || updated;
             updated = UpdateShowExternalIDs(tmdbShow, show.ExternalIds!) || updated;
             updated = await UpdateCompanies(tmdbShow, show.ProductionCompanies!) || updated;
-            var (episodesOrSeasonsUpdated, updatedSeasons, updatedEpisodes, episodeCount, hiddenEpisodeCount) = await UpdateShowSeasonsAndEpisodes(show, downloadCrewAndCast, forceRefresh, downloadImages, quickRefresh, shouldFireEvents);
+            var (episodesOrSeasonsUpdated, updatedSeasons, updatedEpisodes, episodeCount, hiddenEpisodeCount) = await UpdateShowSeasonsAndEpisodes(show, downloadCrewAndCast, forceRefresh, downloadImages, quickRefresh, shouldFireEvents, changedItems);
             updated = episodesOrSeasonsUpdated || updated;
             if (tmdbShow.EpisodeCount != episodeCount)
             {
@@ -1188,284 +1208,348 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
     }
 
-    private async Task<(bool episodesOrSeasonsUpdated, Dictionary<TMDB_Season, UpdateReason> updatedSeasons, Dictionary<TMDB_Episode, UpdateReason> updatedEpisodes, int episodeCount, int hiddenEpisodeCount)> UpdateShowSeasonsAndEpisodes(TvShow show, bool downloadCrewAndCast = false, bool forceRefresh = false, bool downloadImages = false, bool quickRefresh = false, bool shouldFireEvents = false)
+    private sealed class ShowSeasonUpdateState
+    {
+        public readonly bool DownloadCrewAndCast;
+        public readonly bool QuickRefresh;
+        public readonly bool ShouldFireEvents;
+        public readonly (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? ChangedItems;
+        public readonly HashSet<TitleLanguage>? PreferredTitleLanguages;
+        public readonly HashSet<TitleLanguage>? PreferredOverviewLanguages;
+        public int SeasonsToAdd;
+        public int EpisodesToAdd;
+        public int TotalEpisodeCount;
+        public int TotalHiddenEpisodeCount;
+        public readonly Dictionary<int, TMDB_Season> ExistingSeasons;
+        public readonly ConcurrentDictionary<int, TMDB_Episode> ExistingEpisodes;
+        public readonly ConcurrentBag<int> SeasonsToSkip = new();
+        public readonly ConcurrentBag<TMDB_Season> SeasonsToSave = new();
+        public readonly ConcurrentDictionary<TMDB_Season, UpdateReason> SeasonEventsToEmit = new();
+        public readonly ConcurrentBag<int> EpisodesToSkip = new();
+        public readonly ConcurrentBag<TMDB_Episode> EpisodesToSave = new();
+        public readonly ConcurrentDictionary<TMDB_Episode, UpdateReason> EpisodeEventsToEmit = new();
+        public readonly ConcurrentDictionary<int, byte> AllPeopleToAddOrKeep = new();
+        public readonly ConcurrentDictionary<int, byte> AllPeopleToPotentiallyRemove = new();
+
+        public ShowSeasonUpdateState(
+            bool downloadCrewAndCast,
+            bool quickRefresh,
+            bool shouldFireEvents,
+            (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? changedItems,
+            HashSet<TitleLanguage>? preferredTitleLanguages,
+            HashSet<TitleLanguage>? preferredOverviewLanguages,
+            Dictionary<int, TMDB_Season> existingSeasons,
+            ConcurrentDictionary<int, TMDB_Episode> existingEpisodes)
+        {
+            DownloadCrewAndCast = downloadCrewAndCast;
+            QuickRefresh = quickRefresh;
+            ShouldFireEvents = shouldFireEvents;
+            ChangedItems = changedItems;
+            PreferredTitleLanguages = preferredTitleLanguages;
+            PreferredOverviewLanguages = preferredOverviewLanguages;
+            ExistingSeasons = existingSeasons;
+            ExistingEpisodes = existingEpisodes;
+        }
+    }
+
+    private async Task<(bool episodesOrSeasonsUpdated, Dictionary<TMDB_Season, UpdateReason> updatedSeasons, Dictionary<TMDB_Episode, UpdateReason> updatedEpisodes, int episodeCount, int hiddenEpisodeCount)> UpdateShowSeasonsAndEpisodes(TvShow show, bool downloadCrewAndCast = false, bool forceRefresh = false, bool downloadImages = false, bool quickRefresh = false, bool shouldFireEvents = false, (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? changedItems = null)
     {
         var settings = _settingsProvider.GetSettings();
         var preferredTitleLanguages = settings.TMDB.DownloadAllTitles ? null : Languages.PreferredEpisodeNamingLanguages.Select(a => a.Language).ToHashSet();
         var preferredOverviewLanguages = settings.TMDB.DownloadAllOverviews ? null : Languages.PreferredDescriptionNamingLanguages.Select(a => a.Language).ToHashSet();
 
-        var existingSeasons = _tmdbSeasons.GetByTmdbShowID(show.Id)
-            .ToDictionary(season => season.Id);
-        var seasonsToAdd = 0;
-        var seasonsToSkip = new ConcurrentBag<int>();
-        var seasonsToSave = new ConcurrentBag<TMDB_Season>();
-        var seasonEventsToEmit = new ConcurrentDictionary<TMDB_Season, UpdateReason>();
-
-        var totalEpisodeCount = 0;
-        var totalHiddenEpisodeCount = 0;
+        var existingSeasons = _tmdbSeasons.GetByTmdbShowID(show.Id).ToDictionary(season => season.Id);
         var existingEpisodes = new ConcurrentDictionary<int, TMDB_Episode>();
         foreach (var episode in _tmdbEpisodes.GetByTmdbShowID(show.Id))
             existingEpisodes.TryAdd(episode.Id, episode);
-        var episodesToAdd = 0;
-        var episodesToSkip = new ConcurrentBag<int>();
-        var episodesToSave = new ConcurrentBag<TMDB_Episode>();
-        var episodeEventsToEmit = new ConcurrentDictionary<TMDB_Episode, UpdateReason>();
-        var allPeopleToAddOrKeep = new ConcurrentBag<int>();
-        var allPeopleToPotentiallyRemove = new ConcurrentBag<int>();
-        await ProcessWithConcurrencyAsync(_maxConcurrency, show.Seasons!, async reducedSeason =>
-        {
-            _logger.LogDebug("Checking season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedSeason.SeasonNumber, show.Name, show.Id);
 
-            // Skipped seasons still need their episode counts registered so season totals stay accurate.
-            if (changedItems.HasValue && !changedItems.Value.SeasonNumbers.Contains(reducedSeason.SeasonNumber) &&
-                existingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeasonCached))
-            {
-                seasonsToSkip.Add(tmdbSeasonCached.Id);
-                var localEpisodes = _tmdbEpisodes.GetByTmdbSeasonID(tmdbSeasonCached.Id);
-                foreach (var ep in localEpisodes)
-                    episodesToSkip.Add(ep.Id);
-                var visibleCount = localEpisodes.Count(e => !e.IsHidden);
-                Interlocked.Add(ref totalEpisodeCount, visibleCount);
-                Interlocked.Add(ref totalHiddenEpisodeCount, localEpisodes.Count - visibleCount);
-                _logger.LogDebug("Skipping unchanged season {SeasonNumber} for show {ShowTitle} (Show={ShowId}).", reducedSeason.SeasonNumber, show.Name, show.Id);
-                return;
-            }
+        var state = new ShowSeasonUpdateState(downloadCrewAndCast, quickRefresh, shouldFireEvents, changedItems, preferredTitleLanguages, preferredOverviewLanguages, existingSeasons, existingEpisodes);
+        await ProcessWithConcurrencyAsync(_maxConcurrency, show.Seasons!, reducedSeason =>
+            ProcessShowSeasonAsync(show, reducedSeason, state));
 
-
-            var season = await UseClient(c => c.GetTvSeasonAsync(show.Id, reducedSeason.SeasonNumber, TvSeasonMethods.Translations), $"Get season {reducedSeason.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false) ??
-                throw new Exception($"Unable to fetch season {reducedSeason.SeasonNumber} for show \"{show.Name}\".");
-            if (!existingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeason))
-            {
-                Interlocked.Increment(ref seasonsToAdd);
-                tmdbSeason = new(reducedSeason.Id);
-            }
-            var newlyAddedSeason = tmdbSeason.CreatedAt == tmdbSeason.LastUpdatedAt;
-
-            var seasonUpdated = tmdbSeason.Populate(show, season);
-            seasonUpdated = UpdateTitlesAndOverviews(tmdbSeason, season.Translations, preferredTitleLanguages, preferredOverviewLanguages) || seasonUpdated;
-
-            var seasonAlreadySaved = false;
-            if ((newlyAddedSeason && shouldFireEvents) || seasonUpdated)
-            {
-                seasonEventsToEmit.TryAdd(tmdbSeason, newlyAddedSeason ? UpdateReason.Added : UpdateReason.Updated);
-                if (shouldFireEvents)
-                    tmdbSeason.LastUpdatedAt = DateTime.Now;
-                seasonsToSave.Add(tmdbSeason);
-                seasonAlreadySaved = true;
-            }
-
-            seasonsToSkip.Add(tmdbSeason.Id);
-
-            var episodeBag = new List<TMDB_Episode>();
-            var hiddenEpisodeBag = new List<TMDB_Episode>();
-            foreach (var reducedEpisode in season.Episodes!)
-            {
-                _logger.LogDebug("Checking episode {EpisodeNumber} in season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedEpisode.EpisodeNumber, reducedSeason.SeasonNumber, show.Name, show.Id);
-                if (!existingEpisodes.TryGetValue(reducedEpisode.Id, out var tmdbEpisode))
-                {
-                    Interlocked.Increment(ref episodesToAdd);
-                    tmdbEpisode = new(reducedEpisode.Id);
-                }
-                var newlyAddedEpisode = tmdbEpisode.CreatedAt == tmdbEpisode.LastUpdatedAt;
-
-                // If quick refresh is enabled then skip the API call per episode. (Part 1)
-                TvEpisode? episode = null;
-                if (!quickRefresh)
-                {
-                    var episodeMethods = TvEpisodeMethods.ExternalIds | TvEpisodeMethods.Translations;
-                    if (downloadCrewAndCast)
-                        episodeMethods |= TvEpisodeMethods.Credits;
-                    episode = await UseClient(c => c.GetTvEpisodeAsync(show.Id, season.SeasonNumber, reducedEpisode.EpisodeNumber, episodeMethods), $"Get episode {reducedEpisode.EpisodeNumber} in season {season.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false);
-                }
-
-                var episodeUpdated = tmdbEpisode.Populate(show, season, reducedEpisode, episode?.Translations);
-
-                // If quick refresh is enabled then skip the API call per episode, but do add the titles/overviews. (Part 2)
-                if (quickRefresh)
-                {
-                    episodeUpdated = UpdateTitlesAndOverviews(tmdbEpisode, null, preferredTitleLanguages, preferredOverviewLanguages) || episodeUpdated;
-                }
-                else
-                {
-                    episodeUpdated = UpdateTitlesAndOverviews(tmdbEpisode, episode!.Translations, preferredTitleLanguages, preferredOverviewLanguages) || episodeUpdated;
-                    episodeUpdated = UpdateEpisodeExternalIDs(tmdbEpisode, episode.ExternalIds!) || episodeUpdated;
-
-                    // Update crew & cast.
-                    if (downloadCrewAndCast)
-                    {
-                        var (castOrCrewUpdated, peopleToAddOrKeep, peopleToPotentiallyRemove) = UpdateEpisodeCastAndCrew(tmdbEpisode, episode.Credits!);
-                        episodeUpdated |= castOrCrewUpdated;
-                        foreach (var personId in peopleToAddOrKeep)
-                            allPeopleToAddOrKeep.Add(personId);
-                        foreach (var personId in peopleToPotentiallyRemove)
-                            allPeopleToPotentiallyRemove.Add(personId);
-                    }
-                }
-
-                if ((newlyAddedEpisode && shouldFireEvents) || episodeUpdated)
-                {
-                    episodeEventsToEmit.TryAdd(tmdbEpisode, newlyAddedEpisode ? UpdateReason.Added : UpdateReason.Updated);
-                    if (shouldFireEvents)
-                        tmdbEpisode.LastUpdatedAt = DateTime.Now;
-                    episodesToSave.Add(tmdbEpisode);
-                }
-
-                episodesToSkip.Add(tmdbEpisode.Id);
-                if (tmdbEpisode.IsHidden)
-                    hiddenEpisodeBag.Add(tmdbEpisode);
-                else
-                    episodeBag.Add(tmdbEpisode);
-            }
-
-            var episodeCount = episodeBag.Count;
-            var hiddenEpisodeCount = hiddenEpisodeBag.Count;
-            if (tmdbSeason.EpisodeCount != episodeCount)
-            {
-                tmdbSeason.EpisodeCount = episodeCount;
-                seasonUpdated = true;
-            }
-            if (tmdbSeason.HiddenEpisodeCount != hiddenEpisodeCount)
-            {
-                tmdbSeason.HiddenEpisodeCount = hiddenEpisodeCount;
-                seasonUpdated = true;
-            }
-            if (seasonUpdated)
-            {
-                tmdbSeason.LastUpdatedAt = DateTime.Now;
-                if (!seasonAlreadySaved)
-                    seasonsToSave.Add(tmdbSeason);
-            }
-            Interlocked.Add(ref totalEpisodeCount, episodeCount);
-            Interlocked.Add(ref totalHiddenEpisodeCount, hiddenEpisodeCount);
-        });
-
-        var seasonsToRemove = existingSeasons.Values
-            .ExceptBy(seasonsToSkip, season => season.Id)
-            .ToList();
-        var episodesToRemove = existingEpisodes.Values
-            .ExceptBy(episodesToSkip, episode => episode.Id)
-            .ToList();
+        var seasonsToRemove = existingSeasons.Values.ExceptBy(state.SeasonsToSkip, s => s.Id).ToList();
+        var episodesToRemove = existingEpisodes.Values.ExceptBy(state.EpisodesToSkip, e => e.Id).ToList();
 
         _logger.LogDebug(
             "Added/updated/removed/skipped {a}/{u}/{r}/{s} seasons for show {ShowTitle} (Show={ShowId})",
-            seasonsToAdd,
-            seasonsToSave.Count - seasonsToAdd,
+            state.SeasonsToAdd,
+            state.SeasonsToSave.Count - state.SeasonsToAdd,
             seasonsToRemove.Count,
-            existingSeasons.Count + seasonsToAdd - seasonsToRemove.Count - seasonsToSave.Count,
+            existingSeasons.Count + state.SeasonsToAdd - seasonsToRemove.Count - state.SeasonsToSave.Count,
             show.Name,
             show.Id);
-        _tmdbSeasons.Save(seasonsToSave);
+        _tmdbSeasons.Save(state.SeasonsToSave);
 
         foreach (var season in seasonsToRemove)
         {
             PurgeShowSeason(season);
-            seasonEventsToEmit.TryAdd(season, UpdateReason.Removed);
+            state.SeasonEventsToEmit.TryAdd(season, UpdateReason.Removed);
         }
 
         _tmdbSeasons.Delete(seasonsToRemove);
 
         _logger.LogDebug(
             "Added/updated/removed/skipped {a}/{u}/{r}/{s} episodes for show {ShowTitle} (Show={ShowId})",
-            episodesToAdd,
-            episodesToSave.Count - episodesToAdd,
+            state.EpisodesToAdd,
+            state.EpisodesToSave.Count - state.EpisodesToAdd,
             episodesToRemove.Count,
-            existingEpisodes.Count + episodesToAdd - episodesToRemove.Count - episodesToSave.Count,
+            existingEpisodes.Count + state.EpisodesToAdd - episodesToRemove.Count - state.EpisodesToSave.Count,
             show.Name,
             show.Id);
-        _tmdbEpisodes.Save(episodesToSave);
+        _tmdbEpisodes.Save(state.EpisodesToSave);
 
         foreach (var episode in episodesToRemove)
         {
             PurgeShowEpisode(episode);
-            episodeEventsToEmit.TryAdd(episode, UpdateReason.Removed);
+            state.EpisodeEventsToEmit.TryAdd(episode, UpdateReason.Removed);
         }
 
         _tmdbEpisodes.Delete(episodesToRemove);
 
         if (quickRefresh)
             return (
-                seasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || !episodesToSave.IsEmpty || episodesToRemove.Count > 0,
-                seasonEventsToEmit.ToDictionary(),
-                episodeEventsToEmit.ToDictionary(),
-                totalEpisodeCount,
-                totalHiddenEpisodeCount
+                state.SeasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || !state.EpisodesToSave.IsEmpty || episodesToRemove.Count > 0,
+                state.SeasonEventsToEmit.ToDictionary(),
+                state.EpisodeEventsToEmit.ToDictionary(),
+                state.TotalEpisodeCount,
+                state.TotalHiddenEpisodeCount
             );
 
-        // Only add/remove staff if we're not doing a quick refresh.
-        var peopleAdded = 0;
-        var peopleUpdated = 0;
-        var peoplePurged = 0;
-        var peopleToCheck = allPeopleToAddOrKeep.Distinct().ToList();
-        var peopleToPurge = allPeopleToPotentiallyRemove.Distinct().Except(peopleToCheck).ToList();
+        var (peopleAdded, peopleUpdated, peoplePurged, peopleSkipped) = await UpdateShowPeopleAsync(show, forceRefresh, downloadImages, state);
+        _logger.LogDebug("Added/removed {a}/{u}/{r}/{s} staff for show {ShowTitle} (Show={ShowId})",
+            peopleAdded, peopleUpdated, peoplePurged, peopleSkipped, show.Name, show.Id);
+
+        return (
+            state.SeasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || !state.EpisodesToSave.IsEmpty || episodesToRemove.Count > 0 || peopleAdded > 0 || peoplePurged > 0,
+            state.SeasonEventsToEmit.ToDictionary(),
+            state.EpisodeEventsToEmit.ToDictionary(),
+            state.TotalEpisodeCount,
+            state.TotalHiddenEpisodeCount
+        );
+    }
+
+    private async Task<(int Added, int Updated, int Purged, int Skipped)> UpdateShowPeopleAsync(TvShow show, bool forceRefresh, bool downloadImages, ShowSeasonUpdateState state)
+    {
+        var added = 0;
+        var updated = 0;
+        var purged = 0;
+        var peopleToCheck = state.AllPeopleToAddOrKeep.Keys.ToList();
+        var peopleToPurge = state.AllPeopleToPotentiallyRemove.Keys.Except(peopleToCheck).ToList();
         try
         {
             await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToCheck, async personId =>
             {
-                var (added, updated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentShowId: show.Id);
-                if (added)
-                    Interlocked.Increment(ref peopleAdded);
-                if (updated)
-                    Interlocked.Increment(ref peopleUpdated);
+                var (personAdded, personUpdated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentShowId: show.Id);
+                if (personAdded)
+                    Interlocked.Increment(ref added);
+                if (personUpdated)
+                    Interlocked.Increment(ref updated);
             });
         }
         catch (Exception ex)
         {
-            // Partial cast/crew failures are non-fatal: a missing person record does not invalidate
-            // the show. Log and continue so a transient API error doesn't abort the entire show update.
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during show cast/crew update (Show={ShowId})", show.Id);
-            // Same as the movie path: cast/crew rows referencing a person with no TMDB_Person row
-            // cause HTTP 500s when the API resolves cast. Remove entries for any person IDs that
-            // are still absent from the database after the fan-out.
-            var missingPersonIds = peopleToCheck
-                .Where(id => _tmdbPeople.GetByTmdbPersonID(id) is null)
-                .ToHashSet();
-            if (missingPersonIds.Count > 0)
-            {
-                var orphanedCast = _tmdbEpisodeCast.GetByTmdbShowID(show.Id)
-                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
-                    .ToList();
-                var orphanedCrew = _tmdbEpisodeCrew.GetByTmdbShowID(show.Id)
-                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
-                    .ToList();
-                if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
-                {
-                    _logger.LogWarning(
-                        "TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Show={ShowId})",
-                        orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, show.Id);
-                    _tmdbEpisodeCast.Delete(orphanedCast);
-                    _tmdbEpisodeCrew.Delete(orphanedCrew);
-                }
-            }
+            CleanupOrphanedShowCastCrew(show, peopleToCheck);
         }
         try
         {
             await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToPurge, async personId =>
             {
                 if (await PurgePerson(personId))
-                    Interlocked.Increment(ref peoplePurged);
+                    Interlocked.Increment(ref purged);
             });
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to purge one or more people during show cast/crew update (Show={ShowId})", show.Id);
         }
+        return (added, updated, purged, peopleToPurge.Count + peopleToCheck.Count - added - updated - purged);
+    }
 
-        _logger.LogDebug("Added/removed {a}/{u}/{r}/{s} staff for show {ShowTitle} (Show={ShowId})",
-            peopleAdded,
-            peopleUpdated,
-            peoplePurged,
-            peopleToPurge.Count + peopleToCheck.Count - peopleAdded - peopleUpdated - peoplePurged,
-            show.Name,
-            show.Id
-        );
+    private void CleanupOrphanedShowCastCrew(TvShow show, List<int> peopleToCheck)
+    {
+        // Cast/crew rows referencing a person with no TMDB_Person row cause HTTP 500s when the
+        // API resolves cast; remove entries for any person IDs absent from the database after the fan-out.
+        var missingPersonIds = peopleToCheck
+            .Where(id => _tmdbPeople.GetByTmdbPersonID(id) is null)
+            .ToHashSet();
+        if (missingPersonIds.Count > 0)
+        {
+            var orphanedCast = _tmdbEpisodeCast.GetByTmdbShowID(show.Id)
+                .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                .ToList();
+            var orphanedCrew = _tmdbEpisodeCrew.GetByTmdbShowID(show.Id)
+                .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                .ToList();
+            if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
+            {
+                _logger.LogWarning(
+                    "TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Show={ShowId})",
+                    orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, show.Id);
+                _tmdbEpisodeCast.Delete(orphanedCast);
+                _tmdbEpisodeCrew.Delete(orphanedCrew);
+            }
+        }
+    }
 
-        return (
-            seasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || !episodesToSave.IsEmpty || episodesToRemove.Count > 0 || peopleAdded > 0 || peoplePurged > 0,
-            seasonEventsToEmit.ToDictionary(),
-            episodeEventsToEmit.ToDictionary(),
-            totalEpisodeCount,
-            totalHiddenEpisodeCount
-        );
+    private async Task ProcessShowSeasonAsync(TvShow show, SearchTvSeason reducedSeason, ShowSeasonUpdateState state)
+    {
+        _logger.LogDebug("Checking season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedSeason.SeasonNumber, show.Name, show.Id);
+
+        // Skipped seasons still need their episode counts registered so season totals stay accurate.
+        if (TryHandleUnchangedSeason(reducedSeason, show, state))
+            return;
+
+        var season = await UseClient(c => c.GetTvSeasonAsync(show.Id, reducedSeason.SeasonNumber, TvSeasonMethods.Translations), $"Get season {reducedSeason.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false) ??
+            throw new Exception($"Unable to fetch season {reducedSeason.SeasonNumber} for show \"{show.Name}\".");
+        if (!state.ExistingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeason))
+        {
+            Interlocked.Increment(ref state.SeasonsToAdd);
+            tmdbSeason = new(reducedSeason.Id);
+        }
+        var newlyAddedSeason = tmdbSeason.CreatedAt == tmdbSeason.LastUpdatedAt;
+
+        var seasonUpdated = tmdbSeason.Populate(show, season);
+        seasonUpdated = UpdateTitlesAndOverviews(tmdbSeason, season.Translations, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || seasonUpdated;
+
+        var seasonAlreadySaved = MarkSeasonForSave(tmdbSeason, newlyAddedSeason, seasonUpdated, state);
+        state.SeasonsToSkip.Add(tmdbSeason.Id);
+
+        var episodeBag = new List<TMDB_Episode>();
+        var hiddenEpisodeBag = new List<TMDB_Episode>();
+        foreach (var reducedEpisode in season.Episodes!)
+            await ProcessShowEpisodeAsync(show, season, reducedEpisode, state, episodeBag, hiddenEpisodeBag);
+
+        var episodeCount = episodeBag.Count;
+        var hiddenEpisodeCount = hiddenEpisodeBag.Count;
+        if (tmdbSeason.EpisodeCount != episodeCount)
+        {
+            tmdbSeason.EpisodeCount = episodeCount;
+            seasonUpdated = true;
+        }
+        if (tmdbSeason.HiddenEpisodeCount != hiddenEpisodeCount)
+        {
+            tmdbSeason.HiddenEpisodeCount = hiddenEpisodeCount;
+            seasonUpdated = true;
+        }
+        if (seasonUpdated)
+        {
+            tmdbSeason.LastUpdatedAt = DateTime.Now;
+            if (!seasonAlreadySaved)
+                state.SeasonsToSave.Add(tmdbSeason);
+        }
+        Interlocked.Add(ref state.TotalEpisodeCount, episodeCount);
+        Interlocked.Add(ref state.TotalHiddenEpisodeCount, hiddenEpisodeCount);
+    }
+
+    private bool TryHandleUnchangedSeason(SearchTvSeason reducedSeason, TvShow show, ShowSeasonUpdateState state)
+    {
+        if (!state.ChangedItems.HasValue) return false;
+        if (state.ChangedItems.Value.SeasonNumbers.Contains(reducedSeason.SeasonNumber)) return false;
+        if (!state.ExistingSeasons.TryGetValue(reducedSeason.Id, out var season)) return false;
+        state.SeasonsToSkip.Add(season.Id);
+        var localEpisodes = _tmdbEpisodes.GetByTmdbSeasonID(season.Id);
+        foreach (var ep in localEpisodes)
+            state.EpisodesToSkip.Add(ep.Id);
+        var visibleCount = localEpisodes.Count(e => !e.IsHidden);
+        Interlocked.Add(ref state.TotalEpisodeCount, visibleCount);
+        Interlocked.Add(ref state.TotalHiddenEpisodeCount, localEpisodes.Count - visibleCount);
+        _logger.LogDebug("Skipping unchanged season {SeasonNumber} for show {ShowTitle} (Show={ShowId}).", reducedSeason.SeasonNumber, show.Name, show.Id);
+        return true;
+    }
+
+    private static bool MarkSeasonForSave(TMDB_Season tmdbSeason, bool newlyAdded, bool seasonUpdated, ShowSeasonUpdateState state)
+    {
+        if (!((newlyAdded && state.ShouldFireEvents) || seasonUpdated)) return false;
+        state.SeasonEventsToEmit.TryAdd(tmdbSeason, newlyAdded ? UpdateReason.Added : UpdateReason.Updated);
+        if (state.ShouldFireEvents)
+            tmdbSeason.LastUpdatedAt = DateTime.Now;
+        state.SeasonsToSave.Add(tmdbSeason);
+        return true;
+    }
+
+    private async Task ProcessShowEpisodeAsync(
+        TvShow show,
+        TvSeason season,
+        TvSeasonEpisode reducedEpisode,
+        ShowSeasonUpdateState state,
+        List<TMDB_Episode> episodeBag,
+        List<TMDB_Episode> hiddenEpisodeBag)
+    {
+        _logger.LogDebug("Checking episode {EpisodeNumber} in season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedEpisode.EpisodeNumber, season.SeasonNumber, show.Name, show.Id);
+        if (!state.ExistingEpisodes.TryGetValue(reducedEpisode.Id, out var tmdbEpisode))
+        {
+            Interlocked.Increment(ref state.EpisodesToAdd);
+            tmdbEpisode = new(reducedEpisode.Id);
+        }
+        var newlyAddedEpisode = tmdbEpisode.CreatedAt == tmdbEpisode.LastUpdatedAt;
+
+        if (TrySkipUnchangedEpisode(tmdbEpisode, season, reducedEpisode, newlyAddedEpisode, state, episodeBag, hiddenEpisodeBag))
+            return;
+
+        bool episodeUpdated;
+        // If quick refresh is enabled then skip the API call per episode and only refresh titles/overviews.
+        if (state.QuickRefresh)
+        {
+            var baseUpdated = tmdbEpisode.Populate(show, season, reducedEpisode, null);
+            episodeUpdated = UpdateTitlesAndOverviews(tmdbEpisode, null, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || baseUpdated;
+        }
+        else
+        {
+            episodeUpdated = await FullFetchAndUpdateEpisodeAsync(tmdbEpisode, show, season, reducedEpisode, state);
+        }
+
+        if ((newlyAddedEpisode && state.ShouldFireEvents) || episodeUpdated)
+        {
+            state.EpisodeEventsToEmit.TryAdd(tmdbEpisode, newlyAddedEpisode ? UpdateReason.Added : UpdateReason.Updated);
+            if (state.ShouldFireEvents)
+                tmdbEpisode.LastUpdatedAt = DateTime.Now;
+            state.EpisodesToSave.Add(tmdbEpisode);
+        }
+
+        state.EpisodesToSkip.Add(tmdbEpisode.Id);
+        (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
+    }
+
+    private async Task<bool> FullFetchAndUpdateEpisodeAsync(TMDB_Episode tmdbEpisode, TvShow show, TvSeason season, TvSeasonEpisode reducedEpisode, ShowSeasonUpdateState state)
+    {
+        var episodeMethods = TvEpisodeMethods.ExternalIds | TvEpisodeMethods.Translations;
+        if (state.DownloadCrewAndCast)
+            episodeMethods |= TvEpisodeMethods.Credits;
+        var episode = await UseClient(c => c.GetTvEpisodeAsync(show.Id, season.SeasonNumber, reducedEpisode.EpisodeNumber, episodeMethods), $"Get episode {reducedEpisode.EpisodeNumber} in season {season.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false);
+        var updated = tmdbEpisode.Populate(show, season, reducedEpisode, episode!.Translations);
+        updated = UpdateTitlesAndOverviews(tmdbEpisode, episode.Translations, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || updated;
+        updated = UpdateEpisodeExternalIDs(tmdbEpisode, episode.ExternalIds!) || updated;
+        if (state.DownloadCrewAndCast)
+            updated |= UpdateEpisodeCastCrewAndCollectPeople(tmdbEpisode, episode.Credits!, state);
+        return updated;
+    }
+
+    private static bool TrySkipUnchangedEpisode(
+        TMDB_Episode tmdbEpisode,
+        TvSeason season,
+        TvSeasonEpisode reducedEpisode,
+        bool newlyAddedEpisode,
+        ShowSeasonUpdateState state,
+        List<TMDB_Episode> episodeBag,
+        List<TMDB_Episode> hiddenEpisodeBag)
+    {
+        if (!state.ChangedItems.HasValue || newlyAddedEpisode) return false;
+        if (state.ChangedItems.Value.SeasonNumbers.Contains(season.SeasonNumber)) return false;
+        if (state.ChangedItems.Value.Episodes.Contains((season.SeasonNumber, (int)reducedEpisode.EpisodeNumber))) return false;
+        state.EpisodesToSkip.Add(tmdbEpisode.Id);
+        (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
+        return true;
+    }
+
+    private bool UpdateEpisodeCastCrewAndCollectPeople(TMDB_Episode tmdbEpisode, CreditsWithGuestStars credits, ShowSeasonUpdateState state)
+    {
+        var (castOrCrewUpdated, peopleToAddOrKeep, peopleToPotentiallyRemove) = UpdateEpisodeCastAndCrew(tmdbEpisode, credits);
+        foreach (var personId in peopleToAddOrKeep)
+            state.AllPeopleToAddOrKeep.TryAdd(personId, 0);
+        foreach (var personId in peopleToPotentiallyRemove)
+            state.AllPeopleToPotentiallyRemove.TryAdd(personId, 0);
+        return castOrCrewUpdated;
     }
 
     private async Task<bool> UpdateShowAlternateOrdering(TMDB_Show tmdbShow, TvShow show)
@@ -2825,10 +2909,10 @@ public class TmdbMetadataService : ITmdbMetadataService
     {
         // The TMDB Changes API covers at most the last 14 days. Treat anything older as changed
         // so the caller always falls through to a full refresh when history is unavailable.
-        if (since < DateTime.Now.AddDays(-14))
+        if (since < DateTime.Now.AddDays(-TmdbChangesWindowDays))
             return true;
         var changes = await UseClient(c => c.GetMovieChangesAsync(movieId, 0, since, null), $"Get changes for movie {movieId}").ConfigureAwait(false);
-        return changes is { Count: > 0 };
+        return changes is null || changes.Count > 0;
     }
 
     /// <summary>
@@ -2845,7 +2929,7 @@ public class TmdbMetadataService : ITmdbMetadataService
     {
         // The TMDB Changes API covers at most the last 14 days. Return null to signal the caller
         // to perform a full refresh rather than a selective one.
-        if (since < DateTime.Now.AddDays(-14))
+        if (since < DateTime.Now.AddDays(-TmdbChangesWindowDays))
             return null;
         var changes = await UseClient(c => c.GetTvShowChangesAsync(showId, 0, since, null), $"Get changes for show {showId}").ConfigureAwait(false);
         if (changes is null)
@@ -2873,38 +2957,40 @@ public class TmdbMetadataService : ITmdbMetadataService
             if (change.Key is not ("episode" or "season"))
                 continue;
             foreach (var item in change.Items ?? [])
-            {
-                // Each change item type stores its payload differently; normalise to a JObject.
-                var value = item switch
-                {
-                    ChangeItemAdded added => added.Value as JObject,
-                    ChangeItemUpdated updated => updated.Value as JObject,
-                    ChangeItemDestroyed destroyed => destroyed.Value as JObject,
-                    ChangeItemDeleted deleted => deleted.OriginalValue as JObject, // deleted items carry the previous value
-                    _ => null,
-                };
-                if (value is null)
-                    continue;
-
-                var seasonNumber = value["season_number"]?.Value<int>();
-                if (!seasonNumber.HasValue)
-                    continue;
-
-                seasonNumbers.Add(seasonNumber.Value);
-
-                // For episode changes, also record the specific (season, episode) pair so the
-                // fast-path can skip episodes within the season that were not individually changed.
-                if (change.Key == "episode")
-                {
-                    var episodeNumber = value["episode_number"]?.Value<int>();
-                    if (episodeNumber.HasValue)
-                        episodes.Add((seasonNumber.Value, episodeNumber.Value));
-                }
-            }
+                ApplyChangeItem(change.Key, item, seasonNumbers, episodes);
         }
         return (seasonNumbers, episodes);
     }
 
+    private static void ApplyChangeItem(string key, ChangeItemBase item, HashSet<int> seasonNumbers, HashSet<(int Season, int Episode)> episodes)
+    {
+        // Each change item type stores its payload differently; normalise to a JObject.
+        var value = item switch
+        {
+            ChangeItemAdded added => added.Value as JObject,
+            ChangeItemUpdated updated => updated.Value as JObject,
+            ChangeItemDestroyed destroyed => destroyed.Value as JObject,
+            ChangeItemDeleted deleted => deleted.OriginalValue as JObject, // deleted items carry the previous value
+            _ => null,
+        };
+        if (value is null)
+            return;
+
+        var seasonNumber = value["season_number"]?.Value<int>();
+        if (!seasonNumber.HasValue)
+            return;
+
+        seasonNumbers.Add(seasonNumber.Value);
+
+        // For episode changes, also record the specific (season, episode) pair so the
+        // fast-path can skip episodes within the season that were not individually changed.
+        if (key != "episode")
+            return;
+
+        var episodeNumber = value["episode_number"]?.Value<int>();
+        if (episodeNumber.HasValue)
+            episodes.Add((seasonNumber.Value, episodeNumber.Value));
+    }
 
     #endregion
 }

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -684,9 +684,30 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
         catch (AggregateException ex)
         {
-            // Partial cast/crew failures are non-fatal: a missing person record does not invalidate the
-            // movie. Log and continue so a transient API error doesn't abort the entire movie update.
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
+            // Cast/crew rows were already written above. Any person ID whose fetch failed leaves a
+            // dangling reference — the API cannot resolve cast without a matching TMDB_Person row and
+            // will return HTTP 500.
+            var missingPersonIds = peopleToKeep
+                .Where(id => _tmdbPeople.GetByTmdbPersonID(id) is null)
+                .ToHashSet();
+            if (missingPersonIds.Count > 0)
+            {
+                var orphanedCast = _tmdbMovieCast.GetByTmdbMovieID(tmdbMovie.Id)
+                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                    .ToList();
+                var orphanedCrew = _tmdbMovieCrew.GetByTmdbMovieID(tmdbMovie.Id)
+                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                    .ToList();
+                if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
+                {
+                    _logger.LogWarning(
+                        "TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Movie={MovieId})",
+                        orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, tmdbMovie.Id);
+                    _tmdbMovieCast.Delete(orphanedCast);
+                    _tmdbMovieCrew.Delete(orphanedCrew);
+                }
+            }
         }
         try
         {
@@ -698,7 +719,6 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
         catch (AggregateException ex)
         {
-            // Same reasoning: a purge failure for one person should not block cleanup of the rest.
             _logger.LogWarning(ex, "TMDB: Failed to purge one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
         }
 
@@ -837,7 +857,6 @@ public class TmdbMetadataService : ITmdbMetadataService
     {
         var toKeep = _xrefAnidbTmdbMovies.GetAll().Select(xref => xref.TmdbMovieID).ToHashSet();
         // Seeded with toKeep so AllCount in the log includes xref-linked IDs that have no TMDB_Movie row yet.
-        // UnionWith calls each GetAll() exactly once; a Concat chain would re-enumerate the same sources.
         var allMovies = new HashSet<int>(toKeep);
         allMovies.UnionWith(_tmdbMovies.GetAll().Select(m => m.TmdbMovieID));
         allMovies.UnionWith(_shokoImageXrefRepository.GetByEntity(DataSource.TMDB, DataEntityType.Movie).Select(xref => int.Parse(xref.EntityID)));
@@ -1195,6 +1214,23 @@ public class TmdbMetadataService : ITmdbMetadataService
         await ProcessWithConcurrencyAsync(_maxConcurrency, show.Seasons!, async reducedSeason =>
         {
             _logger.LogDebug("Checking season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedSeason.SeasonNumber, show.Name, show.Id);
+
+            // Skipped seasons still need their episode counts registered so season totals stay accurate.
+            if (changedItems.HasValue && !changedItems.Value.SeasonNumbers.Contains(reducedSeason.SeasonNumber) &&
+                existingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeasonCached))
+            {
+                seasonsToSkip.Add(tmdbSeasonCached.Id);
+                var localEpisodes = _tmdbEpisodes.GetByTmdbSeasonID(tmdbSeasonCached.Id);
+                foreach (var ep in localEpisodes)
+                    episodesToSkip.Add(ep.Id);
+                var visibleCount = localEpisodes.Count(e => !e.IsHidden);
+                Interlocked.Add(ref totalEpisodeCount, visibleCount);
+                Interlocked.Add(ref totalHiddenEpisodeCount, localEpisodes.Count - visibleCount);
+                _logger.LogDebug("Skipping unchanged season {SeasonNumber} for show {ShowTitle} (Show={ShowId}).", reducedSeason.SeasonNumber, show.Name, show.Id);
+                return;
+            }
+
+
             var season = await UseClient(c => c.GetTvSeasonAsync(show.Id, reducedSeason.SeasonNumber, TvSeasonMethods.Translations), $"Get season {reducedSeason.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false) ??
                 throw new Exception($"Unable to fetch season {reducedSeason.SeasonNumber} for show \"{show.Name}\".");
             if (!existingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeason))
@@ -1379,6 +1415,29 @@ public class TmdbMetadataService : ITmdbMetadataService
             // Partial cast/crew failures are non-fatal: a missing person record does not invalidate
             // the show. Log and continue so a transient API error doesn't abort the entire show update.
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during show cast/crew update (Show={ShowId})", show.Id);
+            // Same as the movie path: cast/crew rows referencing a person with no TMDB_Person row
+            // cause HTTP 500s when the API resolves cast. Remove entries for any person IDs that
+            // are still absent from the database after the fan-out.
+            var missingPersonIds = peopleToCheck
+                .Where(id => _tmdbPeople.GetByTmdbPersonID(id) is null)
+                .ToHashSet();
+            if (missingPersonIds.Count > 0)
+            {
+                var orphanedCast = _tmdbEpisodeCast.GetByTmdbShowID(show.Id)
+                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                    .ToList();
+                var orphanedCrew = _tmdbEpisodeCrew.GetByTmdbShowID(show.Id)
+                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                    .ToList();
+                if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
+                {
+                    _logger.LogWarning(
+                        "TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Show={ShowId})",
+                        orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, show.Id);
+                    _tmdbEpisodeCast.Delete(orphanedCast);
+                    _tmdbEpisodeCrew.Delete(orphanedCrew);
+                }
+            }
         }
         try
         {
@@ -1390,7 +1449,6 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
         catch (AggregateException ex)
         {
-            // Same reasoning: a purge failure for one person should not block cleanup of the rest.
             _logger.LogWarning(ex, "TMDB: Failed to purge one or more people during show cast/crew update (Show={ShowId})", show.Id);
         }
 
@@ -1937,7 +1995,6 @@ public class TmdbMetadataService : ITmdbMetadataService
     {
         var toKeep = _xrefAnidbTmdbShows.GetAll().Select(xref => xref.TmdbShowID).ToHashSet();
         // Seeded with toKeep so AllCount in the log includes xref-linked IDs that have no TMDB_Show row yet.
-        // UnionWith calls each GetAll() exactly once; a Concat chain would re-enumerate the same sources.
         var allShows = new HashSet<int>(toKeep);
         allShows.UnionWith(_tmdbShows.GetAll().Select(s => s.TmdbShowID));
         allShows.UnionWith(_shokoImageXrefRepository.GetByEntity(DataSource.TMDB, DataEntityType.Show).Select(xref => int.Parse(xref.EntityID)));
@@ -2026,8 +2083,6 @@ public class TmdbMetadataService : ITmdbMetadataService
 
     public async Task PurgeUnlinkedShowNetworks()
     {
-        // Build the linked-network set once before iterating. Checking inside the loop would
-        // issue a DB query per network; precomputing keeps the snapshot consistent and avoids N queries.
         var linkedNetworkIds = _xrefTmdbShowNetwork.GetAll().Select(x => x.TmdbNetworkID).ToHashSet();
         var networks = _tmdbNetwork.GetAll().Where(p => !linkedNetworkIds.Contains(p.TmdbNetworkID)).ToList();
         _logger.LogDebug("Checking {Count} orphaned networks if they should be purged.", networks.Count);
@@ -2798,6 +2853,96 @@ public class TmdbMetadataService : ITmdbMetadataService
 
     private Task<IDisposable> GetLockForEntity(DataEntityType entityType, int id, string metadataKey, string reason)
         => _entityLock.GetLockForEntityAsync(entityType, id, metadataKey, reason);
+
+    /// <summary>
+    /// Returns <see langword="true"/> if TMDB has recorded any changes for the given movie since
+    /// <paramref name="since"/>, or if the TMDB Changes API 14-day window has been exceeded (in
+    /// which case a full refresh is required because the history is no longer available).
+    /// </summary>
+    private async Task<bool> HasMovieChangedSinceAsync(int movieId, DateTime since)
+    {
+        // The TMDB Changes API covers at most the last 14 days. Treat anything older as changed
+        // so the caller always falls through to a full refresh when history is unavailable.
+        if (since < DateTime.Now.AddDays(-14))
+            return true;
+        var changes = await UseClient(c => c.GetMovieChangesAsync(movieId, 0, since, null), $"Get changes for movie {movieId}").ConfigureAwait(false);
+        return changes is { Count: > 0 };
+    }
+
+    /// <summary>
+    /// Fetches the set of changed seasons and episodes for the given show from the TMDB Changes
+    /// API since <paramref name="since"/>, for use as a selective-refresh filter.
+    /// </summary>
+    /// <returns>
+    /// <para><see langword="null"/> if the 14-day Changes API window has been exceeded or the API
+    /// call failed — the caller should fall back to a full refresh of all seasons and episodes.</para>
+    /// <para>Empty sets if no season or episode changes were reported — the caller can skip the update.</para>
+    /// <para>Populated sets containing the season numbers and (season, episode) pairs that changed.</para>
+    /// </returns>
+    private async Task<(HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)?> GetShowChangedItemsAsync(int showId, DateTime since)
+    {
+        // The TMDB Changes API covers at most the last 14 days. Return null to signal the caller
+        // to perform a full refresh rather than a selective one.
+        if (since < DateTime.Now.AddDays(-14))
+            return null;
+        var changes = await UseClient(c => c.GetTvShowChangesAsync(showId, 0, since, null), $"Get changes for show {showId}").ConfigureAwait(false);
+        if (changes is null)
+            return null;
+        return ParseShowChanges(changes);
+    }
+
+    /// <summary>
+    /// Parses a TMDB Changes API response into the sets of season numbers and (season, episode)
+    /// pairs that changed, for use as a selective-refresh filter in
+    /// <see cref="UpdateShowSeasonsAndEpisodes"/>.
+    /// </summary>
+    /// <remarks>
+    /// Only <c>"episode"</c> and <c>"season"</c> change keys are processed; all other keys
+    /// (e.g. <c>"name"</c>, <c>"overview"</c>) are ignored. Episode changes also implicitly add
+    /// their season number to <c>SeasonNumbers</c> so season metadata is always refreshed when
+    /// one of its episodes changed.
+    /// </remarks>
+    internal static (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes) ParseShowChanges(IList<Change> changes)
+    {
+        var seasonNumbers = new HashSet<int>();
+        var episodes = new HashSet<(int Season, int Episode)>();
+        foreach (var change in changes)
+        {
+            if (change.Key is not ("episode" or "season"))
+                continue;
+            foreach (var item in change.Items ?? [])
+            {
+                // Each change item type stores its payload differently; normalise to a JObject.
+                var value = item switch
+                {
+                    ChangeItemAdded added => added.Value as JObject,
+                    ChangeItemUpdated updated => updated.Value as JObject,
+                    ChangeItemDestroyed destroyed => destroyed.Value as JObject,
+                    ChangeItemDeleted deleted => deleted.OriginalValue as JObject, // deleted items carry the previous value
+                    _ => null,
+                };
+                if (value is null)
+                    continue;
+
+                var seasonNumber = value["season_number"]?.Value<int>();
+                if (!seasonNumber.HasValue)
+                    continue;
+
+                seasonNumbers.Add(seasonNumber.Value);
+
+                // For episode changes, also record the specific (season, episode) pair so the
+                // fast-path can skip episodes within the season that were not individually changed.
+                if (change.Key == "episode")
+                {
+                    var episodeNumber = value["episode_number"]?.Value<int>();
+                    if (episodeNumber.HasValue)
+                        episodes.Add((seasonNumber.Value, episodeNumber.Value));
+                }
+            }
+        }
+        return (seasonNumbers, episodes);
+    }
+
 
     #endregion
 }

--- a/Shoko.Server/Providers/TMDB/TmdbRateLimiter.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbRateLimiter.cs
@@ -47,7 +47,7 @@ public sealed class TmdbRateLimiter : IDisposable
         _settingsProvider = settingsProvider;
         var settings = settingsProvider.Load().TMDB.RateLimit;
         _maxRequestsPerWindow = settings.MaxRequestsPerWindow;
-        _limiter = CreateLimiter(settings.MaxRequestsPerWindow, settings.WindowDurationMs);
+        _limiter = CreateLimiter(settings.MaxRequestsPerWindow, settings.WindowDurationMs, settings.TMDB_API_Limits);
         _settingsProvider.Saved += OnSettingsSaved;
     }
 
@@ -65,20 +65,18 @@ public sealed class TmdbRateLimiter : IDisposable
         var settings = _settingsProvider.Load().TMDB.RateLimit;
         _maxRequestsPerWindow = settings.MaxRequestsPerWindow;
         var oldLimiter = _limiter;
-        _limiter = CreateLimiter(settings.MaxRequestsPerWindow, settings.WindowDurationMs);
+        _limiter = CreateLimiter(settings.MaxRequestsPerWindow, settings.WindowDurationMs, settings.TMDB_API_Limits);
         // Dispose the old limiter after a grace period to let any in-flight AcquireAsync calls complete.
         _ = Task.Delay(TimeSpan.FromSeconds(15))
             .ContinueWith(_ => oldLimiter.Dispose(), CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
     }
 
-    private static SlidingWindowRateLimiter CreateLimiter(int maxRequests, int windowMs)
+    private static SlidingWindowRateLimiter CreateLimiter(int maxRequests, int windowMs, int segmentsPerWindow)
         => new(new SlidingWindowRateLimiterOptions
         {
             PermitLimit = maxRequests,
             Window = TimeSpan.FromMilliseconds(windowMs),
-            // 10 segments divide the window into sub-intervals, smoothing request distribution and
-            // reducing burst spikes that would occur at the boundary of a single-segment window.
-            SegmentsPerWindow = 10,
+            SegmentsPerWindow = segmentsPerWindow,
             QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
             QueueLimit = int.MaxValue,
             AutoReplenishment = true,

--- a/Shoko.Server/Providers/TMDB/TmdbRateLimiter.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbRateLimiter.cs
@@ -76,6 +76,8 @@ public sealed class TmdbRateLimiter : IDisposable
         {
             PermitLimit = maxRequests,
             Window = TimeSpan.FromMilliseconds(windowMs),
+            // 10 segments divide the window into sub-intervals, smoothing request distribution and
+            // reducing burst spikes that would occur at the boundary of a single-segment window.
             SegmentsPerWindow = 10,
             QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
             QueueLimit = int.MaxValue,
@@ -93,6 +95,8 @@ public sealed class TmdbRateLimiter : IDisposable
         var until = DateTimeOffset.UtcNow + delay;
         var newTicks = until.UtcTicks;
         long current;
+        // CAS loop: multiple concurrent callers may receive 429s at the same time.
+        // Keep whichever deadline is furthest in the future so the longest backoff wins.
         do
         {
             current = Interlocked.Read(ref _backoffUntilTicks);
@@ -125,6 +129,8 @@ public sealed class TmdbRateLimiter : IDisposable
 
     private async Task WaitForBackoffAsync(CancellationToken cancellationToken = default)
     {
+        // Loop: a concurrent 429 can arrive mid-wait and push the deadline forward.
+        // Re-read the ticks after each delay to catch that case before returning.
         while (true)
         {
             var backoffTicks = Interlocked.Read(ref _backoffUntilTicks);

--- a/Shoko.Server/Settings/TmdbRateLimitSettings.cs
+++ b/Shoko.Server/Settings/TmdbRateLimitSettings.cs
@@ -28,4 +28,15 @@ public class TmdbRateLimitSettings
     [Display(Name = "Window Duration (ms)")]
     [Range(100, 10000)]
     public int WindowDurationMs { get; set; } = 1000;
+
+    /// <summary>
+    /// Number of segments the sliding window is divided into.
+    /// More segments distribute request replenishment more evenly across the window,
+    /// reducing burst spikes at segment boundaries.
+    /// </summary>
+    [Badge("Debug", Theme = DisplayColorTheme.Warning)]
+    [Visibility(Size = DisplayElementSize.Small, Advanced = true)]
+    [Display(Name = "Window Segments")]
+    [Range(1, 100)]
+    public int TMDB_API_Limits { get; set; } = 10;
 }

--- a/Shoko.Tests/Providers/TMDB/TmdbMetadataServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbMetadataServiceTests.cs
@@ -1,0 +1,257 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using Shoko.Server.Providers.TMDB;
+using TMDbLib.Objects.Changes;
+using Xunit;
+
+namespace Shoko.Tests.Providers.TMDB;
+
+public class TmdbMetadataServiceTests
+{
+    #region Helpers
+
+    private static Change EpisodeChange(params (int Season, int Episode)[] episodes)
+    {
+        var items = new List<ChangeItemBase>();
+        foreach (var (season, episode) in episodes)
+            items.Add(new ChangeItemUpdated { Value = EpisodeValue(season, episode) });
+        return new Change { Key = "episode", Items = items };
+    }
+
+    private static Change SeasonChange(params int[] seasonNumbers)
+    {
+        var items = new List<ChangeItemBase>();
+        foreach (var sn in seasonNumbers)
+            items.Add(new ChangeItemUpdated { Value = SeasonValue(sn) });
+        return new Change { Key = "season", Items = items };
+    }
+
+    private static JObject EpisodeValue(int season, int episode) =>
+        new() { ["season_number"] = season, ["episode_number"] = episode, ["episode_id"] = episode * 100 };
+
+    private static JObject SeasonValue(int season) =>
+        new() { ["season_number"] = season };
+
+    #endregion
+
+    [Fact]
+    public void EmptyChangeList_ReturnsEmptySets()
+    {
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges([]);
+
+        Assert.Empty(seasons);
+        Assert.Empty(episodes);
+    }
+
+    [Fact]
+    public void EpisodeChange_ExtractsSeasonAndEpisodePair()
+    {
+        var changes = new List<Change> { EpisodeChange((2, 5)) };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains(2, seasons);
+        Assert.Contains((2, 5), episodes);
+    }
+
+    [Fact]
+    public void EpisodeChange_AddsSeasonNumberToSeasonSet()
+    {
+        var changes = new List<Change> { EpisodeChange((3, 1)) };
+
+        var (seasons, _) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains(3, seasons);
+    }
+
+    [Fact]
+    public void SeasonChange_AddsToSeasonSetOnly()
+    {
+        var changes = new List<Change> { SeasonChange(1) };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains(1, seasons);
+        Assert.Empty(episodes);
+    }
+
+    [Fact]
+    public void UnrelatedKey_IsIgnored()
+    {
+        var changes = new List<Change>
+        {
+            new() { Key = "name", Items = [new ChangeItemUpdated { Value = new JObject { ["value"] = "New Title" } }] },
+            new() { Key = "overview", Items = [new ChangeItemUpdated { Value = new JObject { ["value"] = "New overview." } }] },
+        };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Empty(seasons);
+        Assert.Empty(episodes);
+    }
+
+    [Fact]
+    public void MultipleEpisodesAcrossSeasons_AllCaptured()
+    {
+        var changes = new List<Change> { EpisodeChange((1, 3), (2, 7), (2, 8)) };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Equal(new HashSet<int> { 1, 2 }, seasons);
+        Assert.Equal(new HashSet<(int, int)> { (1, 3), (2, 7), (2, 8) }, episodes);
+    }
+
+    [Fact]
+    public void MixedEpisodeAndSeasonChanges_BothCaptured()
+    {
+        var changes = new List<Change>
+        {
+            EpisodeChange((1, 5)),
+            SeasonChange(2),
+        };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Equal(new HashSet<int> { 1, 2 }, seasons);
+        Assert.Contains((1, 5), episodes);
+        Assert.DoesNotContain((2, 0), episodes);
+    }
+
+    [Fact]
+    public void DuplicateEpisode_DeduplicatedInOutput()
+    {
+        var changes = new List<Change>
+        {
+            EpisodeChange((1, 4)),
+            EpisodeChange((1, 4)),
+        };
+
+        var (_, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Single(episodes);
+        Assert.Contains((1, 4), episodes);
+    }
+
+    [Fact]
+    public void AddedItem_ValueExtracted()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemAdded { Value = EpisodeValue(1, 2) }],
+            },
+        };
+
+        var (_, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains((1, 2), episodes);
+    }
+
+    [Fact]
+    public void DestroyedItem_ValueExtracted()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemDestroyed { Value = EpisodeValue(2, 3) }],
+            },
+        };
+
+        var (_, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains((2, 3), episodes);
+    }
+
+    [Fact]
+    public void DeletedItem_OriginalValueExtracted()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemDeleted { OriginalValue = EpisodeValue(3, 9) }],
+            },
+        };
+
+        var (_, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains((3, 9), episodes);
+    }
+
+    [Fact]
+    public void ItemWithNoValue_Skipped()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemUpdated { Value = null }],
+            },
+        };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Empty(seasons);
+        Assert.Empty(episodes);
+    }
+
+    [Fact]
+    public void ItemWithNonJObjectValue_Skipped()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemUpdated { Value = "unexpected string" }],
+            },
+        };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Empty(seasons);
+        Assert.Empty(episodes);
+    }
+
+    [Fact]
+    public void EpisodeItemMissingSeasonNumber_Skipped()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemUpdated { Value = new JObject { ["episode_number"] = 5 } }],
+            },
+        };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Empty(seasons);
+        Assert.Empty(episodes);
+    }
+
+    [Fact]
+    public void EpisodeItemMissingEpisodeNumber_SeasonStillAdded()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemUpdated { Value = new JObject { ["season_number"] = 2 } }],
+            },
+        };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains(2, seasons);
+        Assert.Empty(episodes);
+    }
+}


### PR DESCRIPTION
## Summary

This PR started as inline comment improvements for code from #1352 and #1355, and grew to include several correctness fixes and one feature discovered during review.

### Commits

1. **`chore(tmdb): add inline comments to rate limiter and purge methods`**
   Original commit. Adds doc-comments and inline `// why` comments to `TmdbRateLimiter.cs` and the cast/crew purge paths in `TmdbMetadataService.cs`.

2. **`fix(tmdb): remove orphaned cast/crew entries when person fetch fails`**
   Cast/crew rows are written before person records are fetched. When the fan-out to `UpdatePerson` fails mid-way (transient error, rate limit), person IDs that were never written leave dangling cast/crew references — the API cannot resolve those entries and returns HTTP 500. After catching the exception, the fix deletes cast/crew rows whose person ID has no corresponding `TMDB_Person` row.

3. **`refactor(tmdb): replace episode concurrency with sequential foreach and ActionBlock`**
   Replaces the `SemaphoreSlim`-based episode loop with `ActionBlock<T>` from TPL Dataflow. Individual worker exceptions are collected so all items complete before any failure is re-thrown as `AggregateException`, rather than faulting the block early and abandoning queued items.

4. **`feat(tmdb): expose TMDB_API_Limits as configurable rate limiter setting`**
   Promotes `SegmentsPerWindow` (previously hardcoded to `10`) to a `TmdbRateLimitSettings` property so it can be tuned alongside `MaxRequestsPerWindow` and `WindowDurationMs`.

5. **`feat(tmdb): skip unchanged seasons/episodes using TMDB Changes API`**
   After the freshness gate, calls `GetShowChangedItemsAsync` to fetch which seasons/episodes changed since `LastUpdatedAt`. Skips `GetTvSeasonAsync` / `GetTvEpisodeAsync` for entries not in the change set. Falls back to full refresh when the entity is newly added, `LastUpdatedAt` is older than 14 days, `forceRefresh` is set, or the Changes API returns `null`. Fixes a bug where a `"season"` key change (which adds to `SeasonNumbers` but not `Episodes`) caused all existing episodes in that season to be wrongly skipped.

6. **`chore(tmdb): add unit tests for ParseShowChanges`**
   15 unit tests covering normal, edge, and error cases for the `ParseShowChanges` internal method introduced in commit 5.

## Notes

- PR remains in **draft** — open to feedback on scope before requesting review.