### PR TITLE
fix(tmdb): require exact title match for subtitle-stripped show searches

### DIFF
--- a/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -461,12 +462,15 @@ public partial class TmdbSearchService : ITmdbSearchService
         }
 
         // Brute force attempt #2: Same as above, but after stripping the title of common "sequel endings"
+        // Require an exact title match for the same reason as attempts #3/#5/#6: we stripped a suffix to
+        // derive the root-series name, so a TMDB result whose own title contains further content (e.g. a
+        // spinoff that has the root title as a prefix) is the wrong show.
         var strippedTitle = SequelSuffixRemovalRegex().Match(originalTitle) is { Success: true } regexResult
             ? originalTitle[..^regexResult.Length].TrimEnd() : null;
         if (!string.IsNullOrEmpty(strippedTitle))
         {
             (results, totalFound) = await SearchShowsRaw(strippedTitle, includeRestricted: restricted, year: airDate.Year).ConfigureAwait(false);
-            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
+            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()) && IsTitleMatch(strippedTitle, result.OriginalName, result.Name));
             if (firstViableResult is not null)
             {
                 _logger.LogTrace("Found {Count} show results for search on {Query}, best match; {ShowName} ({ID})", totalFound, strippedTitle, firstViableResult.OriginalName, firstViableResult.Id);
@@ -476,13 +480,17 @@ public partial class TmdbSearchService : ITmdbSearchService
         }
 
         // Brute force attempt #3: Same as above, but with stripped of any sub-titles.
+        // We require the TMDB result's original name to match the stripped query exactly: the whole
+        // point of stripping the subtitle is to find the *root* show. A result whose original name
+        // has its own subtitle beyond the query indicates a spinoff/side-story was ranked first by
+        // TMDB (e.g. searching 転生したらスライムだった件 and getting 転生したらスライムだった件 転スラ日記).
         var titleWithoutSubTitle = strippedTitle ?? originalTitle;
         var columIndex = titleWithoutSubTitle.IndexOf(isJapanese ? ' ' : ':');
         if (columIndex > 0)
         {
             titleWithoutSubTitle = titleWithoutSubTitle[..columIndex];
             (results, totalFound) = await SearchShowsRaw(titleWithoutSubTitle, includeRestricted: restricted, year: airDate.Year).ConfigureAwait(false);
-            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
+            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()) && IsTitleMatch(titleWithoutSubTitle, result.OriginalName, result.Name));
             if (firstViableResult is not null)
             {
                 _logger.LogTrace("Found {Count} show results for search on {Query}, best match; {ShowName} ({ID})", totalFound, titleWithoutSubTitle, firstViableResult.OriginalName, firstViableResult.Id);
@@ -505,7 +513,7 @@ public partial class TmdbSearchService : ITmdbSearchService
         if (!string.IsNullOrEmpty(strippedTitle))
         {
             (results, totalFound) = await SearchShowsRaw(strippedTitle, includeRestricted: restricted).ConfigureAwait(false);
-            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
+            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()) && IsTitleMatch(strippedTitle, result.OriginalName, result.Name));
             if (firstViableResult is not null)
             {
                 _logger.LogTrace("Found {Count} show results for search on {Query}, best match; {ShowName} ({ID})", totalFound, strippedTitle, firstViableResult.OriginalName, firstViableResult.Id);
@@ -521,7 +529,7 @@ public partial class TmdbSearchService : ITmdbSearchService
         {
             titleWithoutSubTitle = titleWithoutSubTitle[..columIndex];
             (results, totalFound) = await SearchShowsRaw(titleWithoutSubTitle, includeRestricted: restricted).ConfigureAwait(false);
-            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
+            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()) && IsTitleMatch(titleWithoutSubTitle, result.OriginalName, result.Name));
             if (firstViableResult is not null)
             {
                 _logger.LogTrace("Found {Count} show results for search on {Query}, best match; {ShowName} ({ID})", totalFound, titleWithoutSubTitle, firstViableResult.OriginalName, firstViableResult.Id);
@@ -538,6 +546,62 @@ public partial class TmdbSearchService : ITmdbSearchService
     #region Helpers
 
     private bool IsAnimation(IReadOnlyList<string> genres) => genres.Contains("animation", StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns true when at least one of the TMDB result titles is a normalized match for
+    /// <paramref name="query"/>. Used for subtitle-stripped searches where we specifically want the root
+    /// show — a result whose own title contains a subtitle beyond the query is a spinoff, not the root.
+    /// <para>
+    /// Normalization converts full-width punctuation to half-width (NFKC), folds the wave dash 〜 to a
+    /// space, and collapses whitespace, so minor encoding differences between AniDB and TMDB don't
+    /// prevent a valid match.
+    /// </para>
+    /// <para>
+    /// For mixed-script titles (e.g. <c>ONE PUNCH MAN ワンパンマン</c>) each space-delimited segment is
+    /// classified as CJK or Latin, and the CJK and Latin portions are each tried independently against
+    /// the result titles so that a TMDB entry whose original name is purely Japanese (or purely Latin)
+    /// can still be matched.
+    /// </para>
+    /// </summary>
+    private static bool IsTitleMatch(string query, string? originalName, string? localName)
+    {
+        var normalizedQuery = NormalizeTitle(query);
+        if (IsNormalizedMatch(normalizedQuery, originalName) || IsNormalizedMatch(normalizedQuery, localName))
+            return true;
+
+        // Mixed-script fallback: try matching the CJK and Latin portions separately.
+        var words = normalizedQuery.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var cjkPart = string.Join(' ', words.Where(ContainsCjk));
+        var latinPart = string.Join(' ', words.Where(w => !ContainsCjk(w)));
+        if (string.IsNullOrEmpty(cjkPart) || string.IsNullOrEmpty(latinPart))
+            return false; // not a mixed-script title; regular match already failed above
+
+        return IsNormalizedMatch(cjkPart, originalName) || IsNormalizedMatch(cjkPart, localName) ||
+               IsNormalizedMatch(latinPart, originalName) || IsNormalizedMatch(latinPart, localName);
+    }
+
+    private static bool IsNormalizedMatch(string normalizedQuery, string? title)
+        => title is not null && string.Equals(normalizedQuery, NormalizeTitle(title), StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Normalizes a title for comparison by applying NFKC (converts full-width ASCII punctuation and
+    /// letters to half-width), replacing the wave dash 〜 (U+301C) with a space, and collapsing runs
+    /// of whitespace.
+    /// </summary>
+    private static string NormalizeTitle(string title)
+    {
+        var normalized = title
+            .Normalize(NormalizationForm.FormKC)
+            .Replace('〜', ' ')   // wave dash 〜 → space (not converted by NFKC)
+            .Replace('　', ' ');  // ideographic space → regular space (belt-and-suspenders)
+        return string.Join(' ', normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    /// <summary>Returns true if <paramref name="word"/> contains any CJK, hiragana, or katakana character.</summary>
+    private static bool ContainsCjk(string word) => word.Any(c =>
+        c is >= '぀' and <= 'ヿ' or  // hiragana + katakana
+        >= '㐀' and <= '鿿' or        // CJK extension A + unified ideographs
+        >= '豈' and <= '﫿');          // CJK compatibility ideographs
 
     #endregion
 }

--- a/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
@@ -563,7 +563,7 @@ public partial class TmdbSearchService : ITmdbSearchService
     /// can still be matched.
     /// </para>
     /// </summary>
-    private static bool IsTitleMatch(string query, string? originalName, string? localName)
+    internal static bool IsTitleMatch(string query, string? originalName, string? localName)
     {
         var normalizedQuery = NormalizeTitle(query);
         if (IsNormalizedMatch(normalizedQuery, originalName) || IsNormalizedMatch(normalizedQuery, localName))
@@ -580,7 +580,7 @@ public partial class TmdbSearchService : ITmdbSearchService
                IsNormalizedMatch(latinPart, originalName) || IsNormalizedMatch(latinPart, localName);
     }
 
-    private static bool IsNormalizedMatch(string normalizedQuery, string? title)
+    internal static bool IsNormalizedMatch(string normalizedQuery, string? title)
         => title is not null && string.Equals(normalizedQuery, NormalizeTitle(title), StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
@@ -588,7 +588,7 @@ public partial class TmdbSearchService : ITmdbSearchService
     /// letters to half-width), replacing the wave dash 〜 (U+301C) with a space, and collapsing runs
     /// of whitespace.
     /// </summary>
-    private static string NormalizeTitle(string title)
+    internal static string NormalizeTitle(string title)
     {
         var normalized = title
             .Normalize(NormalizationForm.FormKC)
@@ -598,7 +598,7 @@ public partial class TmdbSearchService : ITmdbSearchService
     }
 
     /// <summary>Returns true if <paramref name="word"/> contains any CJK, hiragana, or katakana character.</summary>
-    private static bool ContainsCjk(string word) => word.Any(c =>
+    internal static bool ContainsCjk(string word) => word.Any(c =>
         c is >= '぀' and <= 'ヿ' or  // hiragana + katakana
         >= '㐀' and <= '鿿' or        // CJK extension A + unified ideographs
         >= '豈' and <= '﫿');          // CJK compatibility ideographs

--- a/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
@@ -1,0 +1,121 @@
+using Shoko.Server.Providers.TMDB;
+using Xunit;
+
+namespace Shoko.Tests.Providers.TMDB;
+
+public class TmdbNormalizeTitleTests
+{
+    [Fact]
+    public void PlainAscii_Unchanged()
+        => Assert.Equal("ONE PUNCH MAN", TmdbSearchService.NormalizeTitle("ONE PUNCH MAN"));
+
+    [Fact]
+    public void FullWidthExclamation_ConvertedToHalfWidth()
+        => Assert.Equal("Re:Zero!", TmdbSearchService.NormalizeTitle("Re:Zero！"));
+
+    [Fact]
+    public void WaveDash_ReplacedWithSpace()
+        => Assert.Equal("A B", TmdbSearchService.NormalizeTitle("A〜B"));
+
+    [Fact]
+    public void IdeographicSpace_ReplacedWithSpace()
+        => Assert.Equal("A B", TmdbSearchService.NormalizeTitle("A　B"));
+
+    [Fact]
+    public void MultipleSpaces_Collapsed()
+        => Assert.Equal("A B C", TmdbSearchService.NormalizeTitle("A   B  C"));
+
+    [Fact]
+    public void LeadingAndTrailingSpaces_Trimmed()
+        => Assert.Equal("Tensura", TmdbSearchService.NormalizeTitle("  Tensura  "));
+
+    [Fact]
+    public void MixedFullWidthAndWaveDash_BothNormalized()
+        => Assert.Equal("Sword Art Online!", TmdbSearchService.NormalizeTitle("Ｓｗｏｒｄ　Ａｒｔ　Ｏｎｌｉｎｅ！"));
+}
+
+public class TmdbIsTitleMatchTests
+{
+    // ── Exact / case-insensitive ──────────────────────────────────────────────
+
+    [Fact]
+    public void ExactMatch_ReturnsTrue()
+        => Assert.True(TmdbSearchService.IsTitleMatch("Tensura", "Tensura", null));
+
+    [Fact]
+    public void CaseInsensitiveMatch_ReturnsTrue()
+        => Assert.True(TmdbSearchService.IsTitleMatch("tensura", "TENSURA", null));
+
+    [Fact]
+    public void MatchAgainstLocalName_ReturnsTrue()
+        => Assert.True(TmdbSearchService.IsTitleMatch("Tensura", null, "Tensura"));
+
+    [Fact]
+    public void BothNamesNull_ReturnsFalse()
+        => Assert.False(TmdbSearchService.IsTitleMatch("Tensura", null, null));
+
+    [Fact]
+    public void NoMatch_ReturnsFalse()
+        => Assert.False(TmdbSearchService.IsTitleMatch("Tensura", "The Slime Diaries", null));
+
+    // ── Spinoff rejection (the motivating bug) ────────────────────────────────
+
+    [Fact]
+    public void SpinoffTitle_WithParentAsPrefix_ReturnsFalse()
+        => Assert.False(TmdbSearchService.IsTitleMatch(
+            "転生したらスライムだった件",
+            "転生したらスライムだった件 転スラ日記",
+            "The Slime Diaries: That Time I Got Reincarnated as a Slime"));
+
+    [Fact]
+    public void RootTitle_MatchesRootTmdbEntry_ReturnsTrue()
+        => Assert.True(TmdbSearchService.IsTitleMatch(
+            "転生したらスライムだった件",
+            "転生したらスライムだった件",
+            "That Time I Got Reincarnated as a Slime"));
+
+    // ── Punctuation normalization ─────────────────────────────────────────────
+
+    [Fact]
+    public void FullWidthPunctuation_InQuery_MatchesHalfWidth()
+        => Assert.True(TmdbSearchService.IsTitleMatch("Re:Zero！", "Re:Zero!", null));
+
+    [Fact]
+    public void FullWidthPunctuation_InCandidate_MatchesHalfWidth()
+        => Assert.True(TmdbSearchService.IsTitleMatch("Re:Zero!", "Re:Zero！", null));
+
+    [Fact]
+    public void WaveDash_InQuery_NormalizedBeforeMatch()
+        => Assert.True(TmdbSearchService.IsTitleMatch("A〜B", "A B", null));
+
+    // ── Mixed-script split ────────────────────────────────────────────────────
+
+    [Fact]
+    public void MixedScript_CjkPartMatchesOriginalName()
+        => Assert.True(TmdbSearchService.IsTitleMatch(
+            "ONE PUNCH MAN ワンパンマン",
+            "ワンパンマン",   // Japanese OriginalName
+            null));
+
+    [Fact]
+    public void MixedScript_LatinPartMatchesLocalName()
+        => Assert.True(TmdbSearchService.IsTitleMatch(
+            "ONE PUNCH MAN ワンパンマン",
+            null,
+            "ONE PUNCH MAN")); // English Name
+
+    [Fact]
+    public void MixedScript_NeitherPartMatches_ReturnsFalse()
+        => Assert.False(TmdbSearchService.IsTitleMatch(
+            "ONE PUNCH MAN ワンパンマン",
+            "Mob Psycho 100",
+            "モブサイコ100"));
+
+    [Fact]
+    public void PurelyLatinQuery_NoMixedScriptFallback_ReturnsFalse()
+        => Assert.False(TmdbSearchService.IsTitleMatch("ONE PUNCH MAN", "ワンパンマン", null));
+
+    [Fact]
+    public void PurelyJapaneseQuery_NoMixedScriptFallback_ReturnsFalse()
+        => Assert.False(TmdbSearchService.IsTitleMatch("ワンパンマン", "ONE PUNCH MAN", null));
+}


### PR DESCRIPTION
## Problem

`AutoSearchForShowUsingTitle` uses up to 6 TMDB search attempts, progressively stripping sequel suffixes and subtitles from the query to find the root show. However, attempts #2, #3, #5, and #6 accepted **any** animation result even when the top-ranked TMDB hit was a spinoff that happened to share a year and title prefix with the intended series.

Concrete example: searching for `転生したらスライムだった件` with year 2021 caused TMDB to return **The Slime Diaries** as the top result — it aired in 2021 and its full Japanese title contains the Tensura title as a prefix — even though the correct match is the root Tensura show.

## Fix

### 1. Title match guard (attempts #2, #3, #5, #6)

These four attempts strip sequel suffixes or subtitles specifically to search for the **root** show. A guard (`IsTitleMatch`) now requires that the TMDB result's `OriginalName` or `Name` exactly matches the stripped query before it is accepted.

Attempts #1 (full title + year) and #4 (full title, no year) are intentional broad fallbacks and are left unguarded.

The Slime Diaries is unaffected: its own full Japanese title (`転生したらスライムだった件 転スラ日記`) is looked up via attempt #1, which has no guard.

### 2. Punctuation normalization

AniDB and TMDB sometimes encode the same title with different Unicode punctuation (`!` vs `！`, ` ` vs `〜`). `NormalizeTitle` applies NFKC to convert full-width ASCII to half-width, then folds wave dash `〜` (U+301C — not covered by NFKC) to a space. Both the query and the candidate title are normalized before comparison.

### 3. Mixed-script title support

Some AniDB titles combine Latin and CJK in one string (e.g. `ONE PUNCH MAN ワンパンマン`). After stripping a sequel suffix the combined string matches neither TMDB's Japanese `OriginalName` nor its English `Name`. `IsTitleMatch` now extracts CJK and Latin word groups independently and tries each against both TMDB fields, so `ワンパンマン` can match a Japanese `OriginalName` and `ONE PUNCH MAN` can match an English `Name`.

## Testing

Verified on a local dev build:
- `転生したらスライムだった件 (2021)` → correctly resolves to Tensura (not The Slime Diaries)
- `転スラ日記` (The Slime Diaries itself) → still resolves correctly via attempt #1
- Existing xrefs (shows already linked to TMDB) bypass the search entirely — no regressions expected for those