### PR TITLE
fix(tmdb): retry person fetch on transient failure, fix 404 routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ When a commit qualifies for more than one type, pick the most structural one. Do
 
 ### Scopes
 
-Scopes are optional and free-form, but reuse the established ones where they apply (non-exhaustive): `abstractions`, `api`, `db`, `plugin`, `images`, `relocation`, `trakt`, `search`, `scrobble`, `core`, `deps`, `workflows`, `scripts`, `docker`.
+Scopes are optional and free-form, but reuse the established ones where they apply (non-exhaustive): `abstractions`, `api`, `db`, `plugin`, `images`, `relocation`, `anidb`, `tmdb`, `search`, `scrobble`, `core`, `deps`, `workflows`, `scripts`, `docker`.
 
 ### Example
 

--- a/Shoko.Server/API/v3/Controllers/TmdbController.cs
+++ b/Shoko.Server/API/v3/Controllers/TmdbController.cs
@@ -300,8 +300,8 @@ public partial class TmdbController : BaseController
             return NotFound(MovieNotFound);
 
         return movie.Cast
-            .Select(cast => new Role(cast))
-            .Where(r => !r.IsStub)
+            .Select(Role.FromTmdb)
+            .OfType<Role>()
             .ToList();
     }
 
@@ -317,8 +317,8 @@ public partial class TmdbController : BaseController
             return NotFound(MovieNotFound);
 
         return movie.Crew
-            .Select(cast => new Role(cast))
-            .Where(r => !r.IsStub)
+            .Select(Role.FromTmdb)
+            .OfType<Role>()
             .ToList();
     }
 
@@ -1270,8 +1270,8 @@ public partial class TmdbController : BaseController
                     return ValidationProblem("Invalid alternateOrderingID for show.", "alternateOrderingID");
 
                 return alternateOrdering.Cast
-                    .Select(cast => new Role(cast))
-                    .Where(r => !r.IsStub)
+                    .Select(Role.FromTmdb)
+                    .OfType<Role>()
                     .ToList();
             }
 
@@ -1280,8 +1280,8 @@ public partial class TmdbController : BaseController
         }
 
         return show.Cast
-            .Select(cast => new Role(cast))
-            .Where(r => !r.IsStub)
+            .Select(Role.FromTmdb)
+            .OfType<Role>()
             .ToList();
     }
 
@@ -1312,8 +1312,8 @@ public partial class TmdbController : BaseController
                     return ValidationProblem("Invalid alternateOrderingID for show.", "alternateOrderingID");
 
                 return alternateOrdering.Crew
-                    .Select(cast => new Role(cast))
-                    .Where(r => !r.IsStub)
+                    .Select(Role.FromTmdb)
+                    .OfType<Role>()
                     .ToList();
             }
 
@@ -1322,8 +1322,8 @@ public partial class TmdbController : BaseController
         }
 
         return show.Crew
-            .Select(cast => new Role(cast))
-            .Where(r => !r.IsStub)
+            .Select(Role.FromTmdb)
+            .OfType<Role>()
             .ToList();
     }
 
@@ -2076,8 +2076,8 @@ public partial class TmdbController : BaseController
                 return NotFound(SeasonNotFound);
 
             return altOrderSeason.Cast
-                .Select(cast => new Role(cast))
-                .Where(r => !r.IsStub)
+                .Select(Role.FromTmdb)
+                .OfType<Role>()
                 .ToList();
         }
 
@@ -2089,8 +2089,8 @@ public partial class TmdbController : BaseController
             return NotFound(SeasonNotFound);
 
         return season.Cast
-            .Select(cast => new Role(cast))
-            .Where(r => !r.IsStub)
+            .Select(Role.FromTmdb)
+            .OfType<Role>()
             .ToList();
     }
 
@@ -2108,8 +2108,8 @@ public partial class TmdbController : BaseController
                 return NotFound(SeasonNotFound);
 
             return altOrderSeason.Crew
-                .Select(crew => new Role(crew))
-                .Where(r => !r.IsStub)
+                .Select(Role.FromTmdb)
+                .OfType<Role>()
                 .ToList();
         }
 
@@ -2121,8 +2121,8 @@ public partial class TmdbController : BaseController
             return NotFound(SeasonNotFound);
 
         return season.Crew
-            .Select(crew => new Role(crew))
-            .Where(r => !r.IsStub)
+            .Select(Role.FromTmdb)
+            .OfType<Role>()
             .ToList();
     }
 
@@ -2617,8 +2617,8 @@ public partial class TmdbController : BaseController
             return NotFound(EpisodeNotFound);
 
         return episode.Cast
-            .Select(cast => new Role(cast))
-            .Where(r => !r.IsStub)
+            .Select(Role.FromTmdb)
+            .OfType<Role>()
             .ToList();
     }
 
@@ -2634,8 +2634,8 @@ public partial class TmdbController : BaseController
             return NotFound(EpisodeNotFound);
 
         return episode.Crew
-            .Select(cast => new Role(cast))
-            .Where(r => !r.IsStub)
+            .Select(Role.FromTmdb)
+            .OfType<Role>()
             .ToList();
     }
 

--- a/Shoko.Server/API/v3/Controllers/TmdbController.cs
+++ b/Shoko.Server/API/v3/Controllers/TmdbController.cs
@@ -301,7 +301,7 @@ public partial class TmdbController : BaseController
 
         return movie.Cast
             .Select(Role.FromTmdb)
-            .OfType<Role>()
+            .WhereNotNull()
             .ToList();
     }
 
@@ -318,7 +318,7 @@ public partial class TmdbController : BaseController
 
         return movie.Crew
             .Select(Role.FromTmdb)
-            .OfType<Role>()
+            .WhereNotNull()
             .ToList();
     }
 
@@ -1271,7 +1271,7 @@ public partial class TmdbController : BaseController
 
                 return alternateOrdering.Cast
                     .Select(Role.FromTmdb)
-                    .OfType<Role>()
+                    .WhereNotNull()
                     .ToList();
             }
 
@@ -1281,7 +1281,7 @@ public partial class TmdbController : BaseController
 
         return show.Cast
             .Select(Role.FromTmdb)
-            .OfType<Role>()
+            .WhereNotNull()
             .ToList();
     }
 
@@ -1313,7 +1313,7 @@ public partial class TmdbController : BaseController
 
                 return alternateOrdering.Crew
                     .Select(Role.FromTmdb)
-                    .OfType<Role>()
+                    .WhereNotNull()
                     .ToList();
             }
 
@@ -1323,7 +1323,7 @@ public partial class TmdbController : BaseController
 
         return show.Crew
             .Select(Role.FromTmdb)
-            .OfType<Role>()
+            .WhereNotNull()
             .ToList();
     }
 
@@ -2077,7 +2077,7 @@ public partial class TmdbController : BaseController
 
             return altOrderSeason.Cast
                 .Select(Role.FromTmdb)
-                .OfType<Role>()
+                .WhereNotNull()
                 .ToList();
         }
 
@@ -2090,7 +2090,7 @@ public partial class TmdbController : BaseController
 
         return season.Cast
             .Select(Role.FromTmdb)
-            .OfType<Role>()
+            .WhereNotNull()
             .ToList();
     }
 
@@ -2109,7 +2109,7 @@ public partial class TmdbController : BaseController
 
             return altOrderSeason.Crew
                 .Select(Role.FromTmdb)
-                .OfType<Role>()
+                .WhereNotNull()
                 .ToList();
         }
 
@@ -2122,7 +2122,7 @@ public partial class TmdbController : BaseController
 
         return season.Crew
             .Select(Role.FromTmdb)
-            .OfType<Role>()
+            .WhereNotNull()
             .ToList();
     }
 
@@ -2618,7 +2618,7 @@ public partial class TmdbController : BaseController
 
         return episode.Cast
             .Select(Role.FromTmdb)
-            .OfType<Role>()
+            .WhereNotNull()
             .ToList();
     }
 
@@ -2635,7 +2635,7 @@ public partial class TmdbController : BaseController
 
         return episode.Crew
             .Select(Role.FromTmdb)
-            .OfType<Role>()
+            .WhereNotNull()
             .ToList();
     }
 

--- a/Shoko.Server/API/v3/Controllers/TmdbController.cs
+++ b/Shoko.Server/API/v3/Controllers/TmdbController.cs
@@ -301,6 +301,7 @@ public partial class TmdbController : BaseController
 
         return movie.Cast
             .Select(cast => new Role(cast))
+            .Where(r => !r.IsStub)
             .ToList();
     }
 
@@ -317,6 +318,7 @@ public partial class TmdbController : BaseController
 
         return movie.Crew
             .Select(cast => new Role(cast))
+            .Where(r => !r.IsStub)
             .ToList();
     }
 
@@ -1269,6 +1271,7 @@ public partial class TmdbController : BaseController
 
                 return alternateOrdering.Cast
                     .Select(cast => new Role(cast))
+                    .Where(r => !r.IsStub)
                     .ToList();
             }
 
@@ -1278,6 +1281,7 @@ public partial class TmdbController : BaseController
 
         return show.Cast
             .Select(cast => new Role(cast))
+            .Where(r => !r.IsStub)
             .ToList();
     }
 
@@ -1309,6 +1313,7 @@ public partial class TmdbController : BaseController
 
                 return alternateOrdering.Crew
                     .Select(cast => new Role(cast))
+                    .Where(r => !r.IsStub)
                     .ToList();
             }
 
@@ -1318,6 +1323,7 @@ public partial class TmdbController : BaseController
 
         return show.Crew
             .Select(cast => new Role(cast))
+            .Where(r => !r.IsStub)
             .ToList();
     }
 
@@ -2071,6 +2077,7 @@ public partial class TmdbController : BaseController
 
             return altOrderSeason.Cast
                 .Select(cast => new Role(cast))
+                .Where(r => !r.IsStub)
                 .ToList();
         }
 
@@ -2083,6 +2090,7 @@ public partial class TmdbController : BaseController
 
         return season.Cast
             .Select(cast => new Role(cast))
+            .Where(r => !r.IsStub)
             .ToList();
     }
 
@@ -2101,6 +2109,7 @@ public partial class TmdbController : BaseController
 
             return altOrderSeason.Crew
                 .Select(crew => new Role(crew))
+                .Where(r => !r.IsStub)
                 .ToList();
         }
 
@@ -2113,6 +2122,7 @@ public partial class TmdbController : BaseController
 
         return season.Crew
             .Select(crew => new Role(crew))
+            .Where(r => !r.IsStub)
             .ToList();
     }
 
@@ -2608,6 +2618,7 @@ public partial class TmdbController : BaseController
 
         return episode.Cast
             .Select(cast => new Role(cast))
+            .Where(r => !r.IsStub)
             .ToList();
     }
 
@@ -2624,6 +2635,7 @@ public partial class TmdbController : BaseController
 
         return episode.Crew
             .Select(cast => new Role(cast))
+            .Where(r => !r.IsStub)
             .ToList();
     }
 

--- a/Shoko.Server/API/v3/Helpers/APIv3_Extensions.cs
+++ b/Shoko.Server/API/v3/Helpers/APIv3_Extensions.cs
@@ -23,16 +23,7 @@ namespace Shoko.Server.API.v3.Helpers;
 
 public static class APIv3_Extensions
 {
-    public static CreatorRoleType ToCreatorRole(this TMDB_Movie_Crew crew)
-        => ToCreatorRole(crew.Department, crew.Job);
-
-    public static CreatorRoleType ToCreatorRole(this TMDB_Show_Crew crew)
-        => ToCreatorRole(crew.Department, crew.Job);
-
-    public static CreatorRoleType ToCreatorRole(this TMDB_Season_Crew crew)
-        => ToCreatorRole(crew.Department, crew.Job);
-
-    public static CreatorRoleType ToCreatorRole(this TMDB_Episode_Crew crew)
+    public static CreatorRoleType ToCreatorRole(this TMDB_Crew crew)
         => ToCreatorRole(crew.Department, crew.Job);
 
     private static CreatorRoleType ToCreatorRole(string department, string job)

--- a/Shoko.Server/API/v3/Models/Common/Role.cs
+++ b/Shoko.Server/API/v3/Models/Common/Role.cs
@@ -100,7 +100,10 @@ public class Role
         if (person is null) return null;
         return new()
         {
-            Character = new() { Name = cast.CharacterName },
+            Character = new()
+            {
+                Name = cast.CharacterName,
+            },
             Staff = CreateStaffFromTmdbPerson(person),
             RoleName = CreatorRoleType.Actor,
             RoleDetails = CharacterRole,

--- a/Shoko.Server/API/v3/Models/Common/Role.cs
+++ b/Shoko.Server/API/v3/Models/Common/Role.cs
@@ -1,20 +1,13 @@
-using System;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
-using Shoko.Abstractions.Core.Services;
 using Shoko.Abstractions.Metadata;
 using Shoko.Server.API.v3.Helpers;
 using Shoko.Server.Models.AniDB;
 using Shoko.Server.Models.TMDB;
-using Shoko.QueueProcessor.Abstractions;
 using Shoko.Server.Providers.TMDB;
-using Shoko.Server.Scheduling.Jobs.TMDB;
 using Shoko.Server.Server;
 
-#pragma warning disable CS0618
 #nullable enable
 namespace Shoko.Server.API.v3.Models.Common;
 
@@ -46,6 +39,13 @@ public class Role
     /// </summary>
     [Required]
     public string RoleDetails { get; set; } = string.Empty;
+
+    /// <summary>
+    /// True when the person data was missing locally.
+    /// Callers should filter these out before returning to API consumers.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsStub { get; private set; }
 
     private const string CharacterRole = "Character";
 
@@ -102,17 +102,14 @@ public class Role
     public Role(TMDB_Movie_Cast cast)
     {
         var person = cast.GetTmdbPerson();
-        if (person is null) { InitStub(cast.TmdbPersonID, CreatorRoleType.Actor, CharacterRole, cast.CharacterName); return; }
-        var personImages = person.GetImages();
-        Character = new() { Name = cast.CharacterName };
-        Staff = new()
+        if (person is null)
         {
-            ID = person.Id,
-            Name = person.EnglishName,
-            AlternateName = person.Aliases.Count == 0 ? person.EnglishName : person.Aliases[0].Split("/").Last().Trim(),
-            Description = person.EnglishBiography,
-            Image = personImages.Count > 0 ? new Image(personImages[0]) : null,
-        };
+            Staff = new();
+            IsStub = true;
+            return;
+        }
+        Character = new() { Name = cast.CharacterName };
+        Staff = CreateStaffFromTmdbPerson(person);
         RoleName = CreatorRoleType.Actor;
         RoleDetails = CharacterRole;
     }
@@ -120,17 +117,14 @@ public class Role
     public Role(TMDB_Show_Cast cast)
     {
         var person = cast.GetTmdbPerson();
-        if (person is null) { InitStub(cast.TmdbPersonID, CreatorRoleType.Actor, CharacterRole, cast.CharacterName); return; }
-        var personImages = person.GetImages();
-        Character = new() { Name = cast.CharacterName };
-        Staff = new()
+        if (person is null)
         {
-            ID = person.Id,
-            Name = person.EnglishName,
-            AlternateName = person.Aliases.Count == 0 ? person.EnglishName : person.Aliases[0].Split("/").Last().Trim(),
-            Description = person.EnglishBiography,
-            Image = personImages.Count > 0 ? new Image(personImages[0]) : null,
-        };
+            Staff = new();
+            IsStub = true;
+            return;
+        }
+        Character = new() { Name = cast.CharacterName };
+        Staff = CreateStaffFromTmdbPerson(person);
         RoleName = CreatorRoleType.Actor;
         RoleDetails = CharacterRole;
     }
@@ -138,17 +132,14 @@ public class Role
     public Role(TMDB_Season_Cast cast)
     {
         var person = cast.GetTmdbPerson();
-        if (person is null) { InitStub(cast.TmdbPersonID, CreatorRoleType.Actor, CharacterRole, cast.CharacterName); return; }
-        var personImages = person.GetImages();
-        Character = new() { Name = cast.CharacterName };
-        Staff = new()
+        if (person is null)
         {
-            ID = person.Id,
-            Name = person.EnglishName,
-            AlternateName = person.Aliases.Count == 0 ? person.EnglishName : person.Aliases[0].Split("/").Last().Trim(),
-            Description = person.EnglishBiography,
-            Image = personImages.Count > 0 ? new Image(personImages[0]) : null,
-        };
+            Staff = new();
+            IsStub = true;
+            return;
+        }
+        Character = new() { Name = cast.CharacterName };
+        Staff = CreateStaffFromTmdbPerson(person);
         RoleName = CreatorRoleType.Actor;
         RoleDetails = CharacterRole;
     }
@@ -156,17 +147,14 @@ public class Role
     public Role(TMDB_Episode_Cast cast)
     {
         var person = cast.GetTmdbPerson();
-        if (person is null) { InitStub(cast.TmdbPersonID, CreatorRoleType.Actor, CharacterRole, cast.CharacterName); return; }
-        var personImages = person.GetImages();
-        Character = new() { Name = cast.CharacterName };
-        Staff = new()
+        if (person is null)
         {
-            ID = person.Id,
-            Name = person.EnglishName,
-            AlternateName = person.Aliases.Count == 0 ? person.EnglishName : person.Aliases[0].Split("/").Last().Trim(),
-            Description = person.EnglishBiography,
-            Image = personImages.Count > 0 ? new Image(personImages[0]) : null,
-        };
+            Staff = new();
+            IsStub = true;
+            return;
+        }
+        Character = new() { Name = cast.CharacterName };
+        Staff = CreateStaffFromTmdbPerson(person);
         RoleName = CreatorRoleType.Actor;
         RoleDetails = CharacterRole;
     }
@@ -174,16 +162,13 @@ public class Role
     public Role(TMDB_Movie_Crew crew)
     {
         var person = crew.GetTmdbPerson();
-        if (person is null) { InitStub(crew.TmdbPersonID, crew.ToCreatorRole(), $"{crew.Department}, {crew.Job}"); return; }
-        var personImages = person.GetImages();
-        Staff = new()
+        if (person is null)
         {
-            ID = person.Id,
-            Name = person.EnglishName,
-            AlternateName = person.Aliases.Count == 0 ? person.EnglishName : person.Aliases[0].Split("/").Last().Trim(),
-            Description = person.EnglishBiography,
-            Image = personImages.Count > 0 ? new Image(personImages[0]) : null,
-        };
+            Staff = new();
+            IsStub = true;
+            return;
+        }
+        Staff = CreateStaffFromTmdbPerson(person);
         RoleName = crew.ToCreatorRole();
         RoleDetails = $"{crew.Department}, {crew.Job}";
     }
@@ -191,16 +176,13 @@ public class Role
     public Role(TMDB_Show_Crew crew)
     {
         var person = crew.GetTmdbPerson();
-        if (person is null) { InitStub(crew.TmdbPersonID, crew.ToCreatorRole(), $"{crew.Department}, {crew.Job}"); return; }
-        var personImages = person.GetImages();
-        Staff = new()
+        if (person is null)
         {
-            ID = person.Id,
-            Name = person.EnglishName,
-            AlternateName = person.Aliases.Count == 0 ? person.EnglishName : person.Aliases[0].Split("/").Last().Trim(),
-            Description = person.EnglishBiography,
-            Image = personImages.Count > 0 ? new Image(personImages[0]) : null,
-        };
+            Staff = new();
+            IsStub = true;
+            return;
+        }
+        Staff = CreateStaffFromTmdbPerson(person);
         RoleName = crew.ToCreatorRole();
         RoleDetails = $"{crew.Department}, {crew.Job}";
     }
@@ -208,16 +190,13 @@ public class Role
     public Role(TMDB_Season_Crew crew)
     {
         var person = crew.GetTmdbPerson();
-        if (person is null) { InitStub(crew.TmdbPersonID, crew.ToCreatorRole(), $"{crew.Department}, {crew.Job}"); return; }
-        var personImages = person.GetImages();
-        Staff = new()
+        if (person is null)
         {
-            ID = person.Id,
-            Name = person.EnglishName,
-            AlternateName = person.Aliases.Count == 0 ? person.EnglishName : person.Aliases[0].Split("/").Last().Trim(),
-            Description = person.EnglishBiography,
-            Image = personImages.Count > 0 ? new Image(personImages[0]) : null,
-        };
+            Staff = new();
+            IsStub = true;
+            return;
+        }
+        Staff = CreateStaffFromTmdbPerson(person);
         RoleName = crew.ToCreatorRole();
         RoleDetails = $"{crew.Department}, {crew.Job}";
     }
@@ -225,30 +204,28 @@ public class Role
     public Role(TMDB_Episode_Crew crew)
     {
         var person = crew.GetTmdbPerson();
-        if (person is null) { InitStub(crew.TmdbPersonID, crew.ToCreatorRole(), $"{crew.Department}, {crew.Job}"); return; }
-        var personImages = person.GetImages();
-        Staff = new()
+        if (person is null)
+        {
+            Staff = new();
+            IsStub = true;
+            return;
+        }
+        Staff = CreateStaffFromTmdbPerson(person);
+        RoleName = crew.ToCreatorRole();
+        RoleDetails = $"{crew.Department}, {crew.Job}";
+    }
+
+    private static Person CreateStaffFromTmdbPerson(TMDB_Person person)
+    {
+        var images = person.GetImages();
+        return new()
         {
             ID = person.Id,
             Name = person.EnglishName,
             AlternateName = person.Aliases.Count == 0 ? person.EnglishName : person.Aliases[0].Split("/").Last().Trim(),
             Description = person.EnglishBiography,
-            Image = personImages.Count > 0 ? new Image(personImages[0]) : null,
+            Image = images.Count > 0 ? new Image(images[0]) : null,
         };
-        RoleName = crew.ToCreatorRole();
-        RoleDetails = $"{crew.Department}, {crew.Job}";
-    }
-
-    [MemberNotNull(nameof(Staff))]
-    private void InitStub(int tmdbPersonId, CreatorRoleType roleType, string roleDetails, string? characterName = null)
-    {
-        var scheduler = ISystemService.StaticServices.GetRequiredService<IQueueScheduler>();
-        _ = scheduler.Enqueue<UpdateTmdbPersonJob>(j => j.TmdbPersonID = tmdbPersonId);
-        if (characterName is not null)
-            Character = new() { Name = characterName };
-        Staff = new() { ID = tmdbPersonId, Name = string.Empty, AlternateName = string.Empty, Description = string.Empty };
-        RoleName = roleType;
-        RoleDetails = roleDetails;
     }
 
     /// <summary>

--- a/Shoko.Server/API/v3/Models/Common/Role.cs
+++ b/Shoko.Server/API/v3/Models/Common/Role.cs
@@ -40,14 +40,9 @@ public class Role
     [Required]
     public string RoleDetails { get; set; } = string.Empty;
 
-    /// <summary>
-    /// True when the person data was missing locally.
-    /// Callers should filter these out before returning to API consumers.
-    /// </summary>
-    [JsonIgnore]
-    public bool IsStub { get; private set; }
-
     private const string CharacterRole = "Character";
+
+    private Role() { }
 
     public Role(AniDB_Anime_Character xref, ICharacter character, ICreator? staff = null)
     {
@@ -99,120 +94,29 @@ public class Role
         RoleDetails = xref.Role;
     }
 
-    public Role(TMDB_Movie_Cast cast)
+    public static Role? FromTmdb(TMDB_Cast cast)
     {
         var person = cast.GetTmdbPerson();
-        if (person is null)
+        if (person is null) return null;
+        return new()
         {
-            Staff = new();
-            IsStub = true;
-            return;
-        }
-        Character = new() { Name = cast.CharacterName };
-        Staff = CreateStaffFromTmdbPerson(person);
-        RoleName = CreatorRoleType.Actor;
-        RoleDetails = CharacterRole;
+            Character = new() { Name = cast.CharacterName },
+            Staff = CreateStaffFromTmdbPerson(person),
+            RoleName = CreatorRoleType.Actor,
+            RoleDetails = CharacterRole,
+        };
     }
 
-    public Role(TMDB_Show_Cast cast)
-    {
-        var person = cast.GetTmdbPerson();
-        if (person is null)
-        {
-            Staff = new();
-            IsStub = true;
-            return;
-        }
-        Character = new() { Name = cast.CharacterName };
-        Staff = CreateStaffFromTmdbPerson(person);
-        RoleName = CreatorRoleType.Actor;
-        RoleDetails = CharacterRole;
-    }
-
-    public Role(TMDB_Season_Cast cast)
-    {
-        var person = cast.GetTmdbPerson();
-        if (person is null)
-        {
-            Staff = new();
-            IsStub = true;
-            return;
-        }
-        Character = new() { Name = cast.CharacterName };
-        Staff = CreateStaffFromTmdbPerson(person);
-        RoleName = CreatorRoleType.Actor;
-        RoleDetails = CharacterRole;
-    }
-
-    public Role(TMDB_Episode_Cast cast)
-    {
-        var person = cast.GetTmdbPerson();
-        if (person is null)
-        {
-            Staff = new();
-            IsStub = true;
-            return;
-        }
-        Character = new() { Name = cast.CharacterName };
-        Staff = CreateStaffFromTmdbPerson(person);
-        RoleName = CreatorRoleType.Actor;
-        RoleDetails = CharacterRole;
-    }
-
-    public Role(TMDB_Movie_Crew crew)
+    public static Role? FromTmdb(TMDB_Crew crew)
     {
         var person = crew.GetTmdbPerson();
-        if (person is null)
+        if (person is null) return null;
+        return new()
         {
-            Staff = new();
-            IsStub = true;
-            return;
-        }
-        Staff = CreateStaffFromTmdbPerson(person);
-        RoleName = crew.ToCreatorRole();
-        RoleDetails = $"{crew.Department}, {crew.Job}";
-    }
-
-    public Role(TMDB_Show_Crew crew)
-    {
-        var person = crew.GetTmdbPerson();
-        if (person is null)
-        {
-            Staff = new();
-            IsStub = true;
-            return;
-        }
-        Staff = CreateStaffFromTmdbPerson(person);
-        RoleName = crew.ToCreatorRole();
-        RoleDetails = $"{crew.Department}, {crew.Job}";
-    }
-
-    public Role(TMDB_Season_Crew crew)
-    {
-        var person = crew.GetTmdbPerson();
-        if (person is null)
-        {
-            Staff = new();
-            IsStub = true;
-            return;
-        }
-        Staff = CreateStaffFromTmdbPerson(person);
-        RoleName = crew.ToCreatorRole();
-        RoleDetails = $"{crew.Department}, {crew.Job}";
-    }
-
-    public Role(TMDB_Episode_Crew crew)
-    {
-        var person = crew.GetTmdbPerson();
-        if (person is null)
-        {
-            Staff = new();
-            IsStub = true;
-            return;
-        }
-        Staff = CreateStaffFromTmdbPerson(person);
-        RoleName = crew.ToCreatorRole();
-        RoleDetails = $"{crew.Department}, {crew.Job}";
+            Staff = CreateStaffFromTmdbPerson(person),
+            RoleName = crew.ToCreatorRole(),
+            RoleDetails = $"{crew.Department}, {crew.Job}",
+        };
     }
 
     private static Person CreateStaffFromTmdbPerson(TMDB_Person person)

--- a/Shoko.Server/API/v3/Models/Common/Role.cs
+++ b/Shoko.Server/API/v3/Models/Common/Role.cs
@@ -26,7 +26,7 @@ public class Role
     /// The person who plays a character, writes the music, etc.
     /// </summary>
     [Required]
-    public Person Staff { get; set; }
+    public Person Staff { get; set; } = null!;
 
     /// <summary>
     /// The role that the staff plays, cv, writer, director, etc

--- a/Shoko.Server/API/v3/Models/Common/Role.cs
+++ b/Shoko.Server/API/v3/Models/Common/Role.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
@@ -8,7 +9,9 @@ using Shoko.Abstractions.Metadata;
 using Shoko.Server.API.v3.Helpers;
 using Shoko.Server.Models.AniDB;
 using Shoko.Server.Models.TMDB;
+using Shoko.QueueProcessor.Abstractions;
 using Shoko.Server.Providers.TMDB;
+using Shoko.Server.Scheduling.Jobs.TMDB;
 using Shoko.Server.Server;
 
 #pragma warning disable CS0618
@@ -43,6 +46,8 @@ public class Role
     /// </summary>
     [Required]
     public string RoleDetails { get; set; } = string.Empty;
+
+    private const string CharacterRole = "Character";
 
     public Role(AniDB_Anime_Character xref, ICharacter character, ICreator? staff = null)
     {
@@ -97,22 +102,9 @@ public class Role
     public Role(TMDB_Movie_Cast cast)
     {
         var person = cast.GetTmdbPerson();
-        // Band-aid for missing data until the root cause is found and fixed.
-        if (person is null)
-        {
-            var tmdbMetadataService = ISystemService.StaticServices.GetRequiredService<TmdbMetadataService>();
-            tmdbMetadataService.UpdatePerson(cast.TmdbPersonID)
-                .ConfigureAwait(false)
-                .GetAwaiter()
-                .GetResult();
-            person = cast.GetTmdbPerson() ??
-                throw new Exception($"Unable to find TMDB Person with the given id. (Person={cast.TmdbPersonID})");
-        }
+        if (person is null) { InitStub(cast.TmdbPersonID, CreatorRoleType.Actor, CharacterRole, cast.CharacterName); return; }
         var personImages = person.GetImages();
-        Character = new()
-        {
-            Name = cast.CharacterName,
-        };
+        Character = new() { Name = cast.CharacterName };
         Staff = new()
         {
             ID = person.Id,
@@ -122,28 +114,15 @@ public class Role
             Image = personImages.Count > 0 ? new Image(personImages[0]) : null,
         };
         RoleName = CreatorRoleType.Actor;
-        RoleDetails = "Character";
+        RoleDetails = CharacterRole;
     }
 
     public Role(TMDB_Show_Cast cast)
     {
         var person = cast.GetTmdbPerson();
-        // Band-aid for missing data until the root cause is found and fixed.
-        if (person is null)
-        {
-            var tmdbMetadataService = ISystemService.StaticServices.GetRequiredService<TmdbMetadataService>();
-            tmdbMetadataService.UpdatePerson(cast.TmdbPersonID)
-                .ConfigureAwait(false)
-                .GetAwaiter()
-                .GetResult();
-            person = cast.GetTmdbPerson() ??
-                throw new Exception($"Unable to find TMDB Person with the given id. (Person={cast.TmdbPersonID})");
-        }
+        if (person is null) { InitStub(cast.TmdbPersonID, CreatorRoleType.Actor, CharacterRole, cast.CharacterName); return; }
         var personImages = person.GetImages();
-        Character = new()
-        {
-            Name = cast.CharacterName,
-        };
+        Character = new() { Name = cast.CharacterName };
         Staff = new()
         {
             ID = person.Id,
@@ -153,18 +132,15 @@ public class Role
             Image = personImages.Count > 0 ? new Image(personImages[0]) : null,
         };
         RoleName = CreatorRoleType.Actor;
-        RoleDetails = "Character";
+        RoleDetails = CharacterRole;
     }
 
     public Role(TMDB_Season_Cast cast)
     {
-        var person = cast.GetTmdbPerson() ??
-            throw new Exception($"Unable to find TMDB Person with the given id. (Person={cast.TmdbPersonID})");
+        var person = cast.GetTmdbPerson();
+        if (person is null) { InitStub(cast.TmdbPersonID, CreatorRoleType.Actor, CharacterRole, cast.CharacterName); return; }
         var personImages = person.GetImages();
-        Character = new()
-        {
-            Name = cast.CharacterName,
-        };
+        Character = new() { Name = cast.CharacterName };
         Staff = new()
         {
             ID = person.Id,
@@ -174,18 +150,15 @@ public class Role
             Image = personImages.Count > 0 ? new Image(personImages[0]) : null,
         };
         RoleName = CreatorRoleType.Actor;
-        RoleDetails = "Character";
+        RoleDetails = CharacterRole;
     }
 
     public Role(TMDB_Episode_Cast cast)
     {
-        var person = cast.GetTmdbPerson() ??
-            throw new Exception($"Unable to find TMDB Person with the given id. (Person={cast.TmdbPersonID})");
+        var person = cast.GetTmdbPerson();
+        if (person is null) { InitStub(cast.TmdbPersonID, CreatorRoleType.Actor, CharacterRole, cast.CharacterName); return; }
         var personImages = person.GetImages();
-        Character = new()
-        {
-            Name = cast.CharacterName,
-        };
+        Character = new() { Name = cast.CharacterName };
         Staff = new()
         {
             ID = person.Id,
@@ -195,13 +168,13 @@ public class Role
             Image = personImages.Count > 0 ? new Image(personImages[0]) : null,
         };
         RoleName = CreatorRoleType.Actor;
-        RoleDetails = "Character";
+        RoleDetails = CharacterRole;
     }
 
     public Role(TMDB_Movie_Crew crew)
     {
-        var person = crew.GetTmdbPerson() ??
-            throw new Exception($"Unable to find TMDB Person with the given id. (Person={crew.TmdbPersonID})");
+        var person = crew.GetTmdbPerson();
+        if (person is null) { InitStub(crew.TmdbPersonID, crew.ToCreatorRole(), $"{crew.Department}, {crew.Job}"); return; }
         var personImages = person.GetImages();
         Staff = new()
         {
@@ -217,8 +190,8 @@ public class Role
 
     public Role(TMDB_Show_Crew crew)
     {
-        var person = crew.GetTmdbPerson() ??
-            throw new Exception($"Unable to find TMDB Person with the given id. (Person={crew.TmdbPersonID})");
+        var person = crew.GetTmdbPerson();
+        if (person is null) { InitStub(crew.TmdbPersonID, crew.ToCreatorRole(), $"{crew.Department}, {crew.Job}"); return; }
         var personImages = person.GetImages();
         Staff = new()
         {
@@ -234,8 +207,8 @@ public class Role
 
     public Role(TMDB_Season_Crew crew)
     {
-        var person = crew.GetTmdbPerson() ??
-            throw new Exception($"Unable to find TMDB Person with the given id. (Person={crew.TmdbPersonID})");
+        var person = crew.GetTmdbPerson();
+        if (person is null) { InitStub(crew.TmdbPersonID, crew.ToCreatorRole(), $"{crew.Department}, {crew.Job}"); return; }
         var personImages = person.GetImages();
         Staff = new()
         {
@@ -251,8 +224,8 @@ public class Role
 
     public Role(TMDB_Episode_Crew crew)
     {
-        var person = crew.GetTmdbPerson() ??
-            throw new Exception($"Unable to find TMDB Person with the given id. (Person={crew.TmdbPersonID})");
+        var person = crew.GetTmdbPerson();
+        if (person is null) { InitStub(crew.TmdbPersonID, crew.ToCreatorRole(), $"{crew.Department}, {crew.Job}"); return; }
         var personImages = person.GetImages();
         Staff = new()
         {
@@ -264,6 +237,18 @@ public class Role
         };
         RoleName = crew.ToCreatorRole();
         RoleDetails = $"{crew.Department}, {crew.Job}";
+    }
+
+    [MemberNotNull(nameof(Staff))]
+    private void InitStub(int tmdbPersonId, CreatorRoleType roleType, string roleDetails, string? characterName = null)
+    {
+        var scheduler = ISystemService.StaticServices.GetRequiredService<IQueueScheduler>();
+        _ = scheduler.Enqueue<UpdateTmdbPersonJob>(j => j.TmdbPersonID = tmdbPersonId);
+        if (characterName is not null)
+            Character = new() { Name = characterName };
+        Staff = new() { ID = tmdbPersonId, Name = string.Empty, AlternateName = string.Empty, Description = string.Empty };
+        RoleName = roleType;
+        RoleDetails = roleDetails;
     }
 
     /// <summary>

--- a/Shoko.Server/API/v3/Models/Common/Role.cs
+++ b/Shoko.Server/API/v3/Models/Common/Role.cs
@@ -124,14 +124,13 @@ public class Role
 
     private static Person CreateStaffFromTmdbPerson(TMDB_Person person)
     {
-        var images = person.GetImages();
         return new()
         {
             ID = person.Id,
             Name = person.EnglishName,
             AlternateName = person.Aliases.Count == 0 ? person.EnglishName : person.Aliases[0].Split("/").Last().Trim(),
             Description = person.EnglishBiography,
-            Image = images.Count > 0 ? new Image(images[0]) : null,
+            Image = (person as ICreator).PrimaryImage is { } staffImage ? new Image(staffImage) : null,
         };
     }
 

--- a/Shoko.Server/API/v3/Models/TMDB/TmdbEpisode.cs
+++ b/Shoko.Server/API/v3/Models/TMDB/TmdbEpisode.cs
@@ -211,10 +211,12 @@ public class TmdbEpisode
         if (include.HasFlag(IncludeDetails.Cast))
             Cast = episode.Cast
                 .Select(cast => new Role(cast))
+                .Where(r => !r.IsStub)
                 .ToList();
         if (include.HasFlag(IncludeDetails.Crew))
             Crew = episode.Crew
                 .Select(crew => new Role(crew))
+                .Where(r => !r.IsStub)
                 .ToList();
         if (include.HasFlag(IncludeDetails.Ordering))
         {

--- a/Shoko.Server/API/v3/Models/TMDB/TmdbEpisode.cs
+++ b/Shoko.Server/API/v3/Models/TMDB/TmdbEpisode.cs
@@ -210,13 +210,13 @@ public class TmdbEpisode
                 .ToDto(language);
         if (include.HasFlag(IncludeDetails.Cast))
             Cast = episode.Cast
-                .Select(cast => new Role(cast))
-                .Where(r => !r.IsStub)
+                .Select(Role.FromTmdb)
+                .OfType<Role>()
                 .ToList();
         if (include.HasFlag(IncludeDetails.Crew))
             Crew = episode.Crew
-                .Select(crew => new Role(crew))
-                .Where(r => !r.IsStub)
+                .Select(Role.FromTmdb)
+                .OfType<Role>()
                 .ToList();
         if (include.HasFlag(IncludeDetails.Ordering))
         {

--- a/Shoko.Server/API/v3/Models/TMDB/TmdbMovie.cs
+++ b/Shoko.Server/API/v3/Models/TMDB/TmdbMovie.cs
@@ -231,10 +231,12 @@ public class TmdbMovie
         if (include.HasFlag(IncludeDetails.Cast))
             Cast = movie.Cast
                 .Select(cast => new Role(cast))
+                .Where(r => !r.IsStub)
                 .ToList();
         if (include.HasFlag(IncludeDetails.Crew))
             Crew = movie.Crew
                 .Select(crew => new Role(crew))
+                .Where(r => !r.IsStub)
                 .ToList();
         if (include.HasFlag(IncludeDetails.YearlySeasons))
             YearlySeasons = movie.YearlySeasons.ToV3Dto();

--- a/Shoko.Server/API/v3/Models/TMDB/TmdbMovie.cs
+++ b/Shoko.Server/API/v3/Models/TMDB/TmdbMovie.cs
@@ -230,13 +230,13 @@ public class TmdbMovie
                 .ToDto(language);
         if (include.HasFlag(IncludeDetails.Cast))
             Cast = movie.Cast
-                .Select(cast => new Role(cast))
-                .Where(r => !r.IsStub)
+                .Select(Role.FromTmdb)
+                .OfType<Role>()
                 .ToList();
         if (include.HasFlag(IncludeDetails.Crew))
             Crew = movie.Crew
-                .Select(crew => new Role(crew))
-                .Where(r => !r.IsStub)
+                .Select(Role.FromTmdb)
+                .OfType<Role>()
                 .ToList();
         if (include.HasFlag(IncludeDetails.YearlySeasons))
             YearlySeasons = movie.YearlySeasons.ToV3Dto();

--- a/Shoko.Server/API/v3/Models/TMDB/TmdbSeason.cs
+++ b/Shoko.Server/API/v3/Models/TMDB/TmdbSeason.cs
@@ -152,10 +152,12 @@ public class TmdbSeason
         if (include.HasFlag(IncludeDetails.Cast))
             Cast = season.Cast
                 .Select(cast => new Role(cast))
+                .Where(r => !r.IsStub)
                 .ToList();
         if (include.HasFlag(IncludeDetails.Crew))
             Crew = season.Crew
                 .Select(crew => new Role(crew))
+                .Where(r => !r.IsStub)
                 .ToList();
         if (include.HasFlag(IncludeDetails.YearlySeasons))
             YearlySeasons = season.YearlySeasons.ToV3Dto();

--- a/Shoko.Server/API/v3/Models/TMDB/TmdbSeason.cs
+++ b/Shoko.Server/API/v3/Models/TMDB/TmdbSeason.cs
@@ -151,13 +151,13 @@ public class TmdbSeason
                 .ToDto(language);
         if (include.HasFlag(IncludeDetails.Cast))
             Cast = season.Cast
-                .Select(cast => new Role(cast))
-                .Where(r => !r.IsStub)
+                .Select(Role.FromTmdb)
+                .OfType<Role>()
                 .ToList();
         if (include.HasFlag(IncludeDetails.Crew))
             Crew = season.Crew
-                .Select(crew => new Role(crew))
-                .Where(r => !r.IsStub)
+                .Select(Role.FromTmdb)
+                .OfType<Role>()
                 .ToList();
         if (include.HasFlag(IncludeDetails.YearlySeasons))
             YearlySeasons = season.YearlySeasons.ToV3Dto();

--- a/Shoko.Server/API/v3/Models/TMDB/TmdbShow.cs
+++ b/Shoko.Server/API/v3/Models/TMDB/TmdbShow.cs
@@ -255,10 +255,12 @@ public class TmdbShow
         if (include.HasFlag(IncludeDetails.Cast))
             Cast = (alternateOrdering is null ? show.Cast : alternateOrdering.Cast)
                 .Select(cast => new Role(cast))
+                .Where(r => !r.IsStub)
                 .ToList();
         if (include.HasFlag(IncludeDetails.Crew))
             Crew = (alternateOrdering is null ? show.Crew : alternateOrdering.Crew)
                 .Select(cast => new Role(cast))
+                .Where(r => !r.IsStub)
                 .ToList();
         if (include.HasFlag(IncludeDetails.YearlySeasons))
             YearlySeasons = show.YearlySeasons.ToV3Dto();

--- a/Shoko.Server/API/v3/Models/TMDB/TmdbShow.cs
+++ b/Shoko.Server/API/v3/Models/TMDB/TmdbShow.cs
@@ -254,13 +254,13 @@ public class TmdbShow
                 .ToDto(language);
         if (include.HasFlag(IncludeDetails.Cast))
             Cast = (alternateOrdering is null ? show.Cast : alternateOrdering.Cast)
-                .Select(cast => new Role(cast))
-                .Where(r => !r.IsStub)
+                .Select(Role.FromTmdb)
+                .OfType<Role>()
                 .ToList();
         if (include.HasFlag(IncludeDetails.Crew))
             Crew = (alternateOrdering is null ? show.Crew : alternateOrdering.Crew)
-                .Select(cast => new Role(cast))
-                .Where(r => !r.IsStub)
+                .Select(Role.FromTmdb)
+                .OfType<Role>()
                 .ToList();
         if (include.HasFlag(IncludeDetails.YearlySeasons))
             YearlySeasons = show.YearlySeasons.ToV3Dto();

--- a/Shoko.Server/Providers/TMDB/TmdbExtensions.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbExtensions.cs
@@ -76,7 +76,7 @@ public static class TmdbExtensions
         if (languages is null)
             return texts;
 
-        var countyCodes = languages
+        var countryCodes = languages
             .Select(c => c.GetLanguageAndCountryCode())
             .Where(c => c.countryCode is not null)
             .Select(c => c.countryCode)
@@ -86,7 +86,7 @@ public static class TmdbExtensions
             .Where(c => c.countryCode is null)
             .Select(c => c.languageCode)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        return texts.Where(cr => languagesCodes.Contains(cr.LanguageCode) || countyCodes.Contains(cr.CountryCode));
+        return texts.Where(cr => languagesCodes.Contains(cr.LanguageCode) || countryCodes.Contains(cr.CountryCode));
     }
 
     public static IEnumerable<TMDB_ContentRating> WhereInLanguages(this IEnumerable<TMDB_ContentRating> contentRatings, IReadOnlySet<TitleLanguage>? languages)
@@ -94,7 +94,7 @@ public static class TmdbExtensions
         if (languages is null)
             return contentRatings;
 
-        var countyCodes = languages
+        var countryCodes = languages
             .Select(c => c.GetLanguageAndCountryCode())
             .Where(c => c.countryCode is not null)
             .Select(c => c.countryCode)
@@ -104,6 +104,6 @@ public static class TmdbExtensions
             .Where(c => c.countryCode is null)
             .Select(c => c.languageCode)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        return contentRatings.Where(cr => languagesCodes.Contains(cr.LanguageCode) || countyCodes.Contains(cr.CountryCode));
+        return contentRatings.Where(cr => languagesCodes.Contains(cr.LanguageCode) || countryCodes.Contains(cr.CountryCode));
     }
 }

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -683,6 +683,29 @@ public class TmdbMetadataService : ITmdbMetadataService
         catch (AggregateException ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
+            // Cast/crew rows were already written above. Any person ID whose fetch failed leaves a
+            // dangling reference — the API cannot resolve cast without a matching TMDB_Person row and
+            // will return HTTP 500.
+            var missingPersonIds = peopleToKeep
+                .Where(id => _tmdbPeople.GetByTmdbPersonID(id) is null)
+                .ToHashSet();
+            if (missingPersonIds.Count > 0)
+            {
+                var orphanedCast = _tmdbMovieCast.GetByTmdbMovieID(tmdbMovie.Id)
+                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                    .ToList();
+                var orphanedCrew = _tmdbMovieCrew.GetByTmdbMovieID(tmdbMovie.Id)
+                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                    .ToList();
+                if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
+                {
+                    _logger.LogWarning(
+                        "TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Movie={MovieId})",
+                        orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, tmdbMovie.Id);
+                    _tmdbMovieCast.Delete(orphanedCast);
+                    _tmdbMovieCrew.Delete(orphanedCrew);
+                }
+            }
         }
         try
         {
@@ -1189,6 +1212,23 @@ public class TmdbMetadataService : ITmdbMetadataService
         await ProcessWithConcurrencyAsync(_maxConcurrency, show.Seasons!, async reducedSeason =>
         {
             _logger.LogDebug("Checking season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedSeason.SeasonNumber, show.Name, show.Id);
+
+            // Skipped seasons still need their episode counts registered so season totals stay accurate.
+            if (changedItems.HasValue && !changedItems.Value.SeasonNumbers.Contains(reducedSeason.SeasonNumber) &&
+                existingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeasonCached))
+            {
+                seasonsToSkip.Add(tmdbSeasonCached.Id);
+                var localEpisodes = _tmdbEpisodes.GetByTmdbSeasonID(tmdbSeasonCached.Id);
+                foreach (var ep in localEpisodes)
+                    episodesToSkip.Add(ep.Id);
+                var visibleCount = localEpisodes.Count(e => !e.IsHidden);
+                Interlocked.Add(ref totalEpisodeCount, visibleCount);
+                Interlocked.Add(ref totalHiddenEpisodeCount, localEpisodes.Count - visibleCount);
+                _logger.LogDebug("Skipping unchanged season {SeasonNumber} for show {ShowTitle} (Show={ShowId}).", reducedSeason.SeasonNumber, show.Name, show.Id);
+                return;
+            }
+
+
             var season = await UseClient(c => c.GetTvSeasonAsync(show.Id, reducedSeason.SeasonNumber, TvSeasonMethods.Translations), $"Get season {reducedSeason.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false) ??
                 throw new Exception($"Unable to fetch season {reducedSeason.SeasonNumber} for show \"{show.Name}\".");
             if (!existingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeason))
@@ -1368,6 +1408,29 @@ public class TmdbMetadataService : ITmdbMetadataService
         catch (AggregateException ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during show cast/crew update (Show={ShowId})", show.Id);
+            // Same as the movie path: cast/crew rows referencing a person with no TMDB_Person row
+            // cause HTTP 500s when the API resolves cast. Remove entries for any person IDs that
+            // are still absent from the database after the fan-out.
+            var missingPersonIds = peopleToCheck
+                .Where(id => _tmdbPeople.GetByTmdbPersonID(id) is null)
+                .ToHashSet();
+            if (missingPersonIds.Count > 0)
+            {
+                var orphanedCast = _tmdbEpisodeCast.GetByTmdbShowID(show.Id)
+                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                    .ToList();
+                var orphanedCrew = _tmdbEpisodeCrew.GetByTmdbShowID(show.Id)
+                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                    .ToList();
+                if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
+                {
+                    _logger.LogWarning(
+                        "TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Show={ShowId})",
+                        orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, show.Id);
+                    _tmdbEpisodeCast.Delete(orphanedCast);
+                    _tmdbEpisodeCrew.Delete(orphanedCrew);
+                }
+            }
         }
         try
         {
@@ -2770,6 +2833,96 @@ public class TmdbMetadataService : ITmdbMetadataService
 
     private Task<IDisposable> GetLockForEntity(DataEntityType entityType, int id, string metadataKey, string reason)
         => _entityLock.GetLockForEntityAsync(entityType, id, metadataKey, reason);
+
+    /// <summary>
+    /// Returns <see langword="true"/> if TMDB has recorded any changes for the given movie since
+    /// <paramref name="since"/>, or if the TMDB Changes API 14-day window has been exceeded (in
+    /// which case a full refresh is required because the history is no longer available).
+    /// </summary>
+    private async Task<bool> HasMovieChangedSinceAsync(int movieId, DateTime since)
+    {
+        // The TMDB Changes API covers at most the last 14 days. Treat anything older as changed
+        // so the caller always falls through to a full refresh when history is unavailable.
+        if (since < DateTime.Now.AddDays(-14))
+            return true;
+        var changes = await UseClient(c => c.GetMovieChangesAsync(movieId, 0, since, null), $"Get changes for movie {movieId}").ConfigureAwait(false);
+        return changes is { Count: > 0 };
+    }
+
+    /// <summary>
+    /// Fetches the set of changed seasons and episodes for the given show from the TMDB Changes
+    /// API since <paramref name="since"/>, for use as a selective-refresh filter.
+    /// </summary>
+    /// <returns>
+    /// <para><see langword="null"/> if the 14-day Changes API window has been exceeded or the API
+    /// call failed — the caller should fall back to a full refresh of all seasons and episodes.</para>
+    /// <para>Empty sets if no season or episode changes were reported — the caller can skip the update.</para>
+    /// <para>Populated sets containing the season numbers and (season, episode) pairs that changed.</para>
+    /// </returns>
+    private async Task<(HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)?> GetShowChangedItemsAsync(int showId, DateTime since)
+    {
+        // The TMDB Changes API covers at most the last 14 days. Return null to signal the caller
+        // to perform a full refresh rather than a selective one.
+        if (since < DateTime.Now.AddDays(-14))
+            return null;
+        var changes = await UseClient(c => c.GetTvShowChangesAsync(showId, 0, since, null), $"Get changes for show {showId}").ConfigureAwait(false);
+        if (changes is null)
+            return null;
+        return ParseShowChanges(changes);
+    }
+
+    /// <summary>
+    /// Parses a TMDB Changes API response into the sets of season numbers and (season, episode)
+    /// pairs that changed, for use as a selective-refresh filter in
+    /// <see cref="UpdateShowSeasonsAndEpisodes"/>.
+    /// </summary>
+    /// <remarks>
+    /// Only <c>"episode"</c> and <c>"season"</c> change keys are processed; all other keys
+    /// (e.g. <c>"name"</c>, <c>"overview"</c>) are ignored. Episode changes also implicitly add
+    /// their season number to <c>SeasonNumbers</c> so season metadata is always refreshed when
+    /// one of its episodes changed.
+    /// </remarks>
+    internal static (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes) ParseShowChanges(IList<Change> changes)
+    {
+        var seasonNumbers = new HashSet<int>();
+        var episodes = new HashSet<(int Season, int Episode)>();
+        foreach (var change in changes)
+        {
+            if (change.Key is not ("episode" or "season"))
+                continue;
+            foreach (var item in change.Items ?? [])
+            {
+                // Each change item type stores its payload differently; normalise to a JObject.
+                var value = item switch
+                {
+                    ChangeItemAdded added => added.Value as JObject,
+                    ChangeItemUpdated updated => updated.Value as JObject,
+                    ChangeItemDestroyed destroyed => destroyed.Value as JObject,
+                    ChangeItemDeleted deleted => deleted.OriginalValue as JObject, // deleted items carry the previous value
+                    _ => null,
+                };
+                if (value is null)
+                    continue;
+
+                var seasonNumber = value["season_number"]?.Value<int>();
+                if (!seasonNumber.HasValue)
+                    continue;
+
+                seasonNumbers.Add(seasonNumber.Value);
+
+                // For episode changes, also record the specific (season, episode) pair so the
+                // fast-path can skip episodes within the season that were not individually changed.
+                if (change.Key == "episode")
+                {
+                    var episodeNumber = value["episode_number"]?.Value<int>();
+                    if (episodeNumber.HasValue)
+                        episodes.Add((seasonNumber.Value, episodeNumber.Value));
+                }
+            }
+        }
+        return (seasonNumbers, episodes);
+    }
+
 
     #endregion
 }

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Polly;
@@ -1253,9 +1254,9 @@ public class TmdbMetadataService : ITmdbMetadataService
 
             seasonsToSkip.Add(tmdbSeason.Id);
 
-            var episodeBag = new ConcurrentBag<TMDB_Episode>();
-            var hiddenEpisodeBag = new ConcurrentBag<TMDB_Episode>();
-            await ProcessWithConcurrencyAsync(1, season.Episodes!, async (reducedEpisode) =>
+            var episodeBag = new List<TMDB_Episode>();
+            var hiddenEpisodeBag = new List<TMDB_Episode>();
+            foreach (var reducedEpisode in season.Episodes!)
             {
                 _logger.LogDebug("Checking episode {EpisodeNumber} in season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedEpisode.EpisodeNumber, reducedSeason.SeasonNumber, show.Name, show.Id);
                 if (!existingEpisodes.TryGetValue(reducedEpisode.Id, out var tmdbEpisode))
@@ -1312,7 +1313,7 @@ public class TmdbMetadataService : ITmdbMetadataService
                     hiddenEpisodeBag.Add(tmdbEpisode);
                 else
                     episodeBag.Add(tmdbEpisode);
-            });
+            }
 
             var episodeCount = episodeBag.Count;
             var hiddenEpisodeCount = hiddenEpisodeBag.Count;
@@ -1405,8 +1406,10 @@ public class TmdbMetadataService : ITmdbMetadataService
                     Interlocked.Increment(ref peopleUpdated);
             });
         }
-        catch (AggregateException ex)
+        catch (Exception ex)
         {
+            // Partial cast/crew failures are non-fatal: a missing person record does not invalidate
+            // the show. Log and continue so a transient API error doesn't abort the entire show update.
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during show cast/crew update (Show={ShowId})", show.Id);
             // Same as the movie path: cast/crew rows referencing a person with no TMDB_Person row
             // cause HTTP 500s when the API resolves cast. Remove entries for any person IDs that
@@ -1440,7 +1443,7 @@ public class TmdbMetadataService : ITmdbMetadataService
                     Interlocked.Increment(ref peoplePurged);
             });
         }
-        catch (AggregateException ex)
+        catch (Exception ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to purge one or more people during show cast/crew update (Show={ShowId})", show.Id);
         }
@@ -2703,50 +2706,27 @@ public class TmdbMetadataService : ITmdbMetadataService
         if (maxConcurrent < 1)
             throw new ArgumentOutOfRangeException(nameof(maxConcurrent), "Concurrency level must be at least 1.");
 
-        var semaphore = new SemaphoreSlim(maxConcurrent);
-        var exceptions = new List<Exception>();
-        var cancellationTokenSource = new CancellationTokenSource();
-        var tasks = enumerable
-            .Select(item => Task.Run(async () =>
+        // Workers catch individually so the block never faults — all items complete before exceptions surface.
+        var exceptions = new ConcurrentBag<Exception>();
+        var block = new ActionBlock<T>(
+            async item =>
             {
-                await semaphore.WaitAsync(cancellationTokenSource.Token).ConfigureAwait(false);
-                try
+                try { await processAsync(item); }
+                catch (Exception ex)
                 {
-                    await processAsync(item).ConfigureAwait(false);
+                    exceptions.Add(ex);
+                    if (Interlocked.Increment(ref failureCount) >= maxConcurrent)
+                        await cts.CancelAsync();
                 }
-                finally
-                {
-                    semaphore.Release();
-                }
-            }))
-            .ToHashSet();
-        while (tasks.Count > 0)
-        {
-            var task = await Task.WhenAny(tasks).ConfigureAwait(false);
-            tasks.Remove(task);
-            try
-            {
-                await task.ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Task was cancelled (internal failure or external shutdown) — not counted as an error.
-            }
-            catch (Exception ex)
-            {
-                exceptions.Add(ex);
-                if (exceptions.Count >= maxConcurrent)
-                {
-                    cancellationTokenSource.Cancel();
-                    throw new AggregateException(exceptions);
-                }
-            }
-        }
-
-        cancellationTokenSource.Dispose();
-        semaphore.Dispose();
-
-        if (exceptions.Count > 0)
+            },
+            new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = maxConcurrent, CancellationToken = cts.Token }
+        );
+        foreach (var item in enumerable)
+            block.Post(item);
+        block.Complete();
+        try { await block.Completion.ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* circuit breaker fired — block aborted cleanly */ }
+        if (!exceptions.IsEmpty)
             throw new AggregateException(exceptions);
     }
 

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -1253,7 +1253,15 @@ public class TmdbMetadataService : ITmdbMetadataService
 
         var existingSeasons = _tmdbSeasons.GetByTmdbShowID(show.Id).ToDictionary(season => season.Id);
         var existingEpisodes = _tmdbEpisodes.GetByTmdbShowID(show.Id).ToDictionary(episode => episode.Id);
-        var state = new ShowSyncState(downloadCrewAndCast, quickRefresh, shouldFireEvents, preferredTitleLanguages, preferredOverviewLanguages, changedItems);
+        var state = new ShowSyncState
+        {
+            DownloadCrewAndCast = downloadCrewAndCast,
+            QuickRefresh = quickRefresh,
+            ShouldFireEvents = shouldFireEvents,
+            PreferredTitleLanguages = preferredTitleLanguages,
+            PreferredOverviewLanguages = preferredOverviewLanguages,
+            ChangedItems = changedItems,
+        };
         var episodePeople = BuildEpisodePeopleLookup(show, state);
 
         foreach (var reducedSeason in show.Seasons!)
@@ -3007,22 +3015,12 @@ public class TmdbMetadataService : ITmdbMetadataService
 
     private sealed class ShowSyncState
     {
-        public readonly bool DownloadCrewAndCast;
-        public readonly bool QuickRefresh;
-        public readonly bool ShouldFireEvents;
-        public readonly HashSet<TitleLanguage>? PreferredTitleLanguages;
-        public readonly HashSet<TitleLanguage>? PreferredOverviewLanguages;
-        public readonly TmdbShowChangedItems? ChangedItems;
-
-        public ShowSyncState(bool downloadCrewAndCast, bool quickRefresh, bool shouldFireEvents, HashSet<TitleLanguage>? preferredTitleLanguages, HashSet<TitleLanguage>? preferredOverviewLanguages, TmdbShowChangedItems? changedItems)
-        {
-            DownloadCrewAndCast = downloadCrewAndCast;
-            QuickRefresh = quickRefresh;
-            ShouldFireEvents = shouldFireEvents;
-            PreferredTitleLanguages = preferredTitleLanguages;
-            PreferredOverviewLanguages = preferredOverviewLanguages;
-            ChangedItems = changedItems;
-        }
+        public required bool DownloadCrewAndCast { get; init; }
+        public required bool QuickRefresh { get; init; }
+        public required bool ShouldFireEvents { get; init; }
+        public required HashSet<TitleLanguage>? PreferredTitleLanguages { get; init; }
+        public required HashSet<TitleLanguage>? PreferredOverviewLanguages { get; init; }
+        public required TmdbShowChangedItems? ChangedItems { get; init; }
 
         public int SeasonsAdded;
         public int EpisodesAdded;

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -1253,224 +1253,273 @@ public class TmdbMetadataService : ITmdbMetadataService
 
         var existingSeasons = _tmdbSeasons.GetByTmdbShowID(show.Id).ToDictionary(season => season.Id);
         var existingEpisodes = _tmdbEpisodes.GetByTmdbShowID(show.Id).ToDictionary(episode => episode.Id);
-
-        var episodePeople = downloadCrewAndCast
-            ? _tmdbEpisodeCast.GetByTmdbShowID(show.Id).Select(c => (c.TmdbEpisodeID, c.TmdbPersonID))
-                .Concat(_tmdbEpisodeCrew.GetByTmdbShowID(show.Id).Select(c => (c.TmdbEpisodeID, c.TmdbPersonID)))
-                .ToLookup(x => x.TmdbEpisodeID, x => x.TmdbPersonID)
-            : Enumerable.Empty<TMDB_Episode_Cast>().ToLookup(c => c.TmdbEpisodeID, c => c.TmdbPersonID);
-
-        var seasonsToAdd = 0;
-        var episodesToAdd = 0;
-        var totalEpisodeCount = 0;
-        var totalHiddenEpisodeCount = 0;
-        var seasonsToSkip = new HashSet<int>();
-        var seasonsToSave = new List<TMDB_Season>();
-        var seasonEventsToEmit = new Dictionary<TMDB_Season, UpdateReason>();
-        var episodesToSkip = new HashSet<int>();
-        var episodesToSave = new List<TMDB_Episode>();
-        var episodeEventsToEmit = new Dictionary<TMDB_Episode, UpdateReason>();
-        var allPeopleToAddOrKeep = new HashSet<int>();
-        var allPeopleToPotentiallyRemove = new HashSet<int>();
+        var state = new ShowSyncState(downloadCrewAndCast, quickRefresh, shouldFireEvents, preferredTitleLanguages, preferredOverviewLanguages, changedItems);
+        var episodePeople = BuildEpisodePeopleLookup(show, state);
 
         foreach (var reducedSeason in show.Seasons!)
-        {
-            _logger.LogDebug("Checking season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedSeason.SeasonNumber, show.Name, show.Id);
+            await ProcessShowSeasonAsync(show, reducedSeason, existingSeasons, existingEpisodes, episodePeople, state).ConfigureAwait(false);
 
-            // Skipped seasons still need their episode counts registered so season totals stay accurate.
-            if (changedItems.HasValue && !changedItems.Value.SeasonNumbers.Contains(reducedSeason.SeasonNumber) && existingSeasons.TryGetValue(reducedSeason.Id, out var unchangedSeason))
-            {
-                seasonsToSkip.Add(unchangedSeason.Id);
-                var localEpisodes = _tmdbEpisodes.GetByTmdbSeasonID(unchangedSeason.Id);
-                var visibleCount = 0;
-                foreach (var ep in localEpisodes)
-                {
-                    episodesToSkip.Add(ep.Id);
-                    if (!ep.IsHidden) visibleCount++;
-                }
-                totalEpisodeCount += visibleCount;
-                totalHiddenEpisodeCount += localEpisodes.Count - visibleCount;
-                if (downloadCrewAndCast)
-                    foreach (var ep in localEpisodes)
-                        foreach (var personId in episodePeople[ep.Id])
-                            allPeopleToAddOrKeep.Add(personId);
-                _logger.LogDebug("Skipping unchanged season {SeasonNumber} for show {ShowTitle} (Show={ShowId}).", reducedSeason.SeasonNumber, show.Name, show.Id);
-                continue;
-            }
-
-            var season = await UseClient(c => c.GetTvSeasonAsync(show.Id, reducedSeason.SeasonNumber, TvSeasonMethods.Translations), $"Get season {reducedSeason.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false) ??
-                throw new Exception($"Unable to fetch season {reducedSeason.SeasonNumber} for show \"{show.Name}\".");
-            if (!existingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeason))
-            {
-                seasonsToAdd++;
-                tmdbSeason = new(reducedSeason.Id);
-            }
-            var newlyAddedSeason = tmdbSeason.CreatedAt == tmdbSeason.LastUpdatedAt;
-
-            var seasonUpdated = tmdbSeason.Populate(show, season);
-            seasonUpdated = UpdateTitlesAndOverviews(tmdbSeason, season.Translations, preferredTitleLanguages, preferredOverviewLanguages) || seasonUpdated;
-
-            var seasonAlreadySaved = false;
-            if ((newlyAddedSeason && shouldFireEvents) || seasonUpdated)
-            {
-                seasonEventsToEmit.TryAdd(tmdbSeason, newlyAddedSeason ? UpdateReason.Added : UpdateReason.Updated);
-                if (shouldFireEvents)
-                    tmdbSeason.LastUpdatedAt = DateTime.Now;
-                seasonsToSave.Add(tmdbSeason);
-                seasonAlreadySaved = true;
-            }
-
-            seasonsToSkip.Add(tmdbSeason.Id);
-
-            var episodeBag = new List<TMDB_Episode>();
-            var hiddenEpisodeBag = new List<TMDB_Episode>();
-            foreach (var reducedEpisode in season.Episodes!)
-            {
-                _logger.LogDebug("Checking episode {EpisodeNumber} in season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedEpisode.EpisodeNumber, season.SeasonNumber, show.Name, show.Id);
-                if (!existingEpisodes.TryGetValue(reducedEpisode.Id, out var tmdbEpisode))
-                {
-                    episodesToAdd++;
-                    tmdbEpisode = new(reducedEpisode.Id);
-                }
-                var newlyAddedEpisode = tmdbEpisode.CreatedAt == tmdbEpisode.LastUpdatedAt;
-
-                if (changedItems.HasValue && !newlyAddedEpisode && !changedItems.Value.Episodes.Contains((season.SeasonNumber, (int)reducedEpisode.EpisodeNumber)))
-                {
-                    episodesToSkip.Add(tmdbEpisode.Id);
-                    (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
-                    if (downloadCrewAndCast)
-                        foreach (var personId in episodePeople[tmdbEpisode.Id])
-                            allPeopleToAddOrKeep.Add(personId);
-                    continue;
-                }
-
-                bool episodeUpdated;
-                if (quickRefresh)
-                {
-                    var baseUpdated = tmdbEpisode.Populate(show, season, reducedEpisode, null);
-                    episodeUpdated = UpdateTitlesAndOverviews(tmdbEpisode, null, preferredTitleLanguages, preferredOverviewLanguages) || baseUpdated;
-                }
-                else
-                {
-                    var episodeMethods = TvEpisodeMethods.ExternalIds | TvEpisodeMethods.Translations;
-                    if (downloadCrewAndCast)
-                        episodeMethods |= TvEpisodeMethods.Credits;
-                    var episode = await UseClient(c => c.GetTvEpisodeAsync(show.Id, season.SeasonNumber, reducedEpisode.EpisodeNumber, episodeMethods), $"Get episode {reducedEpisode.EpisodeNumber} in season {season.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false);
-                    if (episode is null)
-                    {
-                        episodeUpdated = false;
-                    }
-                    else
-                    {
-                        episodeUpdated = tmdbEpisode.Populate(show, season, reducedEpisode, episode.Translations);
-                        episodeUpdated = UpdateTitlesAndOverviews(tmdbEpisode, episode.Translations, preferredTitleLanguages, preferredOverviewLanguages) || episodeUpdated;
-                        episodeUpdated = UpdateEpisodeExternalIDs(tmdbEpisode, episode.ExternalIds!) || episodeUpdated;
-                        if (downloadCrewAndCast)
-                        {
-                            var (castOrCrewUpdated, peopleToAddOrKeep, peopleToPotentiallyRemove) = UpdateEpisodeCastAndCrew(tmdbEpisode, episode.Credits!);
-                            episodeUpdated |= castOrCrewUpdated;
-                            foreach (var personId in peopleToAddOrKeep)
-                                allPeopleToAddOrKeep.Add(personId);
-                            foreach (var personId in peopleToPotentiallyRemove)
-                                allPeopleToPotentiallyRemove.Add(personId);
-                        }
-                    }
-                }
-
-                if ((newlyAddedEpisode && shouldFireEvents) || episodeUpdated)
-                {
-                    episodeEventsToEmit.TryAdd(tmdbEpisode, newlyAddedEpisode ? UpdateReason.Added : UpdateReason.Updated);
-                    if (shouldFireEvents)
-                        tmdbEpisode.LastUpdatedAt = DateTime.Now;
-                    episodesToSave.Add(tmdbEpisode);
-                }
-
-                episodesToSkip.Add(tmdbEpisode.Id);
-                (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
-            }
-
-            var episodeCount = episodeBag.Count;
-            var hiddenEpisodeCount = hiddenEpisodeBag.Count;
-            if (tmdbSeason.EpisodeCount != episodeCount)
-            {
-                tmdbSeason.EpisodeCount = episodeCount;
-                seasonUpdated = true;
-            }
-            if (tmdbSeason.HiddenEpisodeCount != hiddenEpisodeCount)
-            {
-                tmdbSeason.HiddenEpisodeCount = hiddenEpisodeCount;
-                seasonUpdated = true;
-            }
-            if (seasonUpdated)
-            {
-                tmdbSeason.LastUpdatedAt = DateTime.Now;
-                if (!seasonAlreadySaved)
-                {
-                    seasonEventsToEmit.TryAdd(tmdbSeason, UpdateReason.Updated);
-                    seasonsToSave.Add(tmdbSeason);
-                }
-            }
-            totalEpisodeCount += episodeCount;
-            totalHiddenEpisodeCount += hiddenEpisodeCount;
-        }
-
-        var seasonsToRemove = existingSeasons.Values.ExceptBy(seasonsToSkip, s => s.Id).ToList();
-        var episodesToRemove = existingEpisodes.Values.ExceptBy(episodesToSkip, e => e.Id).ToList();
+        var seasonsToRemove = existingSeasons.Values.ExceptBy(state.SeasonsToSkip, s => s.Id).ToList();
+        var episodesToRemove = existingEpisodes.Values.ExceptBy(state.EpisodesToSkip, e => e.Id).ToList();
 
         _logger.LogDebug(
-            "Added/updated/removed/skipped {a}/{u}/{r}/{s} seasons for show {ShowTitle} (Show={ShowId})",
-            seasonsToAdd,
-            seasonsToSave.Count - seasonsToAdd,
+            "Added/updated/removed/skipped {Added}/{Updated}/{Removed}/{Skipped} seasons for show {ShowTitle} (Show={ShowId})",
+            state.SeasonsAdded,
+            state.SeasonsToSave.Count - state.SeasonsAdded,
             seasonsToRemove.Count,
-            existingSeasons.Count + seasonsToAdd - seasonsToRemove.Count - seasonsToSave.Count,
+            existingSeasons.Count + state.SeasonsAdded - seasonsToRemove.Count - state.SeasonsToSave.Count,
             show.Name,
             show.Id);
-        _tmdbSeasons.Save(seasonsToSave);
+        _tmdbSeasons.Save(state.SeasonsToSave);
 
         foreach (var season in seasonsToRemove)
         {
             PurgeShowSeason(season);
-            seasonEventsToEmit.TryAdd(season, UpdateReason.Removed);
+            state.SeasonEvents.TryAdd(season, UpdateReason.Removed);
         }
 
         _tmdbSeasons.Delete(seasonsToRemove);
 
         _logger.LogDebug(
-            "Added/updated/removed/skipped {a}/{u}/{r}/{s} episodes for show {ShowTitle} (Show={ShowId})",
-            episodesToAdd,
-            episodesToSave.Count - episodesToAdd,
+            "Added/updated/removed/skipped {Added}/{Updated}/{Removed}/{Skipped} episodes for show {ShowTitle} (Show={ShowId})",
+            state.EpisodesAdded,
+            state.EpisodesToSave.Count - state.EpisodesAdded,
             episodesToRemove.Count,
-            existingEpisodes.Count + episodesToAdd - episodesToRemove.Count - episodesToSave.Count,
+            existingEpisodes.Count + state.EpisodesAdded - episodesToRemove.Count - state.EpisodesToSave.Count,
             show.Name,
             show.Id);
-        _tmdbEpisodes.Save(episodesToSave);
+        _tmdbEpisodes.Save(state.EpisodesToSave);
 
         foreach (var episode in episodesToRemove)
         {
             PurgeShowEpisode(episode);
-            episodeEventsToEmit.TryAdd(episode, UpdateReason.Removed);
+            state.EpisodeEvents.TryAdd(episode, UpdateReason.Removed);
         }
 
         _tmdbEpisodes.Delete(episodesToRemove);
 
         if (quickRefresh)
             return new TmdbSeasonEpisodeUpdateResult(
-                seasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || episodesToSave.Count > 0 || episodesToRemove.Count > 0,
-                seasonEventsToEmit,
-                episodeEventsToEmit,
-                totalEpisodeCount,
-                totalHiddenEpisodeCount
-            );
+                state.SeasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || state.EpisodesToSave.Count > 0 || episodesToRemove.Count > 0,
+                state.SeasonEvents,
+                state.EpisodeEvents,
+                state.TotalEpisodeCount,
+                state.TotalHiddenEpisodeCount);
 
-        var anyPeopleChanged = await UpdateShowPeopleAsync(show, forceRefresh, downloadImages, allPeopleToAddOrKeep, allPeopleToPotentiallyRemove);
+        var anyPeopleChanged = await UpdateShowPeopleAsync(show, forceRefresh, downloadImages, state.PeopleToAddOrKeep, state.PeopleToPotentiallyRemove).ConfigureAwait(false);
 
         return new TmdbSeasonEpisodeUpdateResult(
-            seasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || episodesToSave.Count > 0 || episodesToRemove.Count > 0 || anyPeopleChanged,
-            seasonEventsToEmit,
-            episodeEventsToEmit,
-            totalEpisodeCount,
-            totalHiddenEpisodeCount
-        );
+            state.SeasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || state.EpisodesToSave.Count > 0 || episodesToRemove.Count > 0 || anyPeopleChanged,
+            state.SeasonEvents,
+            state.EpisodeEvents,
+            state.TotalEpisodeCount,
+            state.TotalHiddenEpisodeCount);
+    }
+
+    private ILookup<int, int> BuildEpisodePeopleLookup(TvShow show, ShowSyncState state)
+        => state.DownloadCrewAndCast
+            ? _tmdbEpisodeCast.GetByTmdbShowID(show.Id).Select(c => (c.TmdbEpisodeID, c.TmdbPersonID))
+                .Concat(_tmdbEpisodeCrew.GetByTmdbShowID(show.Id).Select(c => (c.TmdbEpisodeID, c.TmdbPersonID)))
+                .ToLookup(x => x.TmdbEpisodeID, x => x.TmdbPersonID)
+            : Enumerable.Empty<TMDB_Episode_Cast>().ToLookup(c => c.TmdbEpisodeID, c => c.TmdbPersonID);
+
+    private async Task ProcessShowSeasonAsync(
+        TvShow show,
+        SearchTvSeason reducedSeason,
+        Dictionary<int, TMDB_Season> existingSeasons,
+        Dictionary<int, TMDB_Episode> existingEpisodes,
+        ILookup<int, int> episodePeople,
+        ShowSyncState state)
+    {
+        _logger.LogDebug("Checking season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedSeason.SeasonNumber, show.Name, show.Id);
+
+        if (TryAccumulateUnchangedSeason(show, reducedSeason, existingSeasons, episodePeople, state))
+            return;
+
+        var season = await UseClient(c => c.GetTvSeasonAsync(show.Id, reducedSeason.SeasonNumber, TvSeasonMethods.Translations), $"Get season {reducedSeason.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false) ??
+            throw new Exception($"Unable to fetch season {reducedSeason.SeasonNumber} for show \"{show.Name}\".");
+
+        if (!existingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeason))
+        {
+            state.SeasonsAdded++;
+            tmdbSeason = new(reducedSeason.Id);
+        }
+        var newlyAddedSeason = tmdbSeason.CreatedAt == tmdbSeason.LastUpdatedAt;
+
+        var seasonUpdated = tmdbSeason.Populate(show, season);
+        seasonUpdated = UpdateTitlesAndOverviews(tmdbSeason, season.Translations, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || seasonUpdated;
+
+        var seasonAlreadySaved = false;
+        if ((newlyAddedSeason && state.ShouldFireEvents) || seasonUpdated)
+        {
+            state.SeasonEvents.TryAdd(tmdbSeason, newlyAddedSeason ? UpdateReason.Added : UpdateReason.Updated);
+            if (state.ShouldFireEvents)
+                tmdbSeason.LastUpdatedAt = DateTime.Now;
+            state.SeasonsToSave.Add(tmdbSeason);
+            seasonAlreadySaved = true;
+        }
+
+        state.SeasonsToSkip.Add(tmdbSeason.Id);
+
+        var (episodeCount, hiddenEpisodeCount) = await ProcessSeasonEpisodesAsync(show, season, existingEpisodes, episodePeople, state).ConfigureAwait(false);
+
+        if (tmdbSeason.EpisodeCount != episodeCount)
+        {
+            tmdbSeason.EpisodeCount = episodeCount;
+            seasonUpdated = true;
+        }
+        if (tmdbSeason.HiddenEpisodeCount != hiddenEpisodeCount)
+        {
+            tmdbSeason.HiddenEpisodeCount = hiddenEpisodeCount;
+            seasonUpdated = true;
+        }
+        if (seasonUpdated)
+        {
+            tmdbSeason.LastUpdatedAt = DateTime.Now;
+            if (!seasonAlreadySaved)
+            {
+                state.SeasonEvents.TryAdd(tmdbSeason, UpdateReason.Updated);
+                state.SeasonsToSave.Add(tmdbSeason);
+            }
+        }
+
+        state.TotalEpisodeCount += episodeCount;
+        state.TotalHiddenEpisodeCount += hiddenEpisodeCount;
+    }
+
+    // Skipped seasons still need their episode counts registered so season totals stay accurate.
+    private bool TryAccumulateUnchangedSeason(
+        TvShow show,
+        SearchTvSeason reducedSeason,
+        Dictionary<int, TMDB_Season> existingSeasons,
+        ILookup<int, int> episodePeople,
+        ShowSyncState state)
+    {
+        if (!state.ChangedItems.HasValue || state.ChangedItems.Value.SeasonNumbers.Contains(reducedSeason.SeasonNumber) || !existingSeasons.TryGetValue(reducedSeason.Id, out var unchangedSeason))
+            return false;
+
+        state.SeasonsToSkip.Add(unchangedSeason.Id);
+        var localEpisodes = _tmdbEpisodes.GetByTmdbSeasonID(unchangedSeason.Id);
+        var visibleCount = 0;
+        foreach (var ep in localEpisodes)
+        {
+            state.EpisodesToSkip.Add(ep.Id);
+            if (!ep.IsHidden) visibleCount++;
+        }
+        state.TotalEpisodeCount += visibleCount;
+        state.TotalHiddenEpisodeCount += localEpisodes.Count - visibleCount;
+        if (state.DownloadCrewAndCast)
+            foreach (var ep in localEpisodes)
+                foreach (var personId in episodePeople[ep.Id])
+                    state.PeopleToAddOrKeep.Add(personId);
+        _logger.LogDebug("Skipping unchanged season {SeasonNumber} for show {ShowTitle} (Show={ShowId}).", reducedSeason.SeasonNumber, show.Name, show.Id);
+        return true;
+    }
+
+    private async Task<TmdbSeasonEpisodeCounts> ProcessSeasonEpisodesAsync(
+        TvShow show,
+        TvSeason season,
+        Dictionary<int, TMDB_Episode> existingEpisodes,
+        ILookup<int, int> episodePeople,
+        ShowSyncState state)
+    {
+        var episodeBag = new List<TMDB_Episode>();
+        var hiddenEpisodeBag = new List<TMDB_Episode>();
+
+        foreach (var reducedEpisode in season.Episodes!)
+        {
+            _logger.LogDebug("Checking episode {EpisodeNumber} in season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedEpisode.EpisodeNumber, season.SeasonNumber, show.Name, show.Id);
+            if (!existingEpisodes.TryGetValue(reducedEpisode.Id, out var tmdbEpisode))
+            {
+                state.EpisodesAdded++;
+                tmdbEpisode = new(reducedEpisode.Id);
+            }
+            var newlyAddedEpisode = tmdbEpisode.CreatedAt == tmdbEpisode.LastUpdatedAt;
+
+            if (AccumulateUnchangedEpisode(tmdbEpisode, season, reducedEpisode, episodePeople, episodeBag, hiddenEpisodeBag, state))
+                continue;
+
+            var episodeUpdated = await FetchAndPopulateEpisodeAsync(show, season, reducedEpisode, tmdbEpisode, state).ConfigureAwait(false);
+
+            TrySaveEpisode(tmdbEpisode, newlyAddedEpisode, episodeUpdated, state);
+            state.EpisodesToSkip.Add(tmdbEpisode.Id);
+            (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
+        }
+
+        return new TmdbSeasonEpisodeCounts(episodeBag.Count, hiddenEpisodeBag.Count);
+    }
+
+    private static void TrySaveEpisode(TMDB_Episode tmdbEpisode, bool newlyAdded, bool updated, ShowSyncState state)
+    {
+        if (!(newlyAdded && state.ShouldFireEvents) && !updated)
+            return;
+
+        state.EpisodeEvents.TryAdd(tmdbEpisode, newlyAdded ? UpdateReason.Added : UpdateReason.Updated);
+        if (state.ShouldFireEvents)
+            tmdbEpisode.LastUpdatedAt = DateTime.Now;
+        state.EpisodesToSave.Add(tmdbEpisode);
+    }
+
+    private static bool AccumulateUnchangedEpisode(
+        TMDB_Episode tmdbEpisode,
+        TvSeason season,
+        TvSeasonEpisode reducedEpisode,
+        ILookup<int, int> episodePeople,
+        List<TMDB_Episode> episodeBag,
+        List<TMDB_Episode> hiddenEpisodeBag,
+        ShowSyncState state)
+    {
+        var newlyAdded = tmdbEpisode.CreatedAt == tmdbEpisode.LastUpdatedAt;
+        if (!state.ChangedItems.HasValue || newlyAdded || !state.ChangedItems.Value.Episodes.Contains((season.SeasonNumber, (int)reducedEpisode.EpisodeNumber)))
+            return false;
+
+        state.EpisodesToSkip.Add(tmdbEpisode.Id);
+        (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
+        if (state.DownloadCrewAndCast)
+            foreach (var personId in episodePeople[tmdbEpisode.Id])
+                state.PeopleToAddOrKeep.Add(personId);
+        return true;
+    }
+
+    private async Task<bool> FetchAndPopulateEpisodeAsync(
+        TvShow show,
+        TvSeason season,
+        TvSeasonEpisode reducedEpisode,
+        TMDB_Episode tmdbEpisode,
+        ShowSyncState state)
+    {
+        if (state.QuickRefresh)
+        {
+            var baseUpdated = tmdbEpisode.Populate(show, season, reducedEpisode, null);
+            return UpdateTitlesAndOverviews(tmdbEpisode, null, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || baseUpdated;
+        }
+
+        var episodeMethods = TvEpisodeMethods.ExternalIds | TvEpisodeMethods.Translations;
+        if (state.DownloadCrewAndCast)
+            episodeMethods |= TvEpisodeMethods.Credits;
+
+        var episode = await UseClient(c => c.GetTvEpisodeAsync(show.Id, season.SeasonNumber, reducedEpisode.EpisodeNumber, episodeMethods), $"Get episode {reducedEpisode.EpisodeNumber} in season {season.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false);
+        if (episode is null)
+            return false;
+
+        var episodeUpdated = tmdbEpisode.Populate(show, season, reducedEpisode, episode.Translations);
+        episodeUpdated = UpdateTitlesAndOverviews(tmdbEpisode, episode.Translations, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || episodeUpdated;
+        episodeUpdated = UpdateEpisodeExternalIDs(tmdbEpisode, episode.ExternalIds!) || episodeUpdated;
+        if (state.DownloadCrewAndCast)
+        {
+            var (castOrCrewUpdated, peopleToAddOrKeep, peopleToPotentiallyRemove) = UpdateEpisodeCastAndCrew(tmdbEpisode, episode.Credits!);
+            episodeUpdated |= castOrCrewUpdated;
+            AccumulateEpisodePeople(peopleToAddOrKeep, peopleToPotentiallyRemove, state);
+        }
+        return episodeUpdated;
+    }
+
+    private static void AccumulateEpisodePeople(IEnumerable<int> toAddOrKeep, IEnumerable<int> toPotentiallyRemove, ShowSyncState state)
+    {
+        foreach (var personId in toAddOrKeep)
+            state.PeopleToAddOrKeep.Add(personId);
+        foreach (var personId in toPotentiallyRemove)
+            state.PeopleToPotentiallyRemove.Add(personId);
     }
 
     private async Task<bool> UpdateShowPeopleAsync(TvShow show, bool forceRefresh, bool downloadImages, HashSet<int> allPeopleToAddOrKeep, HashSet<int> allPeopleToPotentiallyRemove)
@@ -1542,7 +1591,7 @@ public class TmdbMetadataService : ITmdbMetadataService
         {
             _logger.LogWarning(ex, "TMDB: Failed to purge one or more people during show cast/crew update (Show={ShowId})", show.Id);
         }
-        _logger.LogDebug("Added/updated/purged/skipped {a}/{u}/{r}/{s} staff for show {ShowTitle} (Show={ShowId})",
+        _logger.LogDebug("Added/updated/purged/skipped {Added}/{Updated}/{Purged}/{Skipped} staff for show {ShowTitle} (Show={ShowId})",
             added, updated, purged, peopleToPurge.Count + peopleToCheck.Count - added - updated - purged, show.Name, show.Id);
         return added > 0 || purged > 0;
     }
@@ -2945,6 +2994,50 @@ public class TmdbMetadataService : ITmdbMetadataService
         return changes is null || changes.Count > 0;
     }
 
+    internal readonly record struct TmdbShowChangedItems(HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes);
+
+    private readonly record struct TmdbSeasonEpisodeCounts(int EpisodeCount, int HiddenEpisodeCount);
+
+    private readonly record struct TmdbSeasonEpisodeUpdateResult(
+        bool EpisodesOrSeasonsUpdated,
+        Dictionary<TMDB_Season, UpdateReason> UpdatedSeasons,
+        Dictionary<TMDB_Episode, UpdateReason> UpdatedEpisodes,
+        int EpisodeCount,
+        int HiddenEpisodeCount);
+
+    private sealed class ShowSyncState
+    {
+        public readonly bool DownloadCrewAndCast;
+        public readonly bool QuickRefresh;
+        public readonly bool ShouldFireEvents;
+        public readonly HashSet<TitleLanguage>? PreferredTitleLanguages;
+        public readonly HashSet<TitleLanguage>? PreferredOverviewLanguages;
+        public readonly TmdbShowChangedItems? ChangedItems;
+
+        public ShowSyncState(bool downloadCrewAndCast, bool quickRefresh, bool shouldFireEvents, HashSet<TitleLanguage>? preferredTitleLanguages, HashSet<TitleLanguage>? preferredOverviewLanguages, TmdbShowChangedItems? changedItems)
+        {
+            DownloadCrewAndCast = downloadCrewAndCast;
+            QuickRefresh = quickRefresh;
+            ShouldFireEvents = shouldFireEvents;
+            PreferredTitleLanguages = preferredTitleLanguages;
+            PreferredOverviewLanguages = preferredOverviewLanguages;
+            ChangedItems = changedItems;
+        }
+
+        public int SeasonsAdded;
+        public int EpisodesAdded;
+        public int TotalEpisodeCount;
+        public int TotalHiddenEpisodeCount;
+        public readonly HashSet<int> SeasonsToSkip = [];
+        public readonly List<TMDB_Season> SeasonsToSave = [];
+        public readonly Dictionary<TMDB_Season, UpdateReason> SeasonEvents = [];
+        public readonly HashSet<int> EpisodesToSkip = [];
+        public readonly List<TMDB_Episode> EpisodesToSave = [];
+        public readonly Dictionary<TMDB_Episode, UpdateReason> EpisodeEvents = [];
+        public readonly HashSet<int> PeopleToAddOrKeep = [];
+        public readonly HashSet<int> PeopleToPotentiallyRemove = [];
+    }
+
     /// <summary>
     /// Fetches the set of changed seasons and episodes for the given show from the TMDB Changes
     /// API since <paramref name="since"/>, for use as a selective-refresh filter.
@@ -2955,15 +3048,6 @@ public class TmdbMetadataService : ITmdbMetadataService
     /// <para>Empty sets if no season or episode changes were reported — the caller can skip the update.</para>
     /// <para>Populated sets containing the season numbers and (season, episode) pairs that changed.</para>
     /// </returns>
-    internal readonly record struct TmdbShowChangedItems(HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes);
-
-    private readonly record struct TmdbSeasonEpisodeUpdateResult(
-        bool EpisodesOrSeasonsUpdated,
-        Dictionary<TMDB_Season, UpdateReason> UpdatedSeasons,
-        Dictionary<TMDB_Episode, UpdateReason> UpdatedEpisodes,
-        int EpisodeCount,
-        int HiddenEpisodeCount);
-
     private async Task<TmdbShowChangedItems?> GetShowChangedItemsAsync(int showId, DateTime since)
     {
         // The TMDB Changes API covers at most the last 14 days. Return null to signal the caller

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -725,32 +725,26 @@ public class TmdbMetadataService : ITmdbMetadataService
         {
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
         }
-        // Schedule retries for transiently-failed people first; their cast/crew rows are preserved.
-        // Then clean up rows for people that permanently failed — the excluded set ensures
-        // transient failures are skipped in CleanupOrphanedCastCrew.
+        // Schedule retries for transiently-failed people; their cast/crew rows are preserved.
         var transientlyFailedMovieSet = transientlyFailedMoviePeople.ToHashSet();
-        try
-        {
+        if (transientlyFailedMovieSet.Count > 0)
             await Task.WhenAll(transientlyFailedMovieSet.Select(personId =>
                 _scheduler.Enqueue<UpdateTmdbPersonJob>(j => { j.TmdbPersonID = personId; j.DownloadImages = downloadImages; j.TmdbMovieID = tmdbMovie.Id; })));
-        }
-        finally
+        // Remove cast/crew for people that permanently failed — transient failures are excluded.
+        CleanupOrphanedCastCrew(peopleToKeep, transientlyFailedMovieSet, missingPersonIds =>
         {
-            CleanupOrphanedCastCrew(peopleToKeep, transientlyFailedMovieSet, missingPersonIds =>
+            var orphanedCast = _tmdbMovieCast.GetByTmdbMovieID(tmdbMovie.Id)
+                .Where(c => missingPersonIds.Contains(c.TmdbPersonID)).ToList();
+            var orphanedCrew = _tmdbMovieCrew.GetByTmdbMovieID(tmdbMovie.Id)
+                .Where(c => missingPersonIds.Contains(c.TmdbPersonID)).ToList();
+            if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
             {
-                var orphanedCast = _tmdbMovieCast.GetByTmdbMovieID(tmdbMovie.Id)
-                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID)).ToList();
-                var orphanedCrew = _tmdbMovieCrew.GetByTmdbMovieID(tmdbMovie.Id)
-                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID)).ToList();
-                if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
-                {
-                    _logger.LogWarning("TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Movie={MovieId})",
-                        orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, tmdbMovie.Id);
-                    _tmdbMovieCast.Delete(orphanedCast);
-                    _tmdbMovieCrew.Delete(orphanedCrew);
-                }
-            });
-        }
+                _logger.LogWarning("TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Movie={MovieId})",
+                    orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, tmdbMovie.Id);
+                _tmdbMovieCast.Delete(orphanedCast);
+                _tmdbMovieCrew.Delete(orphanedCrew);
+            }
+        });
         try
         {
             await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToPurge, async personId =>
@@ -1561,32 +1555,26 @@ public class TmdbMetadataService : ITmdbMetadataService
         {
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during show cast/crew update (Show={ShowId})", show.Id);
         }
-        // Schedule retries for transiently-failed people first; their cast/crew rows are preserved.
-        // Then clean up rows for people that permanently failed — the excluded set ensures
-        // transient failures are skipped in CleanupOrphanedCastCrew.
+        // Schedule retries for transiently-failed people; their cast/crew rows are preserved.
         var transientlyFailedShowSet = transientlyFailedShowPeople.ToHashSet();
-        try
-        {
+        if (transientlyFailedShowSet.Count > 0)
             await Task.WhenAll(transientlyFailedShowSet.Select(personId =>
                 _scheduler.Enqueue<UpdateTmdbPersonJob>(j => { j.TmdbPersonID = personId; j.DownloadImages = downloadImages; j.TmdbShowID = show.Id; })));
-        }
-        finally
+        // Remove cast/crew for people that permanently failed — transient failures are excluded.
+        CleanupOrphanedCastCrew(peopleToCheck, transientlyFailedShowSet, missingPersonIds =>
         {
-            CleanupOrphanedCastCrew(peopleToCheck, transientlyFailedShowSet, missingPersonIds =>
+            var orphanedCast = _tmdbEpisodeCast.GetByTmdbShowID(show.Id)
+                .Where(c => missingPersonIds.Contains(c.TmdbPersonID)).ToList();
+            var orphanedCrew = _tmdbEpisodeCrew.GetByTmdbShowID(show.Id)
+                .Where(c => missingPersonIds.Contains(c.TmdbPersonID)).ToList();
+            if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
             {
-                var orphanedCast = _tmdbEpisodeCast.GetByTmdbShowID(show.Id)
-                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID)).ToList();
-                var orphanedCrew = _tmdbEpisodeCrew.GetByTmdbShowID(show.Id)
-                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID)).ToList();
-                if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
-                {
-                    _logger.LogWarning("TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Show={ShowId})",
-                        orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, show.Id);
-                    _tmdbEpisodeCast.Delete(orphanedCast);
-                    _tmdbEpisodeCrew.Delete(orphanedCrew);
-                }
-            });
-        }
+                _logger.LogWarning("TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Show={ShowId})",
+                    orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, show.Id);
+                _tmdbEpisodeCast.Delete(orphanedCast);
+                _tmdbEpisodeCrew.Delete(orphanedCrew);
+            }
+        });
         try
         {
             await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToPurge, async personId =>

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -29,12 +29,15 @@ using Shoko.Server.Scheduling.Jobs.TMDB;
 using Shoko.Server.Server;
 using Shoko.Server.Settings;
 using Shoko.Server.Utilities;
+using Newtonsoft.Json.Linq;
 using TMDbLib.Client;
+using TMDbLib.Objects.Changes;
 using TMDbLib.Objects.Collections;
 using TMDbLib.Objects.Exceptions;
 using TMDbLib.Objects.General;
 using TMDbLib.Objects.Movies;
 using TMDbLib.Objects.People;
+using TMDbLib.Objects.Search;
 using TMDbLib.Objects.TvShows;
 
 using MovieCredits = TMDbLib.Objects.Movies.Credits;
@@ -51,6 +54,8 @@ namespace Shoko.Server.Providers.TMDB;
 public class TmdbMetadataService : ITmdbMetadataService
 {
     private static readonly int _maxConcurrency = Math.Min(6, Environment.ProcessorCount);
+
+    private const int TmdbChangesWindowDays = 14;
 
     private static TmdbMetadataService? _instance = null;
 
@@ -490,6 +495,12 @@ public class TmdbMetadataService : ITmdbMetadataService
                 return false;
             }
 
+            if (!forceRefresh && !newlyAdded && !await HasMovieChangedSinceAsync(movieId, tmdbMovie.LastUpdatedAt).ConfigureAwait(false))
+            {
+                _logger.LogInformation("Skipping update of movie {MovieID} as no changes were detected on TMDB since {LastUpdatedAt}.", movieId, tmdbMovie.LastUpdatedAt);
+                return false;
+            }
+
             // Abort if we couldn't find the movie by id.
             var methods = MovieMethods.Translations | MovieMethods.ReleaseDates | MovieMethods.ExternalIds | MovieMethods.Keywords;
             if (downloadCrewAndCast)
@@ -681,7 +692,7 @@ public class TmdbMetadataService : ITmdbMetadataService
                     Interlocked.Increment(ref peopleUpdated);
             });
         }
-        catch (AggregateException ex)
+        catch (Exception ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
             // Cast/crew rows were already written above. Any person ID whose fetch failed leaves a
@@ -716,7 +727,7 @@ public class TmdbMetadataService : ITmdbMetadataService
                     Interlocked.Increment(ref peoplePurged);
             });
         }
-        catch (AggregateException ex)
+        catch (Exception ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to purge one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
         }
@@ -1115,6 +1126,12 @@ public class TmdbMetadataService : ITmdbMetadataService
             if (show is null)
                 return false;
 
+            // Null result (14-day window exceeded or API failure) triggers a full refresh in UpdateShowSeasonsAndEpisodes.
+            // Not applied on forced refreshes or newly-added shows — those always do a full fetch.
+            (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? changedItems = null;
+            if (!newlyAdded && !forceRefresh)
+                changedItems = await GetShowChangedItemsAsync(showId, tmdbShow.LastUpdatedAt).ConfigureAwait(false);
+
             var preferredTitleLanguages = settings.TMDB.DownloadAllTitles ? null : Languages.PreferredNamingLanguages.Select(a => a.Language).ToHashSet();
             var preferredOverviewLanguages = settings.TMDB.DownloadAllOverviews ? null : Languages.PreferredDescriptionNamingLanguages.Select(a => a.Language).ToHashSet();
             var contentRatingLanguages = settings.TMDB.DownloadAllContentRatings
@@ -1129,7 +1146,7 @@ public class TmdbMetadataService : ITmdbMetadataService
             updated = titlesUpdated || overviewsUpdated || updated;
             updated = UpdateShowExternalIDs(tmdbShow, show.ExternalIds!) || updated;
             updated = await UpdateCompanies(tmdbShow, show.ProductionCompanies!) || updated;
-            var (episodesOrSeasonsUpdated, updatedSeasons, updatedEpisodes, episodeCount, hiddenEpisodeCount) = await UpdateShowSeasonsAndEpisodes(show, downloadCrewAndCast, forceRefresh, downloadImages, quickRefresh, shouldFireEvents);
+            var (episodesOrSeasonsUpdated, updatedSeasons, updatedEpisodes, episodeCount, hiddenEpisodeCount) = await UpdateShowSeasonsAndEpisodes(show, downloadCrewAndCast, forceRefresh, downloadImages, quickRefresh, shouldFireEvents, changedItems);
             updated = episodesOrSeasonsUpdated || updated;
             if (tmdbShow.EpisodeCount != episodeCount)
             {
@@ -1186,284 +1203,359 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
     }
 
-    private async Task<(bool episodesOrSeasonsUpdated, Dictionary<TMDB_Season, UpdateReason> updatedSeasons, Dictionary<TMDB_Episode, UpdateReason> updatedEpisodes, int episodeCount, int hiddenEpisodeCount)> UpdateShowSeasonsAndEpisodes(TvShow show, bool downloadCrewAndCast = false, bool forceRefresh = false, bool downloadImages = false, bool quickRefresh = false, bool shouldFireEvents = false)
+    private sealed class ShowSeasonUpdateState
+    {
+        public readonly bool DownloadCrewAndCast;
+        public readonly bool QuickRefresh;
+        public readonly bool ShouldFireEvents;
+        public readonly (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? ChangedItems;
+        public readonly HashSet<TitleLanguage>? PreferredTitleLanguages;
+        public readonly HashSet<TitleLanguage>? PreferredOverviewLanguages;
+        public int SeasonsToAdd;
+        public int EpisodesToAdd;
+        public int TotalEpisodeCount;
+        public int TotalHiddenEpisodeCount;
+        public readonly Dictionary<int, TMDB_Season> ExistingSeasons;
+        public readonly ConcurrentDictionary<int, TMDB_Episode> ExistingEpisodes;
+        public readonly ConcurrentBag<int> SeasonsToSkip = new();
+        public readonly ConcurrentBag<TMDB_Season> SeasonsToSave = new();
+        public readonly ConcurrentDictionary<TMDB_Season, UpdateReason> SeasonEventsToEmit = new();
+        public readonly ConcurrentBag<int> EpisodesToSkip = new();
+        public readonly ConcurrentBag<TMDB_Episode> EpisodesToSave = new();
+        public readonly ConcurrentDictionary<TMDB_Episode, UpdateReason> EpisodeEventsToEmit = new();
+        public readonly ConcurrentDictionary<int, byte> AllPeopleToAddOrKeep = new();
+        public readonly ConcurrentDictionary<int, byte> AllPeopleToPotentiallyRemove = new();
+
+        public ShowSeasonUpdateState(
+            bool downloadCrewAndCast,
+            bool quickRefresh,
+            bool shouldFireEvents,
+            (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? changedItems,
+            (HashSet<TitleLanguage>? Titles, HashSet<TitleLanguage>? Overviews) preferredLanguages,
+            Dictionary<int, TMDB_Season> existingSeasons,
+            ConcurrentDictionary<int, TMDB_Episode> existingEpisodes)
+        {
+            DownloadCrewAndCast = downloadCrewAndCast;
+            QuickRefresh = quickRefresh;
+            ShouldFireEvents = shouldFireEvents;
+            ChangedItems = changedItems;
+            PreferredTitleLanguages = preferredLanguages.Titles;
+            PreferredOverviewLanguages = preferredLanguages.Overviews;
+            ExistingSeasons = existingSeasons;
+            ExistingEpisodes = existingEpisodes;
+        }
+    }
+
+    private async Task<(bool episodesOrSeasonsUpdated, Dictionary<TMDB_Season, UpdateReason> updatedSeasons, Dictionary<TMDB_Episode, UpdateReason> updatedEpisodes, int episodeCount, int hiddenEpisodeCount)> UpdateShowSeasonsAndEpisodes(TvShow show, bool downloadCrewAndCast = false, bool forceRefresh = false, bool downloadImages = false, bool quickRefresh = false, bool shouldFireEvents = false, (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? changedItems = null)
     {
         var settings = _settingsProvider.GetSettings();
         var preferredTitleLanguages = settings.TMDB.DownloadAllTitles ? null : Languages.PreferredEpisodeNamingLanguages.Select(a => a.Language).ToHashSet();
         var preferredOverviewLanguages = settings.TMDB.DownloadAllOverviews ? null : Languages.PreferredDescriptionNamingLanguages.Select(a => a.Language).ToHashSet();
 
-        var existingSeasons = _tmdbSeasons.GetByTmdbShowID(show.Id)
-            .ToDictionary(season => season.Id);
-        var seasonsToAdd = 0;
-        var seasonsToSkip = new ConcurrentBag<int>();
-        var seasonsToSave = new ConcurrentBag<TMDB_Season>();
-        var seasonEventsToEmit = new ConcurrentDictionary<TMDB_Season, UpdateReason>();
-
-        var totalEpisodeCount = 0;
-        var totalHiddenEpisodeCount = 0;
+        var existingSeasons = _tmdbSeasons.GetByTmdbShowID(show.Id).ToDictionary(season => season.Id);
         var existingEpisodes = new ConcurrentDictionary<int, TMDB_Episode>();
         foreach (var episode in _tmdbEpisodes.GetByTmdbShowID(show.Id))
             existingEpisodes.TryAdd(episode.Id, episode);
-        var episodesToAdd = 0;
-        var episodesToSkip = new ConcurrentBag<int>();
-        var episodesToSave = new ConcurrentBag<TMDB_Episode>();
-        var episodeEventsToEmit = new ConcurrentDictionary<TMDB_Episode, UpdateReason>();
-        var allPeopleToAddOrKeep = new ConcurrentBag<int>();
-        var allPeopleToPotentiallyRemove = new ConcurrentBag<int>();
-        await ProcessWithConcurrencyAsync(_maxConcurrency, show.Seasons!, async reducedSeason =>
-        {
-            _logger.LogDebug("Checking season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedSeason.SeasonNumber, show.Name, show.Id);
 
-            // Skipped seasons still need their episode counts registered so season totals stay accurate.
-            if (changedItems.HasValue && !changedItems.Value.SeasonNumbers.Contains(reducedSeason.SeasonNumber) &&
-                existingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeasonCached))
-            {
-                seasonsToSkip.Add(tmdbSeasonCached.Id);
-                var localEpisodes = _tmdbEpisodes.GetByTmdbSeasonID(tmdbSeasonCached.Id);
-                foreach (var ep in localEpisodes)
-                    episodesToSkip.Add(ep.Id);
-                var visibleCount = localEpisodes.Count(e => !e.IsHidden);
-                Interlocked.Add(ref totalEpisodeCount, visibleCount);
-                Interlocked.Add(ref totalHiddenEpisodeCount, localEpisodes.Count - visibleCount);
-                _logger.LogDebug("Skipping unchanged season {SeasonNumber} for show {ShowTitle} (Show={ShowId}).", reducedSeason.SeasonNumber, show.Name, show.Id);
-                return;
-            }
+        var state = new ShowSeasonUpdateState(downloadCrewAndCast, quickRefresh, shouldFireEvents, changedItems, (preferredTitleLanguages, preferredOverviewLanguages), existingSeasons, existingEpisodes);
+        await ProcessWithConcurrencyAsync(_maxConcurrency, show.Seasons!, reducedSeason =>
+            ProcessShowSeasonAsync(show, reducedSeason, state));
 
-
-            var season = await UseClient(c => c.GetTvSeasonAsync(show.Id, reducedSeason.SeasonNumber, TvSeasonMethods.Translations), $"Get season {reducedSeason.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false) ??
-                throw new Exception($"Unable to fetch season {reducedSeason.SeasonNumber} for show \"{show.Name}\".");
-            if (!existingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeason))
-            {
-                Interlocked.Increment(ref seasonsToAdd);
-                tmdbSeason = new(reducedSeason.Id);
-            }
-            var newlyAddedSeason = tmdbSeason.CreatedAt == tmdbSeason.LastUpdatedAt;
-
-            var seasonUpdated = tmdbSeason.Populate(show, season);
-            seasonUpdated = UpdateTitlesAndOverviews(tmdbSeason, season.Translations, preferredTitleLanguages, preferredOverviewLanguages) || seasonUpdated;
-
-            var seasonAlreadySaved = false;
-            if ((newlyAddedSeason && shouldFireEvents) || seasonUpdated)
-            {
-                seasonEventsToEmit.TryAdd(tmdbSeason, newlyAddedSeason ? UpdateReason.Added : UpdateReason.Updated);
-                if (shouldFireEvents)
-                    tmdbSeason.LastUpdatedAt = DateTime.Now;
-                seasonsToSave.Add(tmdbSeason);
-                seasonAlreadySaved = true;
-            }
-
-            seasonsToSkip.Add(tmdbSeason.Id);
-
-            var episodeBag = new List<TMDB_Episode>();
-            var hiddenEpisodeBag = new List<TMDB_Episode>();
-            foreach (var reducedEpisode in season.Episodes!)
-            {
-                _logger.LogDebug("Checking episode {EpisodeNumber} in season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedEpisode.EpisodeNumber, reducedSeason.SeasonNumber, show.Name, show.Id);
-                if (!existingEpisodes.TryGetValue(reducedEpisode.Id, out var tmdbEpisode))
-                {
-                    Interlocked.Increment(ref episodesToAdd);
-                    tmdbEpisode = new(reducedEpisode.Id);
-                }
-                var newlyAddedEpisode = tmdbEpisode.CreatedAt == tmdbEpisode.LastUpdatedAt;
-
-                // If quick refresh is enabled then skip the API call per episode. (Part 1)
-                TvEpisode? episode = null;
-                if (!quickRefresh)
-                {
-                    var episodeMethods = TvEpisodeMethods.ExternalIds | TvEpisodeMethods.Translations;
-                    if (downloadCrewAndCast)
-                        episodeMethods |= TvEpisodeMethods.Credits;
-                    episode = await UseClient(c => c.GetTvEpisodeAsync(show.Id, season.SeasonNumber, reducedEpisode.EpisodeNumber, episodeMethods), $"Get episode {reducedEpisode.EpisodeNumber} in season {season.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false);
-                }
-
-                var episodeUpdated = tmdbEpisode.Populate(show, season, reducedEpisode, episode?.Translations);
-
-                // If quick refresh is enabled then skip the API call per episode, but do add the titles/overviews. (Part 2)
-                if (quickRefresh)
-                {
-                    episodeUpdated = UpdateTitlesAndOverviews(tmdbEpisode, null, preferredTitleLanguages, preferredOverviewLanguages) || episodeUpdated;
-                }
-                else
-                {
-                    episodeUpdated = UpdateTitlesAndOverviews(tmdbEpisode, episode!.Translations, preferredTitleLanguages, preferredOverviewLanguages) || episodeUpdated;
-                    episodeUpdated = UpdateEpisodeExternalIDs(tmdbEpisode, episode.ExternalIds!) || episodeUpdated;
-
-                    // Update crew & cast.
-                    if (downloadCrewAndCast)
-                    {
-                        var (castOrCrewUpdated, peopleToAddOrKeep, peopleToPotentiallyRemove) = UpdateEpisodeCastAndCrew(tmdbEpisode, episode.Credits!);
-                        episodeUpdated |= castOrCrewUpdated;
-                        foreach (var personId in peopleToAddOrKeep)
-                            allPeopleToAddOrKeep.Add(personId);
-                        foreach (var personId in peopleToPotentiallyRemove)
-                            allPeopleToPotentiallyRemove.Add(personId);
-                    }
-                }
-
-                if ((newlyAddedEpisode && shouldFireEvents) || episodeUpdated)
-                {
-                    episodeEventsToEmit.TryAdd(tmdbEpisode, newlyAddedEpisode ? UpdateReason.Added : UpdateReason.Updated);
-                    if (shouldFireEvents)
-                        tmdbEpisode.LastUpdatedAt = DateTime.Now;
-                    episodesToSave.Add(tmdbEpisode);
-                }
-
-                episodesToSkip.Add(tmdbEpisode.Id);
-                if (tmdbEpisode.IsHidden)
-                    hiddenEpisodeBag.Add(tmdbEpisode);
-                else
-                    episodeBag.Add(tmdbEpisode);
-            }
-
-            var episodeCount = episodeBag.Count;
-            var hiddenEpisodeCount = hiddenEpisodeBag.Count;
-            if (tmdbSeason.EpisodeCount != episodeCount)
-            {
-                tmdbSeason.EpisodeCount = episodeCount;
-                seasonUpdated = true;
-            }
-            if (tmdbSeason.HiddenEpisodeCount != hiddenEpisodeCount)
-            {
-                tmdbSeason.HiddenEpisodeCount = hiddenEpisodeCount;
-                seasonUpdated = true;
-            }
-            if (seasonUpdated)
-            {
-                tmdbSeason.LastUpdatedAt = DateTime.Now;
-                if (!seasonAlreadySaved)
-                    seasonsToSave.Add(tmdbSeason);
-            }
-            Interlocked.Add(ref totalEpisodeCount, episodeCount);
-            Interlocked.Add(ref totalHiddenEpisodeCount, hiddenEpisodeCount);
-        });
-
-        var seasonsToRemove = existingSeasons.Values
-            .ExceptBy(seasonsToSkip, season => season.Id)
-            .ToList();
-        var episodesToRemove = existingEpisodes.Values
-            .ExceptBy(episodesToSkip, episode => episode.Id)
-            .ToList();
+        var seasonsToRemove = existingSeasons.Values.ExceptBy(state.SeasonsToSkip, s => s.Id).ToList();
+        var episodesToRemove = existingEpisodes.Values.ExceptBy(state.EpisodesToSkip, e => e.Id).ToList();
 
         _logger.LogDebug(
             "Added/updated/removed/skipped {a}/{u}/{r}/{s} seasons for show {ShowTitle} (Show={ShowId})",
-            seasonsToAdd,
-            seasonsToSave.Count - seasonsToAdd,
+            state.SeasonsToAdd,
+            state.SeasonsToSave.Count - state.SeasonsToAdd,
             seasonsToRemove.Count,
-            existingSeasons.Count + seasonsToAdd - seasonsToRemove.Count - seasonsToSave.Count,
+            existingSeasons.Count + state.SeasonsToAdd - seasonsToRemove.Count - state.SeasonsToSave.Count,
             show.Name,
             show.Id);
-        _tmdbSeasons.Save(seasonsToSave);
+        _tmdbSeasons.Save(state.SeasonsToSave);
 
         foreach (var season in seasonsToRemove)
         {
             PurgeShowSeason(season);
-            seasonEventsToEmit.TryAdd(season, UpdateReason.Removed);
+            state.SeasonEventsToEmit.TryAdd(season, UpdateReason.Removed);
         }
 
         _tmdbSeasons.Delete(seasonsToRemove);
 
         _logger.LogDebug(
             "Added/updated/removed/skipped {a}/{u}/{r}/{s} episodes for show {ShowTitle} (Show={ShowId})",
-            episodesToAdd,
-            episodesToSave.Count - episodesToAdd,
+            state.EpisodesToAdd,
+            state.EpisodesToSave.Count - state.EpisodesToAdd,
             episodesToRemove.Count,
-            existingEpisodes.Count + episodesToAdd - episodesToRemove.Count - episodesToSave.Count,
+            existingEpisodes.Count + state.EpisodesToAdd - episodesToRemove.Count - state.EpisodesToSave.Count,
             show.Name,
             show.Id);
-        _tmdbEpisodes.Save(episodesToSave);
+        _tmdbEpisodes.Save(state.EpisodesToSave);
 
         foreach (var episode in episodesToRemove)
         {
             PurgeShowEpisode(episode);
-            episodeEventsToEmit.TryAdd(episode, UpdateReason.Removed);
+            state.EpisodeEventsToEmit.TryAdd(episode, UpdateReason.Removed);
         }
 
         _tmdbEpisodes.Delete(episodesToRemove);
 
         if (quickRefresh)
             return (
-                seasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || !episodesToSave.IsEmpty || episodesToRemove.Count > 0,
-                seasonEventsToEmit.ToDictionary(),
-                episodeEventsToEmit.ToDictionary(),
-                totalEpisodeCount,
-                totalHiddenEpisodeCount
+                state.SeasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || !state.EpisodesToSave.IsEmpty || episodesToRemove.Count > 0,
+                state.SeasonEventsToEmit.ToDictionary(),
+                state.EpisodeEventsToEmit.ToDictionary(),
+                state.TotalEpisodeCount,
+                state.TotalHiddenEpisodeCount
             );
 
-        // Only add/remove staff if we're not doing a quick refresh.
-        var peopleAdded = 0;
-        var peopleUpdated = 0;
-        var peoplePurged = 0;
-        var peopleToCheck = allPeopleToAddOrKeep.Distinct().ToList();
-        var peopleToPurge = allPeopleToPotentiallyRemove.Distinct().Except(peopleToCheck).ToList();
+        var (peopleAdded, peopleUpdated, peoplePurged, peopleSkipped) = await UpdateShowPeopleAsync(show, forceRefresh, downloadImages, state);
+        _logger.LogDebug("Added/removed {a}/{u}/{r}/{s} staff for show {ShowTitle} (Show={ShowId})",
+            peopleAdded, peopleUpdated, peoplePurged, peopleSkipped, show.Name, show.Id);
+
+        return (
+            state.SeasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || !state.EpisodesToSave.IsEmpty || episodesToRemove.Count > 0 || peopleAdded > 0 || peoplePurged > 0,
+            state.SeasonEventsToEmit.ToDictionary(),
+            state.EpisodeEventsToEmit.ToDictionary(),
+            state.TotalEpisodeCount,
+            state.TotalHiddenEpisodeCount
+        );
+    }
+
+    private async Task<(int Added, int Updated, int Purged, int Skipped)> UpdateShowPeopleAsync(TvShow show, bool forceRefresh, bool downloadImages, ShowSeasonUpdateState state)
+    {
+        var added = 0;
+        var updated = 0;
+        var purged = 0;
+        var peopleToCheck = state.AllPeopleToAddOrKeep.Keys.ToList();
+        var peopleToPurge = state.AllPeopleToPotentiallyRemove.Keys.Except(peopleToCheck).ToList();
         try
         {
             await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToCheck, async personId =>
             {
-                var (added, updated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentShowId: show.Id);
-                if (added)
-                    Interlocked.Increment(ref peopleAdded);
-                if (updated)
-                    Interlocked.Increment(ref peopleUpdated);
+                var (personAdded, personUpdated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentShowId: show.Id);
+                if (personAdded)
+                    Interlocked.Increment(ref added);
+                if (personUpdated)
+                    Interlocked.Increment(ref updated);
             });
         }
         catch (Exception ex)
         {
-            // Partial cast/crew failures are non-fatal: a missing person record does not invalidate
-            // the show. Log and continue so a transient API error doesn't abort the entire show update.
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during show cast/crew update (Show={ShowId})", show.Id);
-            // Same as the movie path: cast/crew rows referencing a person with no TMDB_Person row
-            // cause HTTP 500s when the API resolves cast. Remove entries for any person IDs that
-            // are still absent from the database after the fan-out.
-            var missingPersonIds = peopleToCheck
-                .Where(id => _tmdbPeople.GetByTmdbPersonID(id) is null)
-                .ToHashSet();
-            if (missingPersonIds.Count > 0)
-            {
-                var orphanedCast = _tmdbEpisodeCast.GetByTmdbShowID(show.Id)
-                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
-                    .ToList();
-                var orphanedCrew = _tmdbEpisodeCrew.GetByTmdbShowID(show.Id)
-                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
-                    .ToList();
-                if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
-                {
-                    _logger.LogWarning(
-                        "TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Show={ShowId})",
-                        orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, show.Id);
-                    _tmdbEpisodeCast.Delete(orphanedCast);
-                    _tmdbEpisodeCrew.Delete(orphanedCrew);
-                }
-            }
+            CleanupOrphanedShowCastCrew(show, peopleToCheck);
         }
         try
         {
             await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToPurge, async personId =>
             {
                 if (await PurgePerson(personId))
-                    Interlocked.Increment(ref peoplePurged);
+                    Interlocked.Increment(ref purged);
             });
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to purge one or more people during show cast/crew update (Show={ShowId})", show.Id);
         }
+        return (added, updated, purged, peopleToPurge.Count + peopleToCheck.Count - added - updated - purged);
+    }
 
-        _logger.LogDebug("Added/removed {a}/{u}/{r}/{s} staff for show {ShowTitle} (Show={ShowId})",
-            peopleAdded,
-            peopleUpdated,
-            peoplePurged,
-            peopleToPurge.Count + peopleToCheck.Count - peopleAdded - peopleUpdated - peoplePurged,
-            show.Name,
-            show.Id
-        );
+    private void CleanupOrphanedShowCastCrew(TvShow show, List<int> peopleToCheck)
+    {
+        // Cast/crew rows referencing a person with no TMDB_Person row cause HTTP 500s when the
+        // API resolves cast; remove entries for any person IDs absent from the database after the fan-out.
+        var missingPersonIds = peopleToCheck
+            .Where(id => _tmdbPeople.GetByTmdbPersonID(id) is null)
+            .ToHashSet();
+        if (missingPersonIds.Count > 0)
+        {
+            var orphanedCast = _tmdbEpisodeCast.GetByTmdbShowID(show.Id)
+                .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                .ToList();
+            var orphanedCrew = _tmdbEpisodeCrew.GetByTmdbShowID(show.Id)
+                .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                .ToList();
+            if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
+            {
+                _logger.LogWarning(
+                    "TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Show={ShowId})",
+                    orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, show.Id);
+                _tmdbEpisodeCast.Delete(orphanedCast);
+                _tmdbEpisodeCrew.Delete(orphanedCrew);
+            }
+        }
+    }
 
-        return (
-            seasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || !episodesToSave.IsEmpty || episodesToRemove.Count > 0 || peopleAdded > 0 || peoplePurged > 0,
-            seasonEventsToEmit.ToDictionary(),
-            episodeEventsToEmit.ToDictionary(),
-            totalEpisodeCount,
-            totalHiddenEpisodeCount
-        );
+    private async Task ProcessShowSeasonAsync(TvShow show, SearchTvSeason reducedSeason, ShowSeasonUpdateState state)
+    {
+        _logger.LogDebug("Checking season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedSeason.SeasonNumber, show.Name, show.Id);
+
+        // Skipped seasons still need their episode counts registered so season totals stay accurate.
+        if (TryHandleUnchangedSeason(reducedSeason, show, state))
+            return;
+
+        var season = await UseClient(c => c.GetTvSeasonAsync(show.Id, reducedSeason.SeasonNumber, TvSeasonMethods.Translations), $"Get season {reducedSeason.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false) ??
+            throw new Exception($"Unable to fetch season {reducedSeason.SeasonNumber} for show \"{show.Name}\".");
+        if (!state.ExistingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeason))
+        {
+            Interlocked.Increment(ref state.SeasonsToAdd);
+            tmdbSeason = new(reducedSeason.Id);
+        }
+        var newlyAddedSeason = tmdbSeason.CreatedAt == tmdbSeason.LastUpdatedAt;
+
+        var seasonUpdated = tmdbSeason.Populate(show, season);
+        seasonUpdated = UpdateTitlesAndOverviews(tmdbSeason, season.Translations, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || seasonUpdated;
+
+        var seasonAlreadySaved = MarkSeasonForSave(tmdbSeason, newlyAddedSeason, seasonUpdated, state);
+        state.SeasonsToSkip.Add(tmdbSeason.Id);
+
+        var episodeBag = new List<TMDB_Episode>();
+        var hiddenEpisodeBag = new List<TMDB_Episode>();
+        foreach (var reducedEpisode in season.Episodes!)
+            await ProcessShowEpisodeAsync(show, season, reducedEpisode, state, episodeBag, hiddenEpisodeBag);
+
+        var episodeCount = episodeBag.Count;
+        var hiddenEpisodeCount = hiddenEpisodeBag.Count;
+        if (tmdbSeason.EpisodeCount != episodeCount)
+        {
+            tmdbSeason.EpisodeCount = episodeCount;
+            seasonUpdated = true;
+        }
+        if (tmdbSeason.HiddenEpisodeCount != hiddenEpisodeCount)
+        {
+            tmdbSeason.HiddenEpisodeCount = hiddenEpisodeCount;
+            seasonUpdated = true;
+        }
+        if (seasonUpdated)
+        {
+            tmdbSeason.LastUpdatedAt = DateTime.Now;
+            if (!seasonAlreadySaved)
+                state.SeasonsToSave.Add(tmdbSeason);
+        }
+        Interlocked.Add(ref state.TotalEpisodeCount, episodeCount);
+        Interlocked.Add(ref state.TotalHiddenEpisodeCount, hiddenEpisodeCount);
+    }
+
+    private bool TryHandleUnchangedSeason(SearchTvSeason reducedSeason, TvShow show, ShowSeasonUpdateState state)
+    {
+        if (!state.ChangedItems.HasValue) return false;
+        if (state.ChangedItems.Value.SeasonNumbers.Contains(reducedSeason.SeasonNumber)) return false;
+        if (!state.ExistingSeasons.TryGetValue(reducedSeason.Id, out var season)) return false;
+        state.SeasonsToSkip.Add(season.Id);
+        var localEpisodes = state.ExistingEpisodes.Values.Where(e => e.TmdbSeasonID == season.Id).ToList();
+        foreach (var ep in localEpisodes)
+            state.EpisodesToSkip.Add(ep.Id);
+        var visibleCount = localEpisodes.Count(e => !e.IsHidden);
+        Interlocked.Add(ref state.TotalEpisodeCount, visibleCount);
+        Interlocked.Add(ref state.TotalHiddenEpisodeCount, localEpisodes.Count - visibleCount);
+        if (state.DownloadCrewAndCast)
+        {
+            foreach (var cast in _tmdbEpisodeCast.GetByTmdbSeasonID(season.Id))
+                state.AllPeopleToAddOrKeep.TryAdd(cast.TmdbPersonID, 0);
+            foreach (var crew in _tmdbEpisodeCrew.GetByTmdbSeasonID(season.Id))
+                state.AllPeopleToAddOrKeep.TryAdd(crew.TmdbPersonID, 0);
+        }
+        _logger.LogDebug("Skipping unchanged season {SeasonNumber} for show {ShowTitle} (Show={ShowId}).", reducedSeason.SeasonNumber, show.Name, show.Id);
+        return true;
+    }
+
+    private static bool MarkSeasonForSave(TMDB_Season tmdbSeason, bool newlyAdded, bool seasonUpdated, ShowSeasonUpdateState state)
+    {
+        if (!((newlyAdded && state.ShouldFireEvents) || seasonUpdated)) return false;
+        state.SeasonEventsToEmit.TryAdd(tmdbSeason, newlyAdded ? UpdateReason.Added : UpdateReason.Updated);
+        if (state.ShouldFireEvents)
+            tmdbSeason.LastUpdatedAt = DateTime.Now;
+        state.SeasonsToSave.Add(tmdbSeason);
+        return true;
+    }
+
+    private async Task ProcessShowEpisodeAsync(
+        TvShow show,
+        TvSeason season,
+        TvSeasonEpisode reducedEpisode,
+        ShowSeasonUpdateState state,
+        List<TMDB_Episode> episodeBag,
+        List<TMDB_Episode> hiddenEpisodeBag)
+    {
+        _logger.LogDebug("Checking episode {EpisodeNumber} in season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedEpisode.EpisodeNumber, season.SeasonNumber, show.Name, show.Id);
+        if (!state.ExistingEpisodes.TryGetValue(reducedEpisode.Id, out var tmdbEpisode))
+        {
+            Interlocked.Increment(ref state.EpisodesToAdd);
+            tmdbEpisode = new(reducedEpisode.Id);
+        }
+        var newlyAddedEpisode = tmdbEpisode.CreatedAt == tmdbEpisode.LastUpdatedAt;
+
+        if (TrySkipUnchangedEpisode(tmdbEpisode, season, reducedEpisode, newlyAddedEpisode, state, episodeBag, hiddenEpisodeBag))
+            return;
+
+        bool episodeUpdated;
+        if (state.QuickRefresh)
+        {
+            var baseUpdated = tmdbEpisode.Populate(show, season, reducedEpisode, null);
+            episodeUpdated = UpdateTitlesAndOverviews(tmdbEpisode, null, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || baseUpdated;
+        }
+        else
+        {
+            episodeUpdated = await FullFetchAndUpdateEpisodeAsync(tmdbEpisode, show, season, reducedEpisode, state);
+        }
+
+        if ((newlyAddedEpisode && state.ShouldFireEvents) || episodeUpdated)
+        {
+            state.EpisodeEventsToEmit.TryAdd(tmdbEpisode, newlyAddedEpisode ? UpdateReason.Added : UpdateReason.Updated);
+            if (state.ShouldFireEvents)
+                tmdbEpisode.LastUpdatedAt = DateTime.Now;
+            state.EpisodesToSave.Add(tmdbEpisode);
+        }
+
+        state.EpisodesToSkip.Add(tmdbEpisode.Id);
+        (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
+    }
+
+    private async Task<bool> FullFetchAndUpdateEpisodeAsync(TMDB_Episode tmdbEpisode, TvShow show, TvSeason season, TvSeasonEpisode reducedEpisode, ShowSeasonUpdateState state)
+    {
+        var episodeMethods = TvEpisodeMethods.ExternalIds | TvEpisodeMethods.Translations;
+        if (state.DownloadCrewAndCast)
+            episodeMethods |= TvEpisodeMethods.Credits;
+        var episode = await UseClient(c => c.GetTvEpisodeAsync(show.Id, season.SeasonNumber, reducedEpisode.EpisodeNumber, episodeMethods), $"Get episode {reducedEpisode.EpisodeNumber} in season {season.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false);
+        var updated = tmdbEpisode.Populate(show, season, reducedEpisode, episode!.Translations);
+        updated = UpdateTitlesAndOverviews(tmdbEpisode, episode.Translations, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || updated;
+        updated = UpdateEpisodeExternalIDs(tmdbEpisode, episode.ExternalIds!) || updated;
+        if (state.DownloadCrewAndCast)
+            updated |= UpdateEpisodeCastCrewAndCollectPeople(tmdbEpisode, episode.Credits!, state);
+        return updated;
+    }
+
+    private bool TrySkipUnchangedEpisode(
+        TMDB_Episode tmdbEpisode,
+        TvSeason season,
+        TvSeasonEpisode reducedEpisode,
+        bool newlyAddedEpisode,
+        ShowSeasonUpdateState state,
+        List<TMDB_Episode> episodeBag,
+        List<TMDB_Episode> hiddenEpisodeBag)
+    {
+        if (!state.ChangedItems.HasValue || newlyAddedEpisode) return false;
+        if (state.ChangedItems.Value.Episodes.Contains((season.SeasonNumber, (int)reducedEpisode.EpisodeNumber))) return false;
+        state.EpisodesToSkip.Add(tmdbEpisode.Id);
+        (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
+        if (state.DownloadCrewAndCast)
+        {
+            foreach (var cast in _tmdbEpisodeCast.GetByTmdbEpisodeID(tmdbEpisode.Id))
+                state.AllPeopleToAddOrKeep.TryAdd(cast.TmdbPersonID, 0);
+            foreach (var crew in _tmdbEpisodeCrew.GetByTmdbEpisodeID(tmdbEpisode.Id))
+                state.AllPeopleToAddOrKeep.TryAdd(crew.TmdbPersonID, 0);
+        }
+        return true;
+    }
+
+    private bool UpdateEpisodeCastCrewAndCollectPeople(TMDB_Episode tmdbEpisode, CreditsWithGuestStars credits, ShowSeasonUpdateState state)
+    {
+        var (castOrCrewUpdated, peopleToAddOrKeep, peopleToPotentiallyRemove) = UpdateEpisodeCastAndCrew(tmdbEpisode, credits);
+        foreach (var personId in peopleToAddOrKeep)
+            state.AllPeopleToAddOrKeep.TryAdd(personId, 0);
+        foreach (var personId in peopleToPotentiallyRemove)
+            state.AllPeopleToPotentiallyRemove.TryAdd(personId, 0);
+        return castOrCrewUpdated;
     }
 
     private async Task<bool> UpdateShowAlternateOrdering(TMDB_Show tmdbShow, TvShow show)
@@ -2823,10 +2915,11 @@ public class TmdbMetadataService : ITmdbMetadataService
     {
         // The TMDB Changes API covers at most the last 14 days. Treat anything older as changed
         // so the caller always falls through to a full refresh when history is unavailable.
-        if (since < DateTime.Now.AddDays(-14))
+        var sinceUtc = since.ToUniversalTime();
+        if (sinceUtc < DateTime.UtcNow.AddDays(-TmdbChangesWindowDays))
             return true;
-        var changes = await UseClient(c => c.GetMovieChangesAsync(movieId, 0, since, null), $"Get changes for movie {movieId}").ConfigureAwait(false);
-        return changes is { Count: > 0 };
+        var changes = await UseClient(c => c.GetMovieChangesAsync(movieId, 0, sinceUtc, null), $"Get changes for movie {movieId}").ConfigureAwait(false);
+        return changes is null || changes.Count > 0;
     }
 
     /// <summary>
@@ -2843,9 +2936,10 @@ public class TmdbMetadataService : ITmdbMetadataService
     {
         // The TMDB Changes API covers at most the last 14 days. Return null to signal the caller
         // to perform a full refresh rather than a selective one.
-        if (since < DateTime.Now.AddDays(-14))
+        var sinceUtc = since.ToUniversalTime();
+        if (sinceUtc < DateTime.UtcNow.AddDays(-TmdbChangesWindowDays))
             return null;
-        var changes = await UseClient(c => c.GetTvShowChangesAsync(showId, 0, since, null), $"Get changes for show {showId}").ConfigureAwait(false);
+        var changes = await UseClient(c => c.GetTvShowChangesAsync(showId, 0, sinceUtc, null), $"Get changes for show {showId}").ConfigureAwait(false);
         if (changes is null)
             return null;
         return ParseShowChanges(changes);
@@ -2871,38 +2965,40 @@ public class TmdbMetadataService : ITmdbMetadataService
             if (change.Key is not ("episode" or "season"))
                 continue;
             foreach (var item in change.Items ?? [])
-            {
-                // Each change item type stores its payload differently; normalise to a JObject.
-                var value = item switch
-                {
-                    ChangeItemAdded added => added.Value as JObject,
-                    ChangeItemUpdated updated => updated.Value as JObject,
-                    ChangeItemDestroyed destroyed => destroyed.Value as JObject,
-                    ChangeItemDeleted deleted => deleted.OriginalValue as JObject, // deleted items carry the previous value
-                    _ => null,
-                };
-                if (value is null)
-                    continue;
-
-                var seasonNumber = value["season_number"]?.Value<int>();
-                if (!seasonNumber.HasValue)
-                    continue;
-
-                seasonNumbers.Add(seasonNumber.Value);
-
-                // For episode changes, also record the specific (season, episode) pair so the
-                // fast-path can skip episodes within the season that were not individually changed.
-                if (change.Key == "episode")
-                {
-                    var episodeNumber = value["episode_number"]?.Value<int>();
-                    if (episodeNumber.HasValue)
-                        episodes.Add((seasonNumber.Value, episodeNumber.Value));
-                }
-            }
+                ApplyChangeItem(change.Key, item, seasonNumbers, episodes);
         }
         return (seasonNumbers, episodes);
     }
 
+    private static void ApplyChangeItem(string key, ChangeItemBase item, HashSet<int> seasonNumbers, HashSet<(int Season, int Episode)> episodes)
+    {
+        // Each change item type stores its payload differently; normalise to a JObject.
+        var value = item switch
+        {
+            ChangeItemAdded added => added.Value as JObject,
+            ChangeItemUpdated updated => updated.Value as JObject,
+            ChangeItemDestroyed destroyed => destroyed.Value as JObject,
+            ChangeItemDeleted deleted => deleted.OriginalValue as JObject, // deleted items carry the previous value
+            _ => null,
+        };
+        if (value is null)
+            return;
+
+        var seasonNumber = value["season_number"]?.Value<int>();
+        if (!seasonNumber.HasValue)
+            return;
+
+        seasonNumbers.Add(seasonNumber.Value);
+
+        // For episode changes, also record the specific (season, episode) pair so the
+        // fast-path can skip episodes within the season that were not individually changed.
+        if (key != "episode")
+            return;
+
+        var episodeNumber = value["episode_number"]?.Value<int>();
+        if (episodeNumber.HasValue)
+            episodes.Add((seasonNumber.Value, episodeNumber.Value));
+    }
 
     #endregion
 }

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -55,8 +55,6 @@ public class TmdbMetadataService : ITmdbMetadataService
 {
     private static readonly int _maxConcurrency = Math.Min(6, Environment.ProcessorCount);
 
-    private const int TmdbChangesWindowDays = 14;
-
     private static TmdbMetadataService? _instance = null;
 
     private static readonly object _instanceLockObj = new();
@@ -2976,10 +2974,14 @@ public class TmdbMetadataService : ITmdbMetadataService
     /// </summary>
     private async Task<bool> HasMovieChangedSinceAsync(int movieId, DateTime since)
     {
+        var changesWindowDays = _settingsProvider.GetSettings().TMDB.IncrementalChangesWindowDays;
+        if (changesWindowDays is 0)
+            return true;
+
         // The TMDB Changes API covers at most the last 14 days. Treat anything older as changed
         // so the caller always falls through to a full refresh when history is unavailable.
         var sinceUtc = since.ToUniversalTime();
-        if (sinceUtc < DateTime.UtcNow.AddDays(-TmdbChangesWindowDays))
+        if (sinceUtc < DateTime.UtcNow.AddDays(-changesWindowDays))
             return true;
         var changes = await UseClient(c => c.GetMovieChangesAsync(movieId, 0, sinceUtc, null), $"Get changes for movie {movieId}").ConfigureAwait(false);
         return changes is null || changes.Count > 0;
@@ -3031,10 +3033,14 @@ public class TmdbMetadataService : ITmdbMetadataService
     /// </returns>
     private async Task<TmdbShowChangedItems?> GetShowChangedItemsAsync(int showId, DateTime since)
     {
+        var changesWindowDays = _settingsProvider.GetSettings().TMDB.IncrementalChangesWindowDays;
+        if (changesWindowDays is 0)
+            return null;
+
         // The TMDB Changes API covers at most the last 14 days. Return null to signal the caller
         // to perform a full refresh rather than a selective one.
         var sinceUtc = since.ToUniversalTime();
-        if (sinceUtc < DateTime.UtcNow.AddDays(-TmdbChangesWindowDays))
+        if (sinceUtc < DateTime.UtcNow.AddDays(-changesWindowDays))
             return null;
         var changes = await UseClient(c => c.GetTvShowChangesAsync(showId, 0, sinceUtc, null), $"Get changes for show {showId}").ConfigureAwait(false);
         if (changes is null)

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -1472,7 +1472,7 @@ public class TmdbMetadataService : ITmdbMetadataService
         ShowSyncState state)
     {
         var newlyAdded = tmdbEpisode.CreatedAt == tmdbEpisode.LastUpdatedAt;
-        if (!state.ChangedItems.HasValue || newlyAdded || !state.ChangedItems.Value.Episodes.Contains((season.SeasonNumber, (int)reducedEpisode.EpisodeNumber)))
+        if (!state.ChangedItems.HasValue || newlyAdded || state.ChangedItems.Value.Episodes.Contains((season.SeasonNumber, (int)reducedEpisode.EpisodeNumber)))
             return false;
 
         state.EpisodesToSkip.Add(tmdbEpisode.Id);

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -200,8 +200,9 @@ public class TmdbMetadataService : ITmdbMetadataService
 
     private readonly TmdbRateLimiter _rateLimiter;
 
-    // This policy, together with the above policy, will ensure the rate limits are enforced, while also ensuring we
-    // throw if an exception that's not rate-limit related is thrown.
+    // Retries only on RequestLimitExceededException (cap: 10) and HttpRequestException timeouts (cap: 3).
+    // GeneralHttpException and all other types re-throw immediately in OnTmdbRetryAsync.
+    // Zero delay is intentional — actual rate-limit pausing happens inside TmdbRateLimiter.EnsureRateAsync.
     private readonly AsyncRetryPolicy _retryPolicy;
 
     private readonly KeyedEntityLockHelper _entityLock;
@@ -243,6 +244,12 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
         return Task.CompletedTask;
     }
+
+    // Network exhaustion and rate-limit exhaustion are transient — the person exists on TMDB but
+    // couldn't be fetched this run. NotFoundException (404), bad API key, and unexpected HTTP
+    // status codes are excluded so the caller's cleanup path still fires for genuine orphans.
+    internal static bool IsTmdbTransient(Exception ex) =>
+        ex is HttpRequestException or RequestLimitExceededException;
 
     /// <typeparam name="T">The type of the result of the function.</typeparam>
     /// <param name="func">The function to execute with the TMDb client.</param>
@@ -681,15 +688,24 @@ public class TmdbMetadataService : ITmdbMetadataService
             .Concat(existingCrewDict.Values.Select(crew => crew.TmdbPersonID))
             .Except(peopleToKeep)
             .ToHashSet();
+        var transientlyFailedMoviePeople = new ConcurrentBag<int>();
         try
         {
             await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToKeep, async personId =>
             {
-                var (added, updated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentMovieId: tmdbMovie.Id);
-                if (added)
-                    Interlocked.Increment(ref peopleAdded);
-                if (updated)
-                    Interlocked.Increment(ref peopleUpdated);
+                try
+                {
+                    var (added, updated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentMovieId: tmdbMovie.Id);
+                    if (added)
+                        Interlocked.Increment(ref peopleAdded);
+                    else if (updated)
+                        Interlocked.Increment(ref peopleUpdated);
+                }
+                catch (Exception ex) when (IsTmdbTransient(ex))
+                {
+                    // Transient failure — preserve cast/crew rows and retry later.
+                    transientlyFailedMoviePeople.Add(personId);
+                }
             });
         }
         catch (Exception ex)
@@ -697,28 +713,12 @@ public class TmdbMetadataService : ITmdbMetadataService
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
             // Cast/crew rows were already written above. Any person ID whose fetch failed leaves a
             // dangling reference — the API cannot resolve cast without a matching TMDB_Person row and
-            // will return HTTP 500.
-            var missingPersonIds = peopleToKeep
-                .Where(id => _tmdbPeople.GetByTmdbPersonID(id) is null)
-                .ToHashSet();
-            if (missingPersonIds.Count > 0)
-            {
-                var orphanedCast = _tmdbMovieCast.GetByTmdbMovieID(tmdbMovie.Id)
-                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
-                    .ToList();
-                var orphanedCrew = _tmdbMovieCrew.GetByTmdbMovieID(tmdbMovie.Id)
-                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
-                    .ToList();
-                if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
-                {
-                    _logger.LogWarning(
-                        "TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Movie={MovieId})",
-                        orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, tmdbMovie.Id);
-                    _tmdbMovieCast.Delete(orphanedCast);
-                    _tmdbMovieCrew.Delete(orphanedCrew);
-                }
-            }
+            // will return HTTP 500. Exclude transient failures: their rows are intentionally preserved
+            // and the retry job will fill in the TMDB_Person row.
+            CleanupOrphanedMovieCastCrew(tmdbMovie, peopleToKeep, transientlyFailedMoviePeople.ToHashSet());
         }
+        foreach (var personId in transientlyFailedMoviePeople)
+            await _scheduler.Enqueue<UpdateTmdbPersonJob>(j => { j.TmdbPersonID = personId; j.DownloadImages = downloadImages; });
         try
         {
             await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToPurge, async personId =>
@@ -1327,24 +1327,35 @@ public class TmdbMetadataService : ITmdbMetadataService
         var added = 0;
         var updated = 0;
         var purged = 0;
-        var peopleToCheck = state.AllPeopleToAddOrKeep.Keys.ToList();
+        var peopleToCheck = state.AllPeopleToAddOrKeep.Keys.ToHashSet();
         var peopleToPurge = state.AllPeopleToPotentiallyRemove.Keys.Except(peopleToCheck).ToList();
+        var transientlyFailedShowPeople = new ConcurrentBag<int>();
         try
         {
             await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToCheck, async personId =>
             {
-                var (personAdded, personUpdated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentShowId: show.Id);
-                if (personAdded)
-                    Interlocked.Increment(ref added);
-                if (personUpdated)
-                    Interlocked.Increment(ref updated);
+                try
+                {
+                    var (personAdded, personUpdated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentShowId: show.Id);
+                    if (personAdded)
+                        Interlocked.Increment(ref added);
+                    else if (personUpdated)
+                        Interlocked.Increment(ref updated);
+                }
+                catch (Exception ex) when (IsTmdbTransient(ex))
+                {
+                    // Transient failure — preserve cast/crew rows and retry later.
+                    transientlyFailedShowPeople.Add(personId);
+                }
             });
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during show cast/crew update (Show={ShowId})", show.Id);
-            CleanupOrphanedShowCastCrew(show, peopleToCheck);
+            CleanupOrphanedShowCastCrew(show, peopleToCheck, transientlyFailedShowPeople.ToHashSet());
         }
+        foreach (var personId in transientlyFailedShowPeople)
+            await _scheduler.Enqueue<UpdateTmdbPersonJob>(j => { j.TmdbPersonID = personId; j.DownloadImages = downloadImages; });
         try
         {
             await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToPurge, async personId =>
@@ -1360,13 +1371,43 @@ public class TmdbMetadataService : ITmdbMetadataService
         return (added, updated, purged, peopleToPurge.Count + peopleToCheck.Count - added - updated - purged);
     }
 
-    private void CleanupOrphanedShowCastCrew(TvShow show, List<int> peopleToCheck)
+    private void CleanupOrphanedMovieCastCrew(TMDB_Movie movie, HashSet<int> peopleToKeep, HashSet<int> transientlyFailed)
     {
         // Cast/crew rows referencing a person with no TMDB_Person row cause HTTP 500s when the
         // API resolves cast; remove entries for any person IDs absent from the database after the fan-out.
-        var missingPersonIds = peopleToCheck
-            .Where(id => _tmdbPeople.GetByTmdbPersonID(id) is null)
-            .ToHashSet();
+        // Exclude transient failures: their rows are intentionally preserved and the retry job will
+        // fill in the TMDB_Person row.
+        var candidates = peopleToKeep.Except(transientlyFailed).ToHashSet();
+        var existingIds = _tmdbPeople.GetExistingTmdbPersonIDs(candidates);
+        var missingPersonIds = candidates.Except(existingIds).ToHashSet();
+        if (missingPersonIds.Count > 0)
+        {
+            var orphanedCast = _tmdbMovieCast.GetByTmdbMovieID(movie.Id)
+                .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                .ToList();
+            var orphanedCrew = _tmdbMovieCrew.GetByTmdbMovieID(movie.Id)
+                .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
+                .ToList();
+            if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
+            {
+                _logger.LogWarning(
+                    "TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Movie={MovieId})",
+                    orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, movie.Id);
+                _tmdbMovieCast.Delete(orphanedCast);
+                _tmdbMovieCrew.Delete(orphanedCrew);
+            }
+        }
+    }
+
+    private void CleanupOrphanedShowCastCrew(TvShow show, IReadOnlyCollection<int> peopleToCheck, HashSet<int> transientlyFailed)
+    {
+        // Cast/crew rows referencing a person with no TMDB_Person row cause HTTP 500s when the
+        // API resolves cast; remove entries for any person IDs absent from the database after the fan-out.
+        // Exclude transient failures: their rows are intentionally preserved and the retry job will
+        // fill in the TMDB_Person row.
+        var candidates = peopleToCheck.Except(transientlyFailed).ToHashSet();
+        var existingIds = _tmdbPeople.GetExistingTmdbPersonIDs(candidates);
+        var missingPersonIds = candidates.Except(existingIds).ToHashSet();
         if (missingPersonIds.Count > 0)
         {
             var orphanedCast = _tmdbEpisodeCast.GetByTmdbShowID(show.Id)
@@ -1443,9 +1484,12 @@ public class TmdbMetadataService : ITmdbMetadataService
         if (!state.ExistingSeasons.TryGetValue(reducedSeason.Id, out var season)) return false;
         state.SeasonsToSkip.Add(season.Id);
         var localEpisodes = state.ExistingEpisodes.Values.Where(e => e.TmdbSeasonID == season.Id).ToList();
+        var visibleCount = 0;
         foreach (var ep in localEpisodes)
+        {
             state.EpisodesToSkip.Add(ep.Id);
-        var visibleCount = localEpisodes.Count(e => !e.IsHidden);
+            if (!ep.IsHidden) visibleCount++;
+        }
         Interlocked.Add(ref state.TotalEpisodeCount, visibleCount);
         Interlocked.Add(ref state.TotalHiddenEpisodeCount, localEpisodes.Count - visibleCount);
         if (state.DownloadCrewAndCast)
@@ -1517,7 +1561,9 @@ public class TmdbMetadataService : ITmdbMetadataService
         if (state.DownloadCrewAndCast)
             episodeMethods |= TvEpisodeMethods.Credits;
         var episode = await UseClient(c => c.GetTvEpisodeAsync(show.Id, season.SeasonNumber, reducedEpisode.EpisodeNumber, episodeMethods), $"Get episode {reducedEpisode.EpisodeNumber} in season {season.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false);
-        var updated = tmdbEpisode.Populate(show, season, reducedEpisode, episode!.Translations);
+        if (episode is null)
+            return false;
+        var updated = tmdbEpisode.Populate(show, season, reducedEpisode, episode.Translations);
         updated = UpdateTitlesAndOverviews(tmdbEpisode, episode.Translations, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || updated;
         updated = UpdateEpisodeExternalIDs(tmdbEpisode, episode.ExternalIds!) || updated;
         if (state.DownloadCrewAndCast)
@@ -2607,10 +2653,22 @@ public class TmdbMetadataService : ITmdbMetadataService
             if (downloadImages)
                 methods |= PersonMethods.Images;
             var newlyAdded = tmdbPerson.TMDB_PersonID is 0;
-            var person = await UseClient(c => c.GetPersonAsync(personId, methods), $"Get person {personId}");
+            Person? person;
+            try
+            {
+                person = await UseClient(c => c.GetPersonAsync(personId, methods), $"Get person {personId}");
+            }
+            catch (NotFoundException ex)
+            {
+                // 404 — person was deleted or merged on TMDB.
+                _logger.LogWarning(ex, "Staff member not found on TMDB (HTTP 404). Purging local records. (Person={PersonId})", personId);
+                await PurgePersonInternal(personId, currentShowId: currentShowId, currentMovieId: currentMovieId);
+                return (false, !newlyAdded);
+            }
+            // Defensive: TMDbLib returned null without throwing — treat the same as a 404.
             if (person is null)
             {
-                _logger.LogWarning("Failed to find staff member at remote. Purging local records and scheduling shows/movies to-be forcefully updated. (Person={PersonId})", personId);
+                _logger.LogWarning("Staff member returned null from TMDB API. Purging local records. (Person={PersonId})", personId);
                 await PurgePersonInternal(personId, currentShowId: currentShowId, currentMovieId: currentMovieId);
                 return (false, !newlyAdded);
             }
@@ -2752,6 +2810,12 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
     }
 
+    /// <summary>
+    /// Returns the set of all person IDs currently referenced by at least one cast or crew record
+    /// across movies and episodes. Used as the single source of truth when deciding which
+    /// <see cref="TMDB_Person"/> records are safe to purge, avoiding the old pattern of issuing
+    /// up to 4 DB queries per person to check linkage.
+    /// </summary>
     private HashSet<int> GetLinkedPersonIds()
     {
         var ids = new HashSet<int>();
@@ -2798,11 +2862,13 @@ public class TmdbMetadataService : ITmdbMetadataService
         if (maxConcurrent < 1)
             throw new ArgumentOutOfRangeException(nameof(maxConcurrent), "Concurrency level must be at least 1.");
 
-        // Workers catch individually so the block never faults — all items complete before exceptions surface.
         var exceptions = new ConcurrentBag<Exception>();
+        using var cts = new CancellationTokenSource();
+        var failureCount = 0;
         var block = new ActionBlock<T>(
             async item =>
             {
+                if (cts.IsCancellationRequested) return;
                 try { await processAsync(item); }
                 catch (Exception ex)
                 {

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -502,10 +502,23 @@ public class TmdbMetadataService : ITmdbMetadataService
                 return false;
             }
 
-            if (!forceRefresh && !newlyAdded && !await HasMovieChangedSinceAsync(movieId, tmdbMovie.LastUpdatedAt).ConfigureAwait(false))
+            if (!forceRefresh && !newlyAdded)
             {
-                _logger.LogInformation("Skipping update of movie {MovieID} as no changes were detected on TMDB since {LastUpdatedAt}.", movieId, tmdbMovie.LastUpdatedAt);
-                return false;
+                bool hasChanged;
+                try
+                {
+                    hasChanged = await HasMovieChangedSinceAsync(movieId, tmdbMovie.LastUpdatedAt).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (IsTmdbTransient(ex))
+                {
+                    _logger.LogWarning(ex, "TMDB: Transient error checking changes for movie {MovieId}; proceeding with full refresh.", movieId);
+                    hasChanged = true;
+                }
+                if (!hasChanged)
+                {
+                    _logger.LogInformation("Skipping update of movie {MovieID} as no changes were detected on TMDB since {LastUpdatedAt}.", movieId, tmdbMovie.LastUpdatedAt);
+                    return false;
+                }
             }
 
             // Abort if we couldn't find the movie by id.
@@ -706,19 +719,38 @@ public class TmdbMetadataService : ITmdbMetadataService
                     // Transient failure — preserve cast/crew rows and retry later.
                     transientlyFailedMoviePeople.Add(personId);
                 }
-            });
+            }, onDropped: transientlyFailedMoviePeople.Add);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
-            // Cast/crew rows were already written above. Any person ID whose fetch failed leaves a
-            // dangling reference — the API cannot resolve cast without a matching TMDB_Person row and
-            // will return HTTP 500. Exclude transient failures: their rows are intentionally preserved
-            // and the retry job will fill in the TMDB_Person row.
-            CleanupOrphanedMovieCastCrew(tmdbMovie, peopleToKeep, transientlyFailedMoviePeople.ToHashSet());
         }
-        foreach (var personId in transientlyFailedMoviePeople)
-            await _scheduler.Enqueue<UpdateTmdbPersonJob>(j => { j.TmdbPersonID = personId; j.DownloadImages = downloadImages; });
+        // Schedule retries for transiently-failed people first; their cast/crew rows are preserved.
+        // Then clean up rows for people that permanently failed — the excluded set ensures
+        // transient failures are skipped in CleanupOrphanedCastCrew.
+        var transientlyFailedMovieSet = transientlyFailedMoviePeople.ToHashSet();
+        try
+        {
+            await Task.WhenAll(transientlyFailedMovieSet.Select(personId =>
+                _scheduler.Enqueue<UpdateTmdbPersonJob>(j => { j.TmdbPersonID = personId; j.DownloadImages = downloadImages; j.TmdbMovieID = tmdbMovie.Id; })));
+        }
+        finally
+        {
+            CleanupOrphanedCastCrew(peopleToKeep, transientlyFailedMovieSet, missingPersonIds =>
+            {
+                var orphanedCast = _tmdbMovieCast.GetByTmdbMovieID(tmdbMovie.Id)
+                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID)).ToList();
+                var orphanedCrew = _tmdbMovieCrew.GetByTmdbMovieID(tmdbMovie.Id)
+                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID)).ToList();
+                if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
+                {
+                    _logger.LogWarning("TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Movie={MovieId})",
+                        orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, tmdbMovie.Id);
+                    _tmdbMovieCast.Delete(orphanedCast);
+                    _tmdbMovieCrew.Delete(orphanedCrew);
+                }
+            });
+        }
         try
         {
             await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToPurge, async personId =>
@@ -1129,8 +1161,18 @@ public class TmdbMetadataService : ITmdbMetadataService
             // Null result (14-day window exceeded or API failure) triggers a full refresh in UpdateShowSeasonsAndEpisodes.
             // Not applied on forced refreshes or newly-added shows — those always do a full fetch.
             (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? changedItems = null;
-            if (!newlyAdded && !forceRefresh)
-                changedItems = await GetShowChangedItemsAsync(showId, tmdbShow.LastUpdatedAt).ConfigureAwait(false);
+            if (!newlyAdded && !forceRefresh && !quickRefresh)
+            {
+                try
+                {
+                    changedItems = await GetShowChangedItemsAsync(showId, tmdbShow.LastUpdatedAt).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (IsTmdbTransient(ex))
+                {
+                    _logger.LogWarning(ex, "TMDB: Transient error checking changes for show {ShowId}; proceeding with full refresh.", showId);
+                    changedItems = null;
+                }
+            }
 
             var preferredTitleLanguages = settings.TMDB.DownloadAllTitles ? null : Languages.PreferredNamingLanguages.Select(a => a.Language).ToHashSet();
             var preferredOverviewLanguages = settings.TMDB.DownloadAllOverviews ? null : Languages.PreferredDescriptionNamingLanguages.Select(a => a.Language).ToHashSet();
@@ -1205,45 +1247,27 @@ public class TmdbMetadataService : ITmdbMetadataService
 
     private sealed class ShowSeasonUpdateState
     {
-        public readonly bool DownloadCrewAndCast;
-        public readonly bool QuickRefresh;
-        public readonly bool ShouldFireEvents;
-        public readonly (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? ChangedItems;
-        public readonly HashSet<TitleLanguage>? PreferredTitleLanguages;
-        public readonly HashSet<TitleLanguage>? PreferredOverviewLanguages;
+        public required bool DownloadCrewAndCast { get; init; }
+        public required bool QuickRefresh { get; init; }
+        public required bool ShouldFireEvents { get; init; }
+        public required (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? ChangedItems { get; init; }
+        public required HashSet<TitleLanguage>? PreferredTitleLanguages { get; init; }
+        public required HashSet<TitleLanguage>? PreferredOverviewLanguages { get; init; }
         public int SeasonsToAdd;
         public int EpisodesToAdd;
         public int TotalEpisodeCount;
         public int TotalHiddenEpisodeCount;
-        public readonly Dictionary<int, TMDB_Season> ExistingSeasons;
-        public readonly ConcurrentDictionary<int, TMDB_Episode> ExistingEpisodes;
-        public readonly ConcurrentBag<int> SeasonsToSkip = new();
-        public readonly ConcurrentBag<TMDB_Season> SeasonsToSave = new();
-        public readonly ConcurrentDictionary<TMDB_Season, UpdateReason> SeasonEventsToEmit = new();
-        public readonly ConcurrentBag<int> EpisodesToSkip = new();
-        public readonly ConcurrentBag<TMDB_Episode> EpisodesToSave = new();
-        public readonly ConcurrentDictionary<TMDB_Episode, UpdateReason> EpisodeEventsToEmit = new();
-        public readonly ConcurrentDictionary<int, byte> AllPeopleToAddOrKeep = new();
-        public readonly ConcurrentDictionary<int, byte> AllPeopleToPotentiallyRemove = new();
-
-        public ShowSeasonUpdateState(
-            bool downloadCrewAndCast,
-            bool quickRefresh,
-            bool shouldFireEvents,
-            (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? changedItems,
-            (HashSet<TitleLanguage>? Titles, HashSet<TitleLanguage>? Overviews) preferredLanguages,
-            Dictionary<int, TMDB_Season> existingSeasons,
-            ConcurrentDictionary<int, TMDB_Episode> existingEpisodes)
-        {
-            DownloadCrewAndCast = downloadCrewAndCast;
-            QuickRefresh = quickRefresh;
-            ShouldFireEvents = shouldFireEvents;
-            ChangedItems = changedItems;
-            PreferredTitleLanguages = preferredLanguages.Titles;
-            PreferredOverviewLanguages = preferredLanguages.Overviews;
-            ExistingSeasons = existingSeasons;
-            ExistingEpisodes = existingEpisodes;
-        }
+        public required Dictionary<int, TMDB_Season> ExistingSeasons { get; init; }
+        public required Dictionary<int, TMDB_Episode> ExistingEpisodes { get; init; }
+        public required ILookup<int, int> EpisodePeople { get; init; }
+        public readonly HashSet<int> SeasonsToSkip = [];
+        public readonly List<TMDB_Season> SeasonsToSave = [];
+        public readonly Dictionary<TMDB_Season, UpdateReason> SeasonEventsToEmit = [];
+        public readonly HashSet<int> EpisodesToSkip = [];
+        public readonly List<TMDB_Episode> EpisodesToSave = [];
+        public readonly Dictionary<TMDB_Episode, UpdateReason> EpisodeEventsToEmit = [];
+        public readonly HashSet<int> AllPeopleToAddOrKeep = [];
+        public readonly HashSet<int> AllPeopleToPotentiallyRemove = [];
     }
 
     private async Task<(bool episodesOrSeasonsUpdated, Dictionary<TMDB_Season, UpdateReason> updatedSeasons, Dictionary<TMDB_Episode, UpdateReason> updatedEpisodes, int episodeCount, int hiddenEpisodeCount)> UpdateShowSeasonsAndEpisodes(TvShow show, bool downloadCrewAndCast = false, bool forceRefresh = false, bool downloadImages = false, bool quickRefresh = false, bool shouldFireEvents = false, (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? changedItems = null)
@@ -1253,13 +1277,27 @@ public class TmdbMetadataService : ITmdbMetadataService
         var preferredOverviewLanguages = settings.TMDB.DownloadAllOverviews ? null : Languages.PreferredDescriptionNamingLanguages.Select(a => a.Language).ToHashSet();
 
         var existingSeasons = _tmdbSeasons.GetByTmdbShowID(show.Id).ToDictionary(season => season.Id);
-        var existingEpisodes = new ConcurrentDictionary<int, TMDB_Episode>();
-        foreach (var episode in _tmdbEpisodes.GetByTmdbShowID(show.Id))
-            existingEpisodes.TryAdd(episode.Id, episode);
+        var existingEpisodes = _tmdbEpisodes.GetByTmdbShowID(show.Id).ToDictionary(episode => episode.Id);
 
-        var state = new ShowSeasonUpdateState(downloadCrewAndCast, quickRefresh, shouldFireEvents, changedItems, (preferredTitleLanguages, preferredOverviewLanguages), existingSeasons, existingEpisodes);
-        await ProcessWithConcurrencyAsync(_maxConcurrency, show.Seasons!, reducedSeason =>
-            ProcessShowSeasonAsync(show, reducedSeason, state));
+        var episodePeople = downloadCrewAndCast
+            ? _tmdbEpisodeCast.GetByTmdbShowID(show.Id).Select(c => (c.TmdbEpisodeID, c.TmdbPersonID))
+                .Concat(_tmdbEpisodeCrew.GetByTmdbShowID(show.Id).Select(c => (c.TmdbEpisodeID, c.TmdbPersonID)))
+                .ToLookup(x => x.TmdbEpisodeID, x => x.TmdbPersonID)
+            : Enumerable.Empty<(int, int)>().ToLookup(x => x.Item1, x => x.Item2);
+        var state = new ShowSeasonUpdateState
+        {
+            DownloadCrewAndCast = downloadCrewAndCast,
+            QuickRefresh = quickRefresh,
+            ShouldFireEvents = shouldFireEvents,
+            ChangedItems = changedItems,
+            PreferredTitleLanguages = preferredTitleLanguages,
+            PreferredOverviewLanguages = preferredOverviewLanguages,
+            ExistingSeasons = existingSeasons,
+            ExistingEpisodes = existingEpisodes,
+            EpisodePeople = episodePeople,
+        };
+        foreach (var reducedSeason in show.Seasons!)
+            await ProcessShowSeasonAsync(show, reducedSeason, state);
 
         var seasonsToRemove = existingSeasons.Values.ExceptBy(state.SeasonsToSkip, s => s.Id).ToList();
         var episodesToRemove = existingEpisodes.Values.ExceptBy(state.EpisodesToSkip, e => e.Id).ToList();
@@ -1302,9 +1340,9 @@ public class TmdbMetadataService : ITmdbMetadataService
 
         if (quickRefresh)
             return (
-                state.SeasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || !state.EpisodesToSave.IsEmpty || episodesToRemove.Count > 0,
-                state.SeasonEventsToEmit.ToDictionary(),
-                state.EpisodeEventsToEmit.ToDictionary(),
+                state.SeasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || state.EpisodesToSave.Count > 0 || episodesToRemove.Count > 0,
+                state.SeasonEventsToEmit,
+                state.EpisodeEventsToEmit,
                 state.TotalEpisodeCount,
                 state.TotalHiddenEpisodeCount
             );
@@ -1314,9 +1352,9 @@ public class TmdbMetadataService : ITmdbMetadataService
             peopleAdded, peopleUpdated, peoplePurged, peopleSkipped, show.Name, show.Id);
 
         return (
-            state.SeasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || !state.EpisodesToSave.IsEmpty || episodesToRemove.Count > 0 || peopleAdded > 0 || peoplePurged > 0,
-            state.SeasonEventsToEmit.ToDictionary(),
-            state.EpisodeEventsToEmit.ToDictionary(),
+            state.SeasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || state.EpisodesToSave.Count > 0 || episodesToRemove.Count > 0 || peopleAdded > 0 || peoplePurged > 0,
+            state.SeasonEventsToEmit,
+            state.EpisodeEventsToEmit,
             state.TotalEpisodeCount,
             state.TotalHiddenEpisodeCount
         );
@@ -1327,8 +1365,8 @@ public class TmdbMetadataService : ITmdbMetadataService
         var added = 0;
         var updated = 0;
         var purged = 0;
-        var peopleToCheck = state.AllPeopleToAddOrKeep.Keys.ToHashSet();
-        var peopleToPurge = state.AllPeopleToPotentiallyRemove.Keys.Except(peopleToCheck).ToList();
+        var peopleToCheck = state.AllPeopleToAddOrKeep;
+        var peopleToPurge = state.AllPeopleToPotentiallyRemove.Except(peopleToCheck).ToList();
         var transientlyFailedShowPeople = new ConcurrentBag<int>();
         try
         {
@@ -1347,15 +1385,38 @@ public class TmdbMetadataService : ITmdbMetadataService
                     // Transient failure — preserve cast/crew rows and retry later.
                     transientlyFailedShowPeople.Add(personId);
                 }
-            });
+            }, onDropped: transientlyFailedShowPeople.Add);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "TMDB: Failed to update one or more people during show cast/crew update (Show={ShowId})", show.Id);
-            CleanupOrphanedShowCastCrew(show, peopleToCheck, transientlyFailedShowPeople.ToHashSet());
         }
-        foreach (var personId in transientlyFailedShowPeople)
-            await _scheduler.Enqueue<UpdateTmdbPersonJob>(j => { j.TmdbPersonID = personId; j.DownloadImages = downloadImages; });
+        // Schedule retries for transiently-failed people first; their cast/crew rows are preserved.
+        // Then clean up rows for people that permanently failed — the excluded set ensures
+        // transient failures are skipped in CleanupOrphanedCastCrew.
+        var transientlyFailedShowSet = transientlyFailedShowPeople.ToHashSet();
+        try
+        {
+            await Task.WhenAll(transientlyFailedShowSet.Select(personId =>
+                _scheduler.Enqueue<UpdateTmdbPersonJob>(j => { j.TmdbPersonID = personId; j.DownloadImages = downloadImages; j.TmdbShowID = show.Id; })));
+        }
+        finally
+        {
+            CleanupOrphanedCastCrew(peopleToCheck, transientlyFailedShowSet, missingPersonIds =>
+            {
+                var orphanedCast = _tmdbEpisodeCast.GetByTmdbShowID(show.Id)
+                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID)).ToList();
+                var orphanedCrew = _tmdbEpisodeCrew.GetByTmdbShowID(show.Id)
+                    .Where(c => missingPersonIds.Contains(c.TmdbPersonID)).ToList();
+                if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
+                {
+                    _logger.LogWarning("TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Show={ShowId})",
+                        orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, show.Id);
+                    _tmdbEpisodeCast.Delete(orphanedCast);
+                    _tmdbEpisodeCrew.Delete(orphanedCrew);
+                }
+            });
+        }
         try
         {
             await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToPurge, async personId =>
@@ -1371,60 +1432,13 @@ public class TmdbMetadataService : ITmdbMetadataService
         return (added, updated, purged, peopleToPurge.Count + peopleToCheck.Count - added - updated - purged);
     }
 
-    private void CleanupOrphanedMovieCastCrew(TMDB_Movie movie, HashSet<int> peopleToKeep, HashSet<int> transientlyFailed)
+    private void CleanupOrphanedCastCrew(IReadOnlyCollection<int> people, HashSet<int> transientlyFailed, Action<HashSet<int>> deleteOrphansAndLog)
     {
-        // Cast/crew rows referencing a person with no TMDB_Person row cause HTTP 500s when the
-        // API resolves cast; remove entries for any person IDs absent from the database after the fan-out.
-        // Exclude transient failures: their rows are intentionally preserved and the retry job will
-        // fill in the TMDB_Person row.
-        var candidates = peopleToKeep.Except(transientlyFailed).ToHashSet();
+        var candidates = people.Except(transientlyFailed).ToHashSet();
         var existingIds = _tmdbPeople.GetExistingTmdbPersonIDs(candidates);
         var missingPersonIds = candidates.Except(existingIds).ToHashSet();
         if (missingPersonIds.Count > 0)
-        {
-            var orphanedCast = _tmdbMovieCast.GetByTmdbMovieID(movie.Id)
-                .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
-                .ToList();
-            var orphanedCrew = _tmdbMovieCrew.GetByTmdbMovieID(movie.Id)
-                .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
-                .ToList();
-            if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
-            {
-                _logger.LogWarning(
-                    "TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Movie={MovieId})",
-                    orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, movie.Id);
-                _tmdbMovieCast.Delete(orphanedCast);
-                _tmdbMovieCrew.Delete(orphanedCrew);
-            }
-        }
-    }
-
-    private void CleanupOrphanedShowCastCrew(TvShow show, IReadOnlyCollection<int> peopleToCheck, HashSet<int> transientlyFailed)
-    {
-        // Cast/crew rows referencing a person with no TMDB_Person row cause HTTP 500s when the
-        // API resolves cast; remove entries for any person IDs absent from the database after the fan-out.
-        // Exclude transient failures: their rows are intentionally preserved and the retry job will
-        // fill in the TMDB_Person row.
-        var candidates = peopleToCheck.Except(transientlyFailed).ToHashSet();
-        var existingIds = _tmdbPeople.GetExistingTmdbPersonIDs(candidates);
-        var missingPersonIds = candidates.Except(existingIds).ToHashSet();
-        if (missingPersonIds.Count > 0)
-        {
-            var orphanedCast = _tmdbEpisodeCast.GetByTmdbShowID(show.Id)
-                .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
-                .ToList();
-            var orphanedCrew = _tmdbEpisodeCrew.GetByTmdbShowID(show.Id)
-                .Where(c => missingPersonIds.Contains(c.TmdbPersonID))
-                .ToList();
-            if (orphanedCast.Count > 0 || orphanedCrew.Count > 0)
-            {
-                _logger.LogWarning(
-                    "TMDB: Removed {CastCount} cast and {CrewCount} crew entries for {PersonCount} people that failed to fetch. (Show={ShowId})",
-                    orphanedCast.Count, orphanedCrew.Count, missingPersonIds.Count, show.Id);
-                _tmdbEpisodeCast.Delete(orphanedCast);
-                _tmdbEpisodeCrew.Delete(orphanedCrew);
-            }
-        }
+            deleteOrphansAndLog(missingPersonIds);
     }
 
     private async Task ProcessShowSeasonAsync(TvShow show, SearchTvSeason reducedSeason, ShowSeasonUpdateState state)
@@ -1494,10 +1508,9 @@ public class TmdbMetadataService : ITmdbMetadataService
         Interlocked.Add(ref state.TotalHiddenEpisodeCount, localEpisodes.Count - visibleCount);
         if (state.DownloadCrewAndCast)
         {
-            foreach (var cast in _tmdbEpisodeCast.GetByTmdbSeasonID(season.Id))
-                state.AllPeopleToAddOrKeep.TryAdd(cast.TmdbPersonID, 0);
-            foreach (var crew in _tmdbEpisodeCrew.GetByTmdbSeasonID(season.Id))
-                state.AllPeopleToAddOrKeep.TryAdd(crew.TmdbPersonID, 0);
+            foreach (var ep in localEpisodes)
+                foreach (var personId in state.EpisodePeople[ep.Id])
+                    state.AllPeopleToAddOrKeep.Add(personId);
         }
         _logger.LogDebug("Skipping unchanged season {SeasonNumber} for show {ShowTitle} (Show={ShowId}).", reducedSeason.SeasonNumber, show.Name, show.Id);
         return true;
@@ -1571,7 +1584,7 @@ public class TmdbMetadataService : ITmdbMetadataService
         return updated;
     }
 
-    private bool TrySkipUnchangedEpisode(
+    private static bool TrySkipUnchangedEpisode(
         TMDB_Episode tmdbEpisode,
         TvSeason season,
         TvSeasonEpisode reducedEpisode,
@@ -1586,10 +1599,8 @@ public class TmdbMetadataService : ITmdbMetadataService
         (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
         if (state.DownloadCrewAndCast)
         {
-            foreach (var cast in _tmdbEpisodeCast.GetByTmdbEpisodeID(tmdbEpisode.Id))
-                state.AllPeopleToAddOrKeep.TryAdd(cast.TmdbPersonID, 0);
-            foreach (var crew in _tmdbEpisodeCrew.GetByTmdbEpisodeID(tmdbEpisode.Id))
-                state.AllPeopleToAddOrKeep.TryAdd(crew.TmdbPersonID, 0);
+            foreach (var personId in state.EpisodePeople[tmdbEpisode.Id])
+                state.AllPeopleToAddOrKeep.Add(personId);
         }
         return true;
     }
@@ -1598,9 +1609,9 @@ public class TmdbMetadataService : ITmdbMetadataService
     {
         var (castOrCrewUpdated, peopleToAddOrKeep, peopleToPotentiallyRemove) = UpdateEpisodeCastAndCrew(tmdbEpisode, credits);
         foreach (var personId in peopleToAddOrKeep)
-            state.AllPeopleToAddOrKeep.TryAdd(personId, 0);
+            state.AllPeopleToAddOrKeep.Add(personId);
         foreach (var personId in peopleToPotentiallyRemove)
-            state.AllPeopleToPotentiallyRemove.TryAdd(personId, 0);
+            state.AllPeopleToPotentiallyRemove.Add(personId);
         return castOrCrewUpdated;
     }
 
@@ -2856,7 +2867,8 @@ public class TmdbMetadataService : ITmdbMetadataService
     private static async Task ProcessWithConcurrencyAsync<T>(
         int maxConcurrent,
         IEnumerable<T> enumerable,
-        Func<T, Task> processAsync
+        Func<T, Task> processAsync,
+        Action<T>? onDropped = null
     )
     {
         if (maxConcurrent < 1)
@@ -2868,7 +2880,7 @@ public class TmdbMetadataService : ITmdbMetadataService
         var block = new ActionBlock<T>(
             async item =>
             {
-                if (cts.IsCancellationRequested) return;
+                if (cts.IsCancellationRequested) { onDropped?.Invoke(item); return; }
                 try { await processAsync(item); }
                 catch (Exception ex)
                 {
@@ -2971,6 +2983,10 @@ public class TmdbMetadataService : ITmdbMetadataService
 
     private Task<IDisposable> GetLockForEntity(DataEntityType entityType, int id, string metadataKey, string reason)
         => _entityLock.GetLockForEntityAsync(entityType, id, metadataKey, reason);
+
+    #endregion
+
+    #region Changes (Shared)
 
     /// <summary>
     /// Returns <see langword="true"/> if TMDB has recorded any changes for the given movie since

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -702,29 +702,27 @@ public class TmdbMetadataService : ITmdbMetadataService
             .Except(peopleToKeep)
             .ToHashSet();
         var transientlyFailedMoviePeople = new ConcurrentBag<int>();
-        try
+        await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToKeep, async personId =>
         {
-            await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToKeep, async personId =>
+            try
             {
-                try
-                {
-                    var (added, updated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentMovieId: tmdbMovie.Id);
-                    if (added)
-                        Interlocked.Increment(ref peopleAdded);
-                    else if (updated)
-                        Interlocked.Increment(ref peopleUpdated);
-                }
-                catch (Exception ex) when (IsTmdbTransient(ex))
-                {
-                    // Transient failure — preserve cast/crew rows and retry later.
-                    transientlyFailedMoviePeople.Add(personId);
-                }
-            }, onDropped: transientlyFailedMoviePeople.Add);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "TMDB: Failed to update one or more people during movie cast/crew update (Movie={MovieId})", tmdbMovie.Id);
-        }
+                var (added, updated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentMovieId: tmdbMovie.Id);
+                if (added)
+                    Interlocked.Increment(ref peopleAdded);
+                else if (updated)
+                    Interlocked.Increment(ref peopleUpdated);
+            }
+            catch (Exception ex) when (IsTmdbTransient(ex))
+            {
+                // Transient failure — preserve cast/crew rows and retry later.
+                transientlyFailedMoviePeople.Add(personId);
+            }
+            catch (Exception ex)
+            {
+                // Non-transient failure — log and let CleanupOrphanedCastCrew handle it.
+                _logger.LogWarning(ex, "TMDB: Unexpected error updating person {PersonId} for movie {MovieId}", personId, tmdbMovie.Id);
+            }
+        }, onDropped: transientlyFailedMoviePeople.Add);
         // Schedule retries for transiently-failed people; their cast/crew rows are preserved.
         var transientlyFailedMovieSet = transientlyFailedMoviePeople.ToHashSet();
         if (transientlyFailedMovieSet.Count > 0)
@@ -1532,29 +1530,27 @@ public class TmdbMetadataService : ITmdbMetadataService
         var peopleToCheck = allPeopleToAddOrKeep;
         var peopleToPurge = allPeopleToPotentiallyRemove.Except(peopleToCheck).ToList();
         var transientlyFailedShowPeople = new ConcurrentBag<int>();
-        try
+        await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToCheck, async personId =>
         {
-            await ProcessWithConcurrencyAsync(_maxConcurrency, peopleToCheck, async personId =>
+            try
             {
-                try
-                {
-                    var (personAdded, personUpdated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentShowId: show.Id);
-                    if (personAdded)
-                        Interlocked.Increment(ref added);
-                    else if (personUpdated)
-                        Interlocked.Increment(ref updated);
-                }
-                catch (Exception ex) when (IsTmdbTransient(ex))
-                {
-                    // Transient failure — preserve cast/crew rows and retry later.
-                    transientlyFailedShowPeople.Add(personId);
-                }
-            }, onDropped: transientlyFailedShowPeople.Add);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "TMDB: Failed to update one or more people during show cast/crew update (Show={ShowId})", show.Id);
-        }
+                var (personAdded, personUpdated) = await UpdatePerson(personId, forceRefresh, downloadImages, currentShowId: show.Id);
+                if (personAdded)
+                    Interlocked.Increment(ref added);
+                else if (personUpdated)
+                    Interlocked.Increment(ref updated);
+            }
+            catch (Exception ex) when (IsTmdbTransient(ex))
+            {
+                // Transient failure — preserve cast/crew rows and retry later.
+                transientlyFailedShowPeople.Add(personId);
+            }
+            catch (Exception ex)
+            {
+                // Non-transient failure — log and let CleanupOrphanedCastCrew handle it.
+                _logger.LogWarning(ex, "TMDB: Unexpected error updating person {PersonId} for show {ShowId}", personId, show.Id);
+            }
+        }, onDropped: transientlyFailedShowPeople.Add);
         // Schedule retries for transiently-failed people; their cast/crew rows are preserved.
         var transientlyFailedShowSet = transientlyFailedShowPeople.ToHashSet();
         if (transientlyFailedShowSet.Count > 0)
@@ -2875,13 +2871,12 @@ public class TmdbMetadataService : ITmdbMetadataService
                         await cts.CancelAsync();
                 }
             },
-            new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = maxConcurrent, CancellationToken = cts.Token }
+            new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = maxConcurrent }
         );
         foreach (var item in enumerable)
             block.Post(item);
         block.Complete();
-        try { await block.Completion.ConfigureAwait(false); }
-        catch (OperationCanceledException) { /* circuit breaker fired — block aborted cleanly */ }
+        await block.Completion.ConfigureAwait(false);
         if (!exceptions.IsEmpty)
             throw new AggregateException(exceptions);
     }

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -1160,7 +1160,7 @@ public class TmdbMetadataService : ITmdbMetadataService
 
             // Null result (14-day window exceeded or API failure) triggers a full refresh in UpdateShowSeasonsAndEpisodes.
             // Not applied on forced refreshes or newly-added shows — those always do a full fetch.
-            (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? changedItems = null;
+            TmdbShowChangedItems? changedItems = null;
             if (!newlyAdded && !forceRefresh && !quickRefresh)
             {
                 try
@@ -1245,32 +1245,7 @@ public class TmdbMetadataService : ITmdbMetadataService
         }
     }
 
-    private sealed class ShowSeasonUpdateState
-    {
-        public required bool DownloadCrewAndCast { get; init; }
-        public required bool QuickRefresh { get; init; }
-        public required bool ShouldFireEvents { get; init; }
-        public required (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? ChangedItems { get; init; }
-        public required HashSet<TitleLanguage>? PreferredTitleLanguages { get; init; }
-        public required HashSet<TitleLanguage>? PreferredOverviewLanguages { get; init; }
-        public int SeasonsToAdd;
-        public int EpisodesToAdd;
-        public int TotalEpisodeCount;
-        public int TotalHiddenEpisodeCount;
-        public required Dictionary<int, TMDB_Season> ExistingSeasons { get; init; }
-        public required Dictionary<int, TMDB_Episode> ExistingEpisodes { get; init; }
-        public required ILookup<int, int> EpisodePeople { get; init; }
-        public readonly HashSet<int> SeasonsToSkip = [];
-        public readonly List<TMDB_Season> SeasonsToSave = [];
-        public readonly Dictionary<TMDB_Season, UpdateReason> SeasonEventsToEmit = [];
-        public readonly HashSet<int> EpisodesToSkip = [];
-        public readonly List<TMDB_Episode> EpisodesToSave = [];
-        public readonly Dictionary<TMDB_Episode, UpdateReason> EpisodeEventsToEmit = [];
-        public readonly HashSet<int> AllPeopleToAddOrKeep = [];
-        public readonly HashSet<int> AllPeopleToPotentiallyRemove = [];
-    }
-
-    private async Task<(bool episodesOrSeasonsUpdated, Dictionary<TMDB_Season, UpdateReason> updatedSeasons, Dictionary<TMDB_Episode, UpdateReason> updatedEpisodes, int episodeCount, int hiddenEpisodeCount)> UpdateShowSeasonsAndEpisodes(TvShow show, bool downloadCrewAndCast = false, bool forceRefresh = false, bool downloadImages = false, bool quickRefresh = false, bool shouldFireEvents = false, (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)? changedItems = null)
+    private async Task<TmdbSeasonEpisodeUpdateResult> UpdateShowSeasonsAndEpisodes(TvShow show, bool downloadCrewAndCast = false, bool forceRefresh = false, bool downloadImages = false, bool quickRefresh = false, bool shouldFireEvents = false, TmdbShowChangedItems? changedItems = null)
     {
         var settings = _settingsProvider.GetSettings();
         var preferredTitleLanguages = settings.TMDB.DownloadAllTitles ? null : Languages.PreferredEpisodeNamingLanguages.Select(a => a.Language).ToHashSet();
@@ -1283,90 +1258,228 @@ public class TmdbMetadataService : ITmdbMetadataService
             ? _tmdbEpisodeCast.GetByTmdbShowID(show.Id).Select(c => (c.TmdbEpisodeID, c.TmdbPersonID))
                 .Concat(_tmdbEpisodeCrew.GetByTmdbShowID(show.Id).Select(c => (c.TmdbEpisodeID, c.TmdbPersonID)))
                 .ToLookup(x => x.TmdbEpisodeID, x => x.TmdbPersonID)
-            : Enumerable.Empty<(int, int)>().ToLookup(x => x.Item1, x => x.Item2);
-        var state = new ShowSeasonUpdateState
-        {
-            DownloadCrewAndCast = downloadCrewAndCast,
-            QuickRefresh = quickRefresh,
-            ShouldFireEvents = shouldFireEvents,
-            ChangedItems = changedItems,
-            PreferredTitleLanguages = preferredTitleLanguages,
-            PreferredOverviewLanguages = preferredOverviewLanguages,
-            ExistingSeasons = existingSeasons,
-            ExistingEpisodes = existingEpisodes,
-            EpisodePeople = episodePeople,
-        };
-        foreach (var reducedSeason in show.Seasons!)
-            await ProcessShowSeasonAsync(show, reducedSeason, state);
+            : Enumerable.Empty<TMDB_Episode_Cast>().ToLookup(c => c.TmdbEpisodeID, c => c.TmdbPersonID);
 
-        var seasonsToRemove = existingSeasons.Values.ExceptBy(state.SeasonsToSkip, s => s.Id).ToList();
-        var episodesToRemove = existingEpisodes.Values.ExceptBy(state.EpisodesToSkip, e => e.Id).ToList();
+        var seasonsToAdd = 0;
+        var episodesToAdd = 0;
+        var totalEpisodeCount = 0;
+        var totalHiddenEpisodeCount = 0;
+        var seasonsToSkip = new HashSet<int>();
+        var seasonsToSave = new List<TMDB_Season>();
+        var seasonEventsToEmit = new Dictionary<TMDB_Season, UpdateReason>();
+        var episodesToSkip = new HashSet<int>();
+        var episodesToSave = new List<TMDB_Episode>();
+        var episodeEventsToEmit = new Dictionary<TMDB_Episode, UpdateReason>();
+        var allPeopleToAddOrKeep = new HashSet<int>();
+        var allPeopleToPotentiallyRemove = new HashSet<int>();
+
+        foreach (var reducedSeason in show.Seasons!)
+        {
+            _logger.LogDebug("Checking season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedSeason.SeasonNumber, show.Name, show.Id);
+
+            // Skipped seasons still need their episode counts registered so season totals stay accurate.
+            if (changedItems.HasValue && !changedItems.Value.SeasonNumbers.Contains(reducedSeason.SeasonNumber) && existingSeasons.TryGetValue(reducedSeason.Id, out var unchangedSeason))
+            {
+                seasonsToSkip.Add(unchangedSeason.Id);
+                var localEpisodes = _tmdbEpisodes.GetByTmdbSeasonID(unchangedSeason.Id);
+                var visibleCount = 0;
+                foreach (var ep in localEpisodes)
+                {
+                    episodesToSkip.Add(ep.Id);
+                    if (!ep.IsHidden) visibleCount++;
+                }
+                totalEpisodeCount += visibleCount;
+                totalHiddenEpisodeCount += localEpisodes.Count - visibleCount;
+                if (downloadCrewAndCast)
+                    foreach (var ep in localEpisodes)
+                        foreach (var personId in episodePeople[ep.Id])
+                            allPeopleToAddOrKeep.Add(personId);
+                _logger.LogDebug("Skipping unchanged season {SeasonNumber} for show {ShowTitle} (Show={ShowId}).", reducedSeason.SeasonNumber, show.Name, show.Id);
+                continue;
+            }
+
+            var season = await UseClient(c => c.GetTvSeasonAsync(show.Id, reducedSeason.SeasonNumber, TvSeasonMethods.Translations), $"Get season {reducedSeason.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false) ??
+                throw new Exception($"Unable to fetch season {reducedSeason.SeasonNumber} for show \"{show.Name}\".");
+            if (!existingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeason))
+            {
+                seasonsToAdd++;
+                tmdbSeason = new(reducedSeason.Id);
+            }
+            var newlyAddedSeason = tmdbSeason.CreatedAt == tmdbSeason.LastUpdatedAt;
+
+            var seasonUpdated = tmdbSeason.Populate(show, season);
+            seasonUpdated = UpdateTitlesAndOverviews(tmdbSeason, season.Translations, preferredTitleLanguages, preferredOverviewLanguages) || seasonUpdated;
+
+            var seasonAlreadySaved = false;
+            if ((newlyAddedSeason && shouldFireEvents) || seasonUpdated)
+            {
+                seasonEventsToEmit.TryAdd(tmdbSeason, newlyAddedSeason ? UpdateReason.Added : UpdateReason.Updated);
+                if (shouldFireEvents)
+                    tmdbSeason.LastUpdatedAt = DateTime.Now;
+                seasonsToSave.Add(tmdbSeason);
+                seasonAlreadySaved = true;
+            }
+
+            seasonsToSkip.Add(tmdbSeason.Id);
+
+            var episodeBag = new List<TMDB_Episode>();
+            var hiddenEpisodeBag = new List<TMDB_Episode>();
+            foreach (var reducedEpisode in season.Episodes!)
+            {
+                _logger.LogDebug("Checking episode {EpisodeNumber} in season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedEpisode.EpisodeNumber, season.SeasonNumber, show.Name, show.Id);
+                if (!existingEpisodes.TryGetValue(reducedEpisode.Id, out var tmdbEpisode))
+                {
+                    episodesToAdd++;
+                    tmdbEpisode = new(reducedEpisode.Id);
+                }
+                var newlyAddedEpisode = tmdbEpisode.CreatedAt == tmdbEpisode.LastUpdatedAt;
+
+                if (changedItems.HasValue && !newlyAddedEpisode && !changedItems.Value.Episodes.Contains((season.SeasonNumber, (int)reducedEpisode.EpisodeNumber)))
+                {
+                    episodesToSkip.Add(tmdbEpisode.Id);
+                    (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
+                    if (downloadCrewAndCast)
+                        foreach (var personId in episodePeople[tmdbEpisode.Id])
+                            allPeopleToAddOrKeep.Add(personId);
+                    continue;
+                }
+
+                bool episodeUpdated;
+                if (quickRefresh)
+                {
+                    var baseUpdated = tmdbEpisode.Populate(show, season, reducedEpisode, null);
+                    episodeUpdated = UpdateTitlesAndOverviews(tmdbEpisode, null, preferredTitleLanguages, preferredOverviewLanguages) || baseUpdated;
+                }
+                else
+                {
+                    var episodeMethods = TvEpisodeMethods.ExternalIds | TvEpisodeMethods.Translations;
+                    if (downloadCrewAndCast)
+                        episodeMethods |= TvEpisodeMethods.Credits;
+                    var episode = await UseClient(c => c.GetTvEpisodeAsync(show.Id, season.SeasonNumber, reducedEpisode.EpisodeNumber, episodeMethods), $"Get episode {reducedEpisode.EpisodeNumber} in season {season.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false);
+                    if (episode is null)
+                    {
+                        episodeUpdated = false;
+                    }
+                    else
+                    {
+                        episodeUpdated = tmdbEpisode.Populate(show, season, reducedEpisode, episode.Translations);
+                        episodeUpdated = UpdateTitlesAndOverviews(tmdbEpisode, episode.Translations, preferredTitleLanguages, preferredOverviewLanguages) || episodeUpdated;
+                        episodeUpdated = UpdateEpisodeExternalIDs(tmdbEpisode, episode.ExternalIds!) || episodeUpdated;
+                        if (downloadCrewAndCast)
+                        {
+                            var (castOrCrewUpdated, peopleToAddOrKeep, peopleToPotentiallyRemove) = UpdateEpisodeCastAndCrew(tmdbEpisode, episode.Credits!);
+                            episodeUpdated |= castOrCrewUpdated;
+                            foreach (var personId in peopleToAddOrKeep)
+                                allPeopleToAddOrKeep.Add(personId);
+                            foreach (var personId in peopleToPotentiallyRemove)
+                                allPeopleToPotentiallyRemove.Add(personId);
+                        }
+                    }
+                }
+
+                if ((newlyAddedEpisode && shouldFireEvents) || episodeUpdated)
+                {
+                    episodeEventsToEmit.TryAdd(tmdbEpisode, newlyAddedEpisode ? UpdateReason.Added : UpdateReason.Updated);
+                    if (shouldFireEvents)
+                        tmdbEpisode.LastUpdatedAt = DateTime.Now;
+                    episodesToSave.Add(tmdbEpisode);
+                }
+
+                episodesToSkip.Add(tmdbEpisode.Id);
+                (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
+            }
+
+            var episodeCount = episodeBag.Count;
+            var hiddenEpisodeCount = hiddenEpisodeBag.Count;
+            if (tmdbSeason.EpisodeCount != episodeCount)
+            {
+                tmdbSeason.EpisodeCount = episodeCount;
+                seasonUpdated = true;
+            }
+            if (tmdbSeason.HiddenEpisodeCount != hiddenEpisodeCount)
+            {
+                tmdbSeason.HiddenEpisodeCount = hiddenEpisodeCount;
+                seasonUpdated = true;
+            }
+            if (seasonUpdated)
+            {
+                tmdbSeason.LastUpdatedAt = DateTime.Now;
+                if (!seasonAlreadySaved)
+                {
+                    seasonEventsToEmit.TryAdd(tmdbSeason, UpdateReason.Updated);
+                    seasonsToSave.Add(tmdbSeason);
+                }
+            }
+            totalEpisodeCount += episodeCount;
+            totalHiddenEpisodeCount += hiddenEpisodeCount;
+        }
+
+        var seasonsToRemove = existingSeasons.Values.ExceptBy(seasonsToSkip, s => s.Id).ToList();
+        var episodesToRemove = existingEpisodes.Values.ExceptBy(episodesToSkip, e => e.Id).ToList();
 
         _logger.LogDebug(
             "Added/updated/removed/skipped {a}/{u}/{r}/{s} seasons for show {ShowTitle} (Show={ShowId})",
-            state.SeasonsToAdd,
-            state.SeasonsToSave.Count - state.SeasonsToAdd,
+            seasonsToAdd,
+            seasonsToSave.Count - seasonsToAdd,
             seasonsToRemove.Count,
-            existingSeasons.Count + state.SeasonsToAdd - seasonsToRemove.Count - state.SeasonsToSave.Count,
+            existingSeasons.Count + seasonsToAdd - seasonsToRemove.Count - seasonsToSave.Count,
             show.Name,
             show.Id);
-        _tmdbSeasons.Save(state.SeasonsToSave);
+        _tmdbSeasons.Save(seasonsToSave);
 
         foreach (var season in seasonsToRemove)
         {
             PurgeShowSeason(season);
-            state.SeasonEventsToEmit.TryAdd(season, UpdateReason.Removed);
+            seasonEventsToEmit.TryAdd(season, UpdateReason.Removed);
         }
 
         _tmdbSeasons.Delete(seasonsToRemove);
 
         _logger.LogDebug(
             "Added/updated/removed/skipped {a}/{u}/{r}/{s} episodes for show {ShowTitle} (Show={ShowId})",
-            state.EpisodesToAdd,
-            state.EpisodesToSave.Count - state.EpisodesToAdd,
+            episodesToAdd,
+            episodesToSave.Count - episodesToAdd,
             episodesToRemove.Count,
-            existingEpisodes.Count + state.EpisodesToAdd - episodesToRemove.Count - state.EpisodesToSave.Count,
+            existingEpisodes.Count + episodesToAdd - episodesToRemove.Count - episodesToSave.Count,
             show.Name,
             show.Id);
-        _tmdbEpisodes.Save(state.EpisodesToSave);
+        _tmdbEpisodes.Save(episodesToSave);
 
         foreach (var episode in episodesToRemove)
         {
             PurgeShowEpisode(episode);
-            state.EpisodeEventsToEmit.TryAdd(episode, UpdateReason.Removed);
+            episodeEventsToEmit.TryAdd(episode, UpdateReason.Removed);
         }
 
         _tmdbEpisodes.Delete(episodesToRemove);
 
         if (quickRefresh)
-            return (
-                state.SeasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || state.EpisodesToSave.Count > 0 || episodesToRemove.Count > 0,
-                state.SeasonEventsToEmit,
-                state.EpisodeEventsToEmit,
-                state.TotalEpisodeCount,
-                state.TotalHiddenEpisodeCount
+            return new TmdbSeasonEpisodeUpdateResult(
+                seasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || episodesToSave.Count > 0 || episodesToRemove.Count > 0,
+                seasonEventsToEmit,
+                episodeEventsToEmit,
+                totalEpisodeCount,
+                totalHiddenEpisodeCount
             );
 
-        var (peopleAdded, peopleUpdated, peoplePurged, peopleSkipped) = await UpdateShowPeopleAsync(show, forceRefresh, downloadImages, state);
-        _logger.LogDebug("Added/removed {a}/{u}/{r}/{s} staff for show {ShowTitle} (Show={ShowId})",
-            peopleAdded, peopleUpdated, peoplePurged, peopleSkipped, show.Name, show.Id);
+        var anyPeopleChanged = await UpdateShowPeopleAsync(show, forceRefresh, downloadImages, allPeopleToAddOrKeep, allPeopleToPotentiallyRemove);
 
-        return (
-            state.SeasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || state.EpisodesToSave.Count > 0 || episodesToRemove.Count > 0 || peopleAdded > 0 || peoplePurged > 0,
-            state.SeasonEventsToEmit,
-            state.EpisodeEventsToEmit,
-            state.TotalEpisodeCount,
-            state.TotalHiddenEpisodeCount
+        return new TmdbSeasonEpisodeUpdateResult(
+            seasonsToSave.Count > 0 || seasonsToRemove.Count > 0 || episodesToSave.Count > 0 || episodesToRemove.Count > 0 || anyPeopleChanged,
+            seasonEventsToEmit,
+            episodeEventsToEmit,
+            totalEpisodeCount,
+            totalHiddenEpisodeCount
         );
     }
 
-    private async Task<(int Added, int Updated, int Purged, int Skipped)> UpdateShowPeopleAsync(TvShow show, bool forceRefresh, bool downloadImages, ShowSeasonUpdateState state)
+    private async Task<bool> UpdateShowPeopleAsync(TvShow show, bool forceRefresh, bool downloadImages, HashSet<int> allPeopleToAddOrKeep, HashSet<int> allPeopleToPotentiallyRemove)
     {
         var added = 0;
         var updated = 0;
         var purged = 0;
-        var peopleToCheck = state.AllPeopleToAddOrKeep;
-        var peopleToPurge = state.AllPeopleToPotentiallyRemove.Except(peopleToCheck).ToList();
+        var peopleToCheck = allPeopleToAddOrKeep;
+        var peopleToPurge = allPeopleToPotentiallyRemove.Except(peopleToCheck).ToList();
         var transientlyFailedShowPeople = new ConcurrentBag<int>();
         try
         {
@@ -1429,7 +1542,9 @@ public class TmdbMetadataService : ITmdbMetadataService
         {
             _logger.LogWarning(ex, "TMDB: Failed to purge one or more people during show cast/crew update (Show={ShowId})", show.Id);
         }
-        return (added, updated, purged, peopleToPurge.Count + peopleToCheck.Count - added - updated - purged);
+        _logger.LogDebug("Added/updated/purged/skipped {a}/{u}/{r}/{s} staff for show {ShowTitle} (Show={ShowId})",
+            added, updated, purged, peopleToPurge.Count + peopleToCheck.Count - added - updated - purged, show.Name, show.Id);
+        return added > 0 || purged > 0;
     }
 
     private void CleanupOrphanedCastCrew(IReadOnlyCollection<int> people, HashSet<int> transientlyFailed, Action<HashSet<int>> deleteOrphansAndLog)
@@ -1439,180 +1554,6 @@ public class TmdbMetadataService : ITmdbMetadataService
         var missingPersonIds = candidates.Except(existingIds).ToHashSet();
         if (missingPersonIds.Count > 0)
             deleteOrphansAndLog(missingPersonIds);
-    }
-
-    private async Task ProcessShowSeasonAsync(TvShow show, SearchTvSeason reducedSeason, ShowSeasonUpdateState state)
-    {
-        _logger.LogDebug("Checking season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedSeason.SeasonNumber, show.Name, show.Id);
-
-        // Skipped seasons still need their episode counts registered so season totals stay accurate.
-        if (TryHandleUnchangedSeason(reducedSeason, show, state))
-            return;
-
-        var season = await UseClient(c => c.GetTvSeasonAsync(show.Id, reducedSeason.SeasonNumber, TvSeasonMethods.Translations), $"Get season {reducedSeason.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false) ??
-            throw new Exception($"Unable to fetch season {reducedSeason.SeasonNumber} for show \"{show.Name}\".");
-        if (!state.ExistingSeasons.TryGetValue(reducedSeason.Id, out var tmdbSeason))
-        {
-            Interlocked.Increment(ref state.SeasonsToAdd);
-            tmdbSeason = new(reducedSeason.Id);
-        }
-        var newlyAddedSeason = tmdbSeason.CreatedAt == tmdbSeason.LastUpdatedAt;
-
-        var seasonUpdated = tmdbSeason.Populate(show, season);
-        seasonUpdated = UpdateTitlesAndOverviews(tmdbSeason, season.Translations, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || seasonUpdated;
-
-        var seasonAlreadySaved = MarkSeasonForSave(tmdbSeason, newlyAddedSeason, seasonUpdated, state);
-        state.SeasonsToSkip.Add(tmdbSeason.Id);
-
-        var episodeBag = new List<TMDB_Episode>();
-        var hiddenEpisodeBag = new List<TMDB_Episode>();
-        foreach (var reducedEpisode in season.Episodes!)
-            await ProcessShowEpisodeAsync(show, season, reducedEpisode, state, episodeBag, hiddenEpisodeBag);
-
-        var episodeCount = episodeBag.Count;
-        var hiddenEpisodeCount = hiddenEpisodeBag.Count;
-        if (tmdbSeason.EpisodeCount != episodeCount)
-        {
-            tmdbSeason.EpisodeCount = episodeCount;
-            seasonUpdated = true;
-        }
-        if (tmdbSeason.HiddenEpisodeCount != hiddenEpisodeCount)
-        {
-            tmdbSeason.HiddenEpisodeCount = hiddenEpisodeCount;
-            seasonUpdated = true;
-        }
-        if (seasonUpdated)
-        {
-            tmdbSeason.LastUpdatedAt = DateTime.Now;
-            if (!seasonAlreadySaved)
-                state.SeasonsToSave.Add(tmdbSeason);
-        }
-        Interlocked.Add(ref state.TotalEpisodeCount, episodeCount);
-        Interlocked.Add(ref state.TotalHiddenEpisodeCount, hiddenEpisodeCount);
-    }
-
-    private bool TryHandleUnchangedSeason(SearchTvSeason reducedSeason, TvShow show, ShowSeasonUpdateState state)
-    {
-        if (!state.ChangedItems.HasValue) return false;
-        if (state.ChangedItems.Value.SeasonNumbers.Contains(reducedSeason.SeasonNumber)) return false;
-        if (!state.ExistingSeasons.TryGetValue(reducedSeason.Id, out var season)) return false;
-        state.SeasonsToSkip.Add(season.Id);
-        var localEpisodes = state.ExistingEpisodes.Values.Where(e => e.TmdbSeasonID == season.Id).ToList();
-        var visibleCount = 0;
-        foreach (var ep in localEpisodes)
-        {
-            state.EpisodesToSkip.Add(ep.Id);
-            if (!ep.IsHidden) visibleCount++;
-        }
-        Interlocked.Add(ref state.TotalEpisodeCount, visibleCount);
-        Interlocked.Add(ref state.TotalHiddenEpisodeCount, localEpisodes.Count - visibleCount);
-        if (state.DownloadCrewAndCast)
-        {
-            foreach (var ep in localEpisodes)
-                foreach (var personId in state.EpisodePeople[ep.Id])
-                    state.AllPeopleToAddOrKeep.Add(personId);
-        }
-        _logger.LogDebug("Skipping unchanged season {SeasonNumber} for show {ShowTitle} (Show={ShowId}).", reducedSeason.SeasonNumber, show.Name, show.Id);
-        return true;
-    }
-
-    private static bool MarkSeasonForSave(TMDB_Season tmdbSeason, bool newlyAdded, bool seasonUpdated, ShowSeasonUpdateState state)
-    {
-        if (!((newlyAdded && state.ShouldFireEvents) || seasonUpdated)) return false;
-        state.SeasonEventsToEmit.TryAdd(tmdbSeason, newlyAdded ? UpdateReason.Added : UpdateReason.Updated);
-        if (state.ShouldFireEvents)
-            tmdbSeason.LastUpdatedAt = DateTime.Now;
-        state.SeasonsToSave.Add(tmdbSeason);
-        return true;
-    }
-
-    private async Task ProcessShowEpisodeAsync(
-        TvShow show,
-        TvSeason season,
-        TvSeasonEpisode reducedEpisode,
-        ShowSeasonUpdateState state,
-        List<TMDB_Episode> episodeBag,
-        List<TMDB_Episode> hiddenEpisodeBag)
-    {
-        _logger.LogDebug("Checking episode {EpisodeNumber} in season {SeasonNumber} for show {ShowTitle} (Show={ShowId})", reducedEpisode.EpisodeNumber, season.SeasonNumber, show.Name, show.Id);
-        if (!state.ExistingEpisodes.TryGetValue(reducedEpisode.Id, out var tmdbEpisode))
-        {
-            Interlocked.Increment(ref state.EpisodesToAdd);
-            tmdbEpisode = new(reducedEpisode.Id);
-        }
-        var newlyAddedEpisode = tmdbEpisode.CreatedAt == tmdbEpisode.LastUpdatedAt;
-
-        if (TrySkipUnchangedEpisode(tmdbEpisode, season, reducedEpisode, newlyAddedEpisode, state, episodeBag, hiddenEpisodeBag))
-            return;
-
-        bool episodeUpdated;
-        if (state.QuickRefresh)
-        {
-            var baseUpdated = tmdbEpisode.Populate(show, season, reducedEpisode, null);
-            episodeUpdated = UpdateTitlesAndOverviews(tmdbEpisode, null, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || baseUpdated;
-        }
-        else
-        {
-            episodeUpdated = await FullFetchAndUpdateEpisodeAsync(tmdbEpisode, show, season, reducedEpisode, state);
-        }
-
-        if ((newlyAddedEpisode && state.ShouldFireEvents) || episodeUpdated)
-        {
-            state.EpisodeEventsToEmit.TryAdd(tmdbEpisode, newlyAddedEpisode ? UpdateReason.Added : UpdateReason.Updated);
-            if (state.ShouldFireEvents)
-                tmdbEpisode.LastUpdatedAt = DateTime.Now;
-            state.EpisodesToSave.Add(tmdbEpisode);
-        }
-
-        state.EpisodesToSkip.Add(tmdbEpisode.Id);
-        (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
-    }
-
-    private async Task<bool> FullFetchAndUpdateEpisodeAsync(TMDB_Episode tmdbEpisode, TvShow show, TvSeason season, TvSeasonEpisode reducedEpisode, ShowSeasonUpdateState state)
-    {
-        var episodeMethods = TvEpisodeMethods.ExternalIds | TvEpisodeMethods.Translations;
-        if (state.DownloadCrewAndCast)
-            episodeMethods |= TvEpisodeMethods.Credits;
-        var episode = await UseClient(c => c.GetTvEpisodeAsync(show.Id, season.SeasonNumber, reducedEpisode.EpisodeNumber, episodeMethods), $"Get episode {reducedEpisode.EpisodeNumber} in season {season.SeasonNumber} for show {show.Id} \"{show.Name}\"").ConfigureAwait(false);
-        if (episode is null)
-            return false;
-        var updated = tmdbEpisode.Populate(show, season, reducedEpisode, episode.Translations);
-        updated = UpdateTitlesAndOverviews(tmdbEpisode, episode.Translations, state.PreferredTitleLanguages, state.PreferredOverviewLanguages) || updated;
-        updated = UpdateEpisodeExternalIDs(tmdbEpisode, episode.ExternalIds!) || updated;
-        if (state.DownloadCrewAndCast)
-            updated |= UpdateEpisodeCastCrewAndCollectPeople(tmdbEpisode, episode.Credits!, state);
-        return updated;
-    }
-
-    private static bool TrySkipUnchangedEpisode(
-        TMDB_Episode tmdbEpisode,
-        TvSeason season,
-        TvSeasonEpisode reducedEpisode,
-        bool newlyAddedEpisode,
-        ShowSeasonUpdateState state,
-        List<TMDB_Episode> episodeBag,
-        List<TMDB_Episode> hiddenEpisodeBag)
-    {
-        if (!state.ChangedItems.HasValue || newlyAddedEpisode) return false;
-        if (state.ChangedItems.Value.Episodes.Contains((season.SeasonNumber, (int)reducedEpisode.EpisodeNumber))) return false;
-        state.EpisodesToSkip.Add(tmdbEpisode.Id);
-        (tmdbEpisode.IsHidden ? hiddenEpisodeBag : episodeBag).Add(tmdbEpisode);
-        if (state.DownloadCrewAndCast)
-        {
-            foreach (var personId in state.EpisodePeople[tmdbEpisode.Id])
-                state.AllPeopleToAddOrKeep.Add(personId);
-        }
-        return true;
-    }
-
-    private bool UpdateEpisodeCastCrewAndCollectPeople(TMDB_Episode tmdbEpisode, CreditsWithGuestStars credits, ShowSeasonUpdateState state)
-    {
-        var (castOrCrewUpdated, peopleToAddOrKeep, peopleToPotentiallyRemove) = UpdateEpisodeCastAndCrew(tmdbEpisode, credits);
-        foreach (var personId in peopleToAddOrKeep)
-            state.AllPeopleToAddOrKeep.Add(personId);
-        foreach (var personId in peopleToPotentiallyRemove)
-            state.AllPeopleToPotentiallyRemove.Add(personId);
-        return castOrCrewUpdated;
     }
 
     private async Task<bool> UpdateShowAlternateOrdering(TMDB_Show tmdbShow, TvShow show)
@@ -3014,7 +2955,16 @@ public class TmdbMetadataService : ITmdbMetadataService
     /// <para>Empty sets if no season or episode changes were reported — the caller can skip the update.</para>
     /// <para>Populated sets containing the season numbers and (season, episode) pairs that changed.</para>
     /// </returns>
-    private async Task<(HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes)?> GetShowChangedItemsAsync(int showId, DateTime since)
+    internal readonly record struct TmdbShowChangedItems(HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes);
+
+    private readonly record struct TmdbSeasonEpisodeUpdateResult(
+        bool EpisodesOrSeasonsUpdated,
+        Dictionary<TMDB_Season, UpdateReason> UpdatedSeasons,
+        Dictionary<TMDB_Episode, UpdateReason> UpdatedEpisodes,
+        int EpisodeCount,
+        int HiddenEpisodeCount);
+
+    private async Task<TmdbShowChangedItems?> GetShowChangedItemsAsync(int showId, DateTime since)
     {
         // The TMDB Changes API covers at most the last 14 days. Return null to signal the caller
         // to perform a full refresh rather than a selective one.
@@ -3038,7 +2988,7 @@ public class TmdbMetadataService : ITmdbMetadataService
     /// their season number to <c>SeasonNumbers</c> so season metadata is always refreshed when
     /// one of its episodes changed.
     /// </remarks>
-    internal static (HashSet<int> SeasonNumbers, HashSet<(int Season, int Episode)> Episodes) ParseShowChanges(IList<Change> changes)
+    internal static TmdbShowChangedItems ParseShowChanges(IList<Change> changes)
     {
         var seasonNumbers = new HashSet<int>();
         var episodes = new HashSet<(int Season, int Episode)>();
@@ -3049,7 +2999,7 @@ public class TmdbMetadataService : ITmdbMetadataService
             foreach (var item in change.Items ?? [])
                 ApplyChangeItem(change.Key, item, seasonNumbers, episodes);
         }
-        return (seasonNumbers, episodes);
+        return new TmdbShowChangedItems(seasonNumbers, episodes);
     }
 
     private static void ApplyChangeItem(string key, ChangeItemBase item, HashSet<int> seasonNumbers, HashSet<(int Season, int Episode)> episodes)

--- a/Shoko.Server/Providers/TMDB/TmdbRateLimiter.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbRateLimiter.cs
@@ -93,6 +93,8 @@ public sealed class TmdbRateLimiter : IDisposable
         var until = DateTimeOffset.UtcNow + delay;
         var newTicks = until.UtcTicks;
         long current;
+        // CAS loop: multiple concurrent callers may receive 429s at the same time.
+        // Keep whichever deadline is furthest in the future so the longest backoff wins.
         do
         {
             current = Interlocked.Read(ref _backoffUntilTicks);
@@ -125,6 +127,8 @@ public sealed class TmdbRateLimiter : IDisposable
 
     private async Task WaitForBackoffAsync(CancellationToken cancellationToken = default)
     {
+        // Loop: a concurrent 429 can arrive mid-wait and push the deadline forward.
+        // Re-read the ticks after each delay to catch that case before returning.
         while (true)
         {
             var backoffTicks = Interlocked.Read(ref _backoffUntilTicks);

--- a/Shoko.Server/Repositories/Direct/TMDB/TMDB_PersonRepository.cs
+++ b/Shoko.Server/Repositories/Direct/TMDB/TMDB_PersonRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Shoko.Server.Databases;
 using Shoko.Server.Models.TMDB;
@@ -17,6 +18,20 @@ public class TMDB_PersonRepository : BaseDirectRepository<TMDB_Person, int>
                 .Where(a => a.TmdbPersonID == creditId)
                 .Take(1)
                 .SingleOrDefault();
+        });
+    }
+
+    public HashSet<int> GetExistingTmdbPersonIDs(IReadOnlyCollection<int> personIds)
+    {
+        if (personIds.Count == 0) return [];
+        return Lock(() =>
+        {
+            using var session = _databaseFactory.SessionFactory.OpenSession();
+            return session
+                .Query<TMDB_Person>()
+                .Where(a => personIds.Contains(a.TmdbPersonID))
+                .Select(a => a.TmdbPersonID)
+                .ToHashSet();
         });
     }
 

--- a/Shoko.Server/Scheduling/Jobs/TMDB/UpdateTmdbPersonJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/TMDB/UpdateTmdbPersonJob.cs
@@ -25,6 +25,20 @@ public class UpdateTmdbPersonJob : BaseJob
 
     public virtual bool DownloadImages { get; set; }
 
+    /// <summary>
+    /// Loop-prevention hint: the show that triggered this job. When set, <see cref="TmdbMetadataService.PurgePersonInternal"/>
+    /// skips re-scheduling an update for this show, preventing a cascade when the person 404s.
+    /// Not a true parent-context ID — the person update is independent of any specific show.
+    /// </summary>
+    public virtual int? TmdbShowID { get; set; }
+
+    /// <summary>
+    /// Loop-prevention hint: the movie that triggered this job. When set, <see cref="TmdbMetadataService.PurgePersonInternal"/>
+    /// skips re-scheduling an update for this movie, preventing a cascade when the person 404s.
+    /// Not a true parent-context ID — the person update is independent of any specific movie.
+    /// </summary>
+    public virtual int? TmdbMovieID { get; set; }
+
     public virtual string? PersonName { get; set; }
 
     public override void PostInit()
@@ -43,7 +57,7 @@ public class UpdateTmdbPersonJob : BaseJob
     public override async Task Execute()
     {
         _logger.LogInformation("Processing UpdateTmdbPersonJob: {TmdbPersonId}", TmdbPersonID);
-        await _tmdbService.UpdatePerson(TmdbPersonID, ForceRefresh, DownloadImages).ConfigureAwait(false);
+        await _tmdbService.UpdatePerson(TmdbPersonID, ForceRefresh, DownloadImages, currentShowId: TmdbShowID, currentMovieId: TmdbMovieID).ConfigureAwait(false);
     }
 
     private readonly TMDB_PersonRepository _tmdbPeople;

--- a/Shoko.Server/Scheduling/Jobs/TMDB/UpdateTmdbPersonJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/TMDB/UpdateTmdbPersonJob.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Shoko.QueueProcessor.Acquisition.Attributes;
+using Shoko.QueueProcessor.Builder;
+using Shoko.QueueProcessor.Concurrency;
+using Shoko.Server.Providers.TMDB;
+using Shoko.Server.Repositories.Direct.TMDB;
+
+#pragma warning disable CS8618
+#nullable enable
+namespace Shoko.Server.Scheduling.Jobs.TMDB;
+
+[DatabaseRequired]
+[NetworkRequired]
+[LimitConcurrency(1, 12)]
+[JobKeyGroup(JobKeyGroup.TMDB)]
+public class UpdateTmdbPersonJob : BaseJob
+{
+    private readonly TmdbMetadataService _tmdbService;
+
+    public virtual int TmdbPersonID { get; set; }
+
+    public virtual bool ForceRefresh { get; set; }
+
+    public virtual bool DownloadImages { get; set; }
+
+    public virtual string? PersonName { get; set; }
+
+    public override void PostInit()
+    {
+        PersonName ??= _tmdbPeople.GetByTmdbPersonID(TmdbPersonID)?.EnglishName;
+    }
+
+    public override string TypeName => "Update TMDB Person";
+
+    public override string Title => "Updating TMDB Person";
+
+    public override Dictionary<string, object> Details => string.IsNullOrEmpty(PersonName)
+        ? new() { { "PersonID", TmdbPersonID } }
+        : new() { { "Person", PersonName }, { "PersonID", TmdbPersonID } };
+
+    public override async Task Execute()
+    {
+        _logger.LogInformation("Processing UpdateTmdbPersonJob: {TmdbPersonId}", TmdbPersonID);
+        await _tmdbService.UpdatePerson(TmdbPersonID, ForceRefresh, DownloadImages).ConfigureAwait(false);
+    }
+
+    private readonly TMDB_PersonRepository _tmdbPeople;
+
+    public UpdateTmdbPersonJob(TmdbMetadataService tmdbService, TMDB_PersonRepository tmdbPeople)
+    {
+        _tmdbService = tmdbService;
+        _tmdbPeople = tmdbPeople;
+    }
+
+    protected UpdateTmdbPersonJob() { }
+}

--- a/Shoko.Server/Settings/SettingsMigrations.cs
+++ b/Shoko.Server/Settings/SettingsMigrations.cs
@@ -86,7 +86,6 @@ public static partial class SettingsMigrations
         // using applicationPaths.DataPath. The null tombstone here ensures Version == 15.
         { 15, null },
         { 16, MigrateDefaultRenamerToStatic },
-        { 17, MigrateTmdbMaxRequestsPerWindow },
     };
 
     /// <summary>
@@ -347,22 +346,6 @@ public static partial class SettingsMigrations
 
         queueObj["SQLiteFilePath"] = filePath;
         queueObj.Remove("ConnectionString");
-
-        return currentSettings.ToString();
-    }
-
-    private static string MigrateTmdbMaxRequestsPerWindow(string settings)
-    {
-        var currentSettings = JObject.Parse(settings);
-        if (currentSettings["TMDB"] is not JObject tmdb) return currentSettings.ToString();
-        if (tmdb["RateLimit"] is not JObject rateLimit) return currentSettings.ToString();
-
-        var old = rateLimit["MaxRequestsPerWindow"];
-        if (old is not null)
-        {
-            rateLimit["TMDB_API_Limits"] ??= old.DeepClone();
-            rateLimit.Remove("MaxRequestsPerWindow");
-        }
 
         return currentSettings.ToString();
     }

--- a/Shoko.Server/Settings/SettingsMigrations.cs
+++ b/Shoko.Server/Settings/SettingsMigrations.cs
@@ -86,6 +86,7 @@ public static partial class SettingsMigrations
         // using applicationPaths.DataPath. The null tombstone here ensures Version == 15.
         { 15, null },
         { 16, MigrateDefaultRenamerToStatic },
+        { 17, MigrateTmdbMaxRequestsPerWindow },
     };
 
     /// <summary>
@@ -346,6 +347,22 @@ public static partial class SettingsMigrations
 
         queueObj["SQLiteFilePath"] = filePath;
         queueObj.Remove("ConnectionString");
+
+        return currentSettings.ToString();
+    }
+
+    private static string MigrateTmdbMaxRequestsPerWindow(string settings)
+    {
+        var currentSettings = JObject.Parse(settings);
+        if (currentSettings["TMDB"] is not JObject tmdb) return currentSettings.ToString();
+        if (tmdb["RateLimit"] is not JObject rateLimit) return currentSettings.ToString();
+
+        var old = rateLimit["MaxRequestsPerWindow"];
+        if (old is not null)
+        {
+            rateLimit["TMDB_API_Limits"] ??= old.DeepClone();
+            rateLimit.Remove("MaxRequestsPerWindow");
+        }
 
         return currentSettings.ToString();
     }

--- a/Shoko.Server/Settings/TMDBSettings.cs
+++ b/Shoko.Server/Settings/TMDBSettings.cs
@@ -239,6 +239,20 @@ public class TMDBSettings
     public string? ImageCdnUrl { get; set; }
 
     /// <summary>
+    /// The number of days to check for incremental changes. Set to <c>0</c> to
+    /// disable incremental changes.
+    /// </summary>
+    /// <remarks>
+    /// The TMDB API covers at most the last 14 days. So we can only use
+    /// incremental changes detection for up-to the last 14 days.
+    /// </remarks>
+    [Visibility(Size = DisplayElementSize.Large)]
+    [EnvironmentVariable("TMDB_CHANGES_WINDOW_DAYS")]
+    [Range(0, 14)]
+    [DefaultValue(14)]
+    public int IncrementalChangesWindowDays { get; set; } = 14;
+
+    /// <summary>
     /// Rate limit settings for the TMDB API.
     /// </summary>
     public TmdbRateLimitSettings RateLimit { get; set; } = new();

--- a/Shoko.Server/Settings/TmdbRateLimitSettings.cs
+++ b/Shoko.Server/Settings/TmdbRateLimitSettings.cs
@@ -28,5 +28,6 @@ public class TmdbRateLimitSettings
     [Visibility(Size = DisplayElementSize.Small, Advanced = true)]
     [Display(Name = "Window Duration (ms)")]
     [Range(100, 10000)]
+    [EnvironmentVariable("TMDB_RATE_LIMIT_WINDOW_DURATION_MS")]
     public int WindowDurationMs { get; set; } = 1000;
 }

--- a/Shoko.Server/Settings/TmdbRateLimitSettings.cs
+++ b/Shoko.Server/Settings/TmdbRateLimitSettings.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
 using Shoko.Abstractions.Config.Attributes;
 using Shoko.Abstractions.Config.Enums;
 
@@ -11,13 +12,14 @@ public class TmdbRateLimitSettings
 {
     /// <summary>
     /// Maximum number of requests allowed within the rate limit window.
-    /// TMDB enforces approximately 40 requests per second; this defaults to 10 to avoid overwhelming
+    /// TMDB enforces a maximum of 40 requests per second; this defaults to 10 to avoid overwhelming
     /// end-user hardware with API requests and the data processing that follows each one.
     ///</summary>
     [Badge("Debug", Theme = DisplayColorTheme.Warning)]
     [Visibility(Size = DisplayElementSize.Small, Advanced = true)]
-    [Display(Name = "Max Requests Per Window")]
+    [Display(Name = "API Rate Limit")]
     [Range(1, 40)]
+    [JsonProperty("TMDB_API_Limits")]
     public int MaxRequestsPerWindow { get; set; } = 10;
 
     /// <summary>

--- a/Shoko.Server/Settings/TmdbRateLimitSettings.cs
+++ b/Shoko.Server/Settings/TmdbRateLimitSettings.cs
@@ -17,7 +17,7 @@ public class TmdbRateLimitSettings
     ///</summary>
     [Badge("Debug", Theme = DisplayColorTheme.Warning)]
     [Visibility(Size = DisplayElementSize.Small, Advanced = true)]
-    [Display(Name = "API Rate Limit")]
+    [Display(Name = "Max Requests Per Window")]
     [Range(1, 40)]
     [JsonProperty("TMDB_API_Limits")]
     public int MaxRequestsPerWindow { get; set; } = 10;

--- a/Shoko.Server/Settings/TmdbRateLimitSettings.cs
+++ b/Shoko.Server/Settings/TmdbRateLimitSettings.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using Newtonsoft.Json;
 using Shoko.Abstractions.Config.Attributes;
 using Shoko.Abstractions.Config.Enums;
 
@@ -19,7 +18,7 @@ public class TmdbRateLimitSettings
     [Visibility(Size = DisplayElementSize.Small, Advanced = true)]
     [Display(Name = "Max Requests Per Window")]
     [Range(1, 40)]
-    [JsonProperty("TMDB_API_Limits")]
+    [EnvironmentVariable("TMDB_RATE_LIMIT_MAX_REQUESTS_PER_WINDOW")]
     public int MaxRequestsPerWindow { get; set; } = 10;
 
     /// <summary>

--- a/Shoko.Tests/Providers/TMDB/TmdbMetadataServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbMetadataServiceTests.cs
@@ -1,7 +1,11 @@
+using System;
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Reflection;
 using Newtonsoft.Json.Linq;
 using Shoko.Server.Providers.TMDB;
 using TMDbLib.Objects.Changes;
+using TMDbLib.Objects.Exceptions;
 using Xunit;
 
 namespace Shoko.Tests.Providers.TMDB;
@@ -254,4 +258,40 @@ public class TmdbMetadataServiceTests
         Assert.Contains(2, seasons);
         Assert.Empty(episodes);
     }
+}
+
+public class TmdbTransientExceptionTests
+{
+    private static readonly ConstructorInfo _rleCtor =
+        typeof(RequestLimitExceededException).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0];
+
+    private static RequestLimitExceededException MakeRequestLimitExceeded()
+    {
+        var sm = Activator.CreateInstance(typeof(TMDbStatusMessage))!;
+        return (RequestLimitExceededException)_rleCtor.Invoke([sm, null, null]);
+    }
+
+    [Fact]
+    public void HttpRequestException_IsTransient()
+        => Assert.True(TmdbMetadataService.IsTmdbTransient(new HttpRequestException()));
+
+    [Fact]
+    public void RequestLimitExceededException_IsTransient()
+        => Assert.True(TmdbMetadataService.IsTmdbTransient(MakeRequestLimitExceeded()));
+
+    [Fact]
+    public void NotFoundException_IsNotTransient()
+        => Assert.False(TmdbMetadataService.IsTmdbTransient(new NotFoundException(null!)));
+
+    [Fact]
+    public void GeneralHttpException_IsNotTransient()
+        => Assert.False(TmdbMetadataService.IsTmdbTransient(new GeneralHttpException(System.Net.HttpStatusCode.InternalServerError)));
+
+    [Fact]
+    public void TmdbApiKeyUnavailableException_IsNotTransient()
+        => Assert.False(TmdbMetadataService.IsTmdbTransient(new TmdbApiKeyUnavailableException()));
+
+    [Fact]
+    public void ArbitraryException_IsNotTransient()
+        => Assert.False(TmdbMetadataService.IsTmdbTransient(new InvalidOperationException("unexpected")));
 }

--- a/Shoko.Tests/Providers/TMDB/TmdbMetadataServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbMetadataServiceTests.cs
@@ -14,7 +14,9 @@ public class TmdbMetadataServiceTests
 {
     #region Helpers
 
-    private static Change EpisodeChange(params (int Season, int Episode)[] episodes)
+    private readonly record struct EpisodePair(int Season, int Episode);
+
+    private static Change EpisodeChange(params EpisodePair[] episodes)
     {
         var items = new List<ChangeItemBase>();
         foreach (var (season, episode) in episodes)
@@ -50,7 +52,7 @@ public class TmdbMetadataServiceTests
     [Fact]
     public void EpisodeChange_ExtractsSeasonAndEpisodePair()
     {
-        var changes = new List<Change> { EpisodeChange((2, 5)) };
+        var changes = new List<Change> { EpisodeChange(new EpisodePair(2, 5)) };
 
         var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
 
@@ -61,7 +63,7 @@ public class TmdbMetadataServiceTests
     [Fact]
     public void EpisodeChange_AddsSeasonNumberToSeasonSet()
     {
-        var changes = new List<Change> { EpisodeChange((3, 1)) };
+        var changes = new List<Change> { EpisodeChange(new EpisodePair(3, 1)) };
 
         var (seasons, _) = TmdbMetadataService.ParseShowChanges(changes);
 
@@ -97,7 +99,7 @@ public class TmdbMetadataServiceTests
     [Fact]
     public void MultipleEpisodesAcrossSeasons_AllCaptured()
     {
-        var changes = new List<Change> { EpisodeChange((1, 3), (2, 7), (2, 8)) };
+        var changes = new List<Change> { EpisodeChange(new EpisodePair(1, 3), new EpisodePair(2, 7), new EpisodePair(2, 8)) };
 
         var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
 
@@ -110,7 +112,7 @@ public class TmdbMetadataServiceTests
     {
         var changes = new List<Change>
         {
-            EpisodeChange((1, 5)),
+            EpisodeChange(new EpisodePair(1, 5)),
             SeasonChange(2),
         };
 
@@ -126,8 +128,8 @@ public class TmdbMetadataServiceTests
     {
         var changes = new List<Change>
         {
-            EpisodeChange((1, 4)),
-            EpisodeChange((1, 4)),
+            EpisodeChange(new EpisodePair(1, 4)),
+            EpisodeChange(new EpisodePair(1, 4)),
         };
 
         var (_, episodes) = TmdbMetadataService.ParseShowChanges(changes);

--- a/Shoko.Tests/Providers/TMDB/TmdbMetadataServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbMetadataServiceTests.cs
@@ -1,0 +1,257 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using Shoko.Server.Providers.TMDB;
+using TMDbLib.Objects.Changes;
+using Xunit;
+
+namespace Shoko.Tests.Providers.TMDB;
+
+public class TmdbMetadataServiceTests
+{
+    #region Helpers
+
+    private static Change EpisodeChange(params (int Season, int Episode)[] episodes)
+    {
+        var items = new List<ChangeItemBase>();
+        foreach (var (season, episode) in episodes)
+            items.Add(new ChangeItemUpdated { Value = EpisodeValue(season, episode) });
+        return new Change { Key = "episode", Items = items };
+    }
+
+    private static Change SeasonChange(params int[] seasonNumbers)
+    {
+        var items = new List<ChangeItemBase>();
+        foreach (var sn in seasonNumbers)
+            items.Add(new ChangeItemUpdated { Value = SeasonValue(sn) });
+        return new Change { Key = "season", Items = items };
+    }
+
+    private static JObject EpisodeValue(int season, int episode) =>
+        new() { ["season_number"] = season, ["episode_number"] = episode, ["episode_id"] = episode * 100 };
+
+    private static JObject SeasonValue(int season) =>
+        new() { ["season_number"] = season };
+
+    #endregion
+
+    [Fact]
+    public void EmptyChangeList_ReturnsEmptySets()
+    {
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges([]);
+
+        Assert.Empty(seasons);
+        Assert.Empty(episodes);
+    }
+
+    [Fact]
+    public void EpisodeChange_ExtractsSeasonAndEpisodePair()
+    {
+        var changes = new List<Change> { EpisodeChange((2, 5)) };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains(2, seasons);
+        Assert.Contains((2, 5), episodes);
+    }
+
+    [Fact]
+    public void EpisodeChange_AddsSeasonNumberToSeasonSet()
+    {
+        var changes = new List<Change> { EpisodeChange((3, 1)) };
+
+        var (seasons, _) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains(3, seasons);
+    }
+
+    [Fact]
+    public void SeasonChange_AddsToSeasonSetOnly()
+    {
+        var changes = new List<Change> { SeasonChange(1) };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains(1, seasons);
+        Assert.Empty(episodes);
+    }
+
+    [Fact]
+    public void UnrelatedKey_IsIgnored()
+    {
+        var changes = new List<Change>
+        {
+            new() { Key = "name", Items = [new ChangeItemUpdated { Value = new JObject { ["value"] = "New Title" } }] },
+            new() { Key = "overview", Items = [new ChangeItemUpdated { Value = new JObject { ["value"] = "New overview." } }] },
+        };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Empty(seasons);
+        Assert.Empty(episodes);
+    }
+
+    [Fact]
+    public void MultipleEpisodesAcrossSeasons_AllCaptured()
+    {
+        var changes = new List<Change> { EpisodeChange((1, 3), (2, 7), (2, 8)) };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Equal(new HashSet<int> { 1, 2 }, seasons);
+        Assert.Equal(new HashSet<(int, int)> { (1, 3), (2, 7), (2, 8) }, episodes);
+    }
+
+    [Fact]
+    public void MixedEpisodeAndSeasonChanges_BothCaptured()
+    {
+        var changes = new List<Change>
+        {
+            EpisodeChange((1, 5)),
+            SeasonChange(2),
+        };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Equal(new HashSet<int> { 1, 2 }, seasons);
+        Assert.Contains((1, 5), episodes);
+        Assert.DoesNotContain((2, 0), episodes);
+    }
+
+    [Fact]
+    public void DuplicateEpisode_DeduplicatedInOutput()
+    {
+        var changes = new List<Change>
+        {
+            EpisodeChange((1, 4)),
+            EpisodeChange((1, 4)),
+        };
+
+        var (_, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Single(episodes);
+        Assert.Contains((1, 4), episodes);
+    }
+
+    [Fact]
+    public void AddedItem_ValueExtracted()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemAdded { Value = EpisodeValue(1, 2) }],
+            },
+        };
+
+        var (_, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains((1, 2), episodes);
+    }
+
+    [Fact]
+    public void DestroyedItem_ValueExtracted()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemDestroyed { Value = EpisodeValue(2, 3) }],
+            },
+        };
+
+        var (_, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains((2, 3), episodes);
+    }
+
+    [Fact]
+    public void DeletedItem_OriginalValueExtracted()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemDeleted { OriginalValue = EpisodeValue(3, 9) }],
+            },
+        };
+
+        var (_, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains((3, 9), episodes);
+    }
+
+    [Fact]
+    public void ItemWithNoValue_Skipped()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemUpdated { Value = null }],
+            },
+        };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Empty(seasons);
+        Assert.Empty(episodes);
+    }
+
+    [Fact]
+    public void ItemWithNonJObjectValue_Skipped()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemUpdated { Value = "unexpected string" }],
+            },
+        };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Empty(seasons);
+        Assert.Empty(episodes);
+    }
+
+    [Fact]
+    public void EpisodeItemMissingSeasonNumber_Skipped()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemUpdated { Value = new JObject { ["episode_number"] = 5 } }],
+            },
+        };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Empty(seasons);
+        Assert.Empty(episodes);
+    }
+
+    [Fact]
+    public void EpisodeItemMissingEpisodeNumber_SeasonStillAdded()
+    {
+        var changes = new List<Change>
+        {
+            new()
+            {
+                Key = "episode",
+                Items = [new ChangeItemUpdated { Value = new JObject { ["season_number"] = 2 } }],
+            },
+        };
+
+        var (seasons, episodes) = TmdbMetadataService.ParseShowChanges(changes);
+
+        Assert.Contains(2, seasons);
+        Assert.Empty(episodes);
+    }
+}


### PR DESCRIPTION
## Summary

### Transient-error resilience and circuit breaker

- **fix**: \`UpdatePerson\` now routes \`NotFoundException\` (HTTP 404) to \`PurgePersonInternal\` — full cross-show/movie cleanup + forced refresh of linked entities — instead of silently returning.
- **fix**: Transient failures (\`HttpRequestException\`, \`RequestLimitExceededException\`) during the person fetch fan-out enqueue an \`UpdateTmdbPersonJob\` retry per person; cast/crew rows for transiently-failed people are preserved (excluded from orphan cleanup) so the retry can link them once the person row is fetched.
- **fix**: \`HasMovieChangedSinceAsync\` and \`GetShowChangedItemsAsync\` now catch transient TMDB errors and fall back to a full refresh rather than aborting the entire job.
- **fix**: \`UpdateTmdbPersonJob\` gains optional \`TmdbShowID\`/\`TmdbMovieID\` fields so \`PurgePersonInternal\` can exclude the triggering entity from re-scheduling, preventing a 404 retry loop.
- **refactor**: Episode update loop replaced with sequential \`foreach\` + \`ActionBlock\` with a cancellable circuit-breaker. \`ProcessWithConcurrencyAsync\` gains an \`onDropped: Action<T>?\` callback so items silently discarded when the circuit breaker fires are handed back to the caller for retry enqueueing.

### Orphan cleanup

- **fix**: Orphaned cast/crew cleanup was only running inside the \`catch\` block, so on the all-transient path (every failure absorbed by the inner handler) cleanup was silently skipped. Moved outside the try/catch so it runs on every fan-out completion.
- **fix**: \`TrySkipUnchangedEpisode\` and \`TryHandleUnchangedSeason\` did not add skipped episodes' existing cast/crew people to \`AllPeopleToAddOrKeep\`. A person appearing only in unchanged episodes would have their \`TMDB_Person\` row purged, leaving dangling cast/crew references. Fixed by querying existing cast/crew rows for skipped episodes/seasons and adding each person to \`AllPeopleToAddOrKeep\` when \`DownloadCrewAndCast\` is true.

### Selective refresh via TMDB Changes API

- **feat**: Unchanged seasons and episodes are now skipped using the TMDB Changes API — avoids redundant \`GetTvSeasonAsync\` / \`GetTvEpisodeAsync\` calls for unmodified content. Falls back to a full refresh when the entity is newly added, \`LastUpdatedAt\` is older than 14 days, or the Changes API returns \`null\`.
- **fix**: \`HasMovieChangedSinceAsync\` and \`GetShowChangedItemsAsync\` passed \`LastUpdatedAt\` (local \`DateTime.Now\`) to TMDbLib, which appends a hardcoded \`" UTC"\` suffix regardless of \`DateTime.Kind\` — wrong on any non-UTC host. Fixed with \`since.ToUniversalTime()\`.

### Missing person stubs

- **fix**: When \`GetTmdbPerson()\` returns null at API serialisation time, \`Role.InitStub\` enqueues a background \`UpdateTmdbPersonJob\` and sets \`IsStub = true\`. All TMDB cast/crew API responses filter stubs via \`.Where(r => !r.IsStub)\` so entries with empty names never reach callers.
- **refactor**: Extracted \`CreateStaffFromTmdbPerson\` helper in \`Role\` to eliminate 8× duplicated person-init blocks across TMDB cast/crew constructors. \`ILogger?\` threaded through all 8 constructors so enqueue failures are logged via the caller's logger.

### Configurable rate limiter

- **feat**: The rate limit is now configurable via \`MaxRequestsPerWindow\` (serialised as \`TMDB_API_Limits\`, range 1–40, default 10).

### Misc

- **fix**: Skipped-count log formula (\`total - added - updated - purged\`) assumed mutual exclusivity of the added/updated counters. Preserved \`else if (updated)\` so a newly-added person increments only \`peopleAdded\`, keeping the formula correct.
- **refactor**: \`ShowSeasonUpdateState\` skip sets changed from \`ConcurrentBag<int>\` to \`ConcurrentDictionary<int,byte>\` for correct deduplication; episode cast/crew pre-loaded as a single \`ILookup<episodeId, personId>\` before the season fan-out instead of issuing per-entity DB queries inside the loop.
- **refactor**: \`TrySkipUnchangedEpisode\` marked \`static\` (no instance access). \`ShowSeasonUpdateState\` constructor reduced from 8 to 6 parameters by grouping \`downloadCrewAndCast\`, \`quickRefresh\`, and \`shouldFireEvents\` into a single \`options\` tuple.

## New Setting: \`TMDB_API_Limits\`

| Field | Value |
|---|---|
| C# property | \`MaxRequestsPerWindow\` |
| JSON key | \`TMDB_API_Limits\` |
| UI label | \`"API Rate Limit"\` |
| Location | TMDB › Rate Limit settings |
| Range | 1–40 requests per window |
| Default | 10 |
