### PR TITLE
fix(config): handle null JToken in ToJson extension

### DIFF
--- a/Shoko.Server/Services/Configuration/JTokenExtensions.cs
+++ b/Shoko.Server/Services/Configuration/JTokenExtensions.cs
@@ -10,6 +10,7 @@ internal static class JTokenExtensions
         {
             JTokenType.Boolean => token.Value<bool>().ToString().ToLowerInvariant(),
             JTokenType.String => JsonConvert.SerializeObject(token.Value<string>()),
+            JTokenType.Null => "null",
             _ => token.ToString(),
         };
 }


### PR DESCRIPTION
## Summary

`PATCH /api/v3/Settings` throws a 500 whenever a setting that is both:
- decorated with `[EnvironmentVariable]`, **and**
- stored as an explicit JSON `null` in `settings-server.json` (i.e. the property is present with a `null` value, not absent)

is in play and the corresponding environment variable is set.

## Edge Case

`JTokenExtensions.ToJson()` is used to snapshot the original value of a property before it is overwritten by an environment variable on load. The snapshot is later used during save validation to revert the env-var override back to its original value before writing to disk.

The switch in `ToJson()` handled `Boolean` and `String` explicitly, but fell through to `_ => token.ToString()` for everything else. For a `JValue` whose type is `JTokenType.Null`, `JValue.ToString()` returns `""` (empty string) — **not** `"null"` as one would expect.

That empty string is stored as `tuple.Original`. On the next save, `ShokoJsonSchemaValidator` calls `JToken.Parse(tuple.Original)` → `JToken.Parse("")` → `Newtonsoft.Json.JsonReaderException: Error reading JToken from JsonReader. Path '', line 0, position 0`, which propagates as an unhandled 500.

**Trigger conditions (all must be true):**
1. A setting class has a property with `[EnvironmentVariable("SOME_VAR")]`
2. The corresponding env var is set at container/process startup
3. The property exists in the on-disk JSON config with an explicit `null` value (not absent — an absent property is handled correctly via the `token?.ToJson()` null-conditional returning C# `null`, which hits the `tuple.Original is null` guard at the call site)

The concrete case that surfaced this: `TMDB.UserApiKey` with `[EnvironmentVariable("TMDB_API_KEY")]`, where `settings-server.json` contained `"UserApiKey": null` written by a prior server run.

## Fix

Add an explicit `JTokenType.Null => "null"` arm to the switch so the snapshot round-trips correctly through `JToken.Parse`.