### PR TITLE
feat(tmdb,search): collect top-N candidates and score by title, date, and season

### DIFF
--- a/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
@@ -301,6 +301,7 @@ public partial class TmdbSearchService : ITmdbSearchService
                 (true, _, true)  => MatchRating.DateAndTitleMatches,
                 (true, _, false) => MatchRating.TitleMatches,
                 (_, true, true)  => MatchRating.DateAndTitleKindaMatches,
+                (_, _, true)     => MatchRating.DateMatches,
                 (_, true, false) => MatchRating.TitleKindaMatches,
                 _                => MatchRating.FirstAvailable,
             };
@@ -310,6 +311,10 @@ public partial class TmdbSearchService : ITmdbSearchService
                 "Candidate movie {MovieName} ({ID}): rating={Rating}, releaseYear={ReleaseYear}",
                 full.Title, full.Id, rating, full.ReleaseDate?.Year
             );
+
+            // Maximum confidence — no other candidate can outscore this, so skip remaining fetches.
+            if (rating is MatchRating.DateAndTitleMatches)
+                break;
         }
 
         // If all GetMovieAsync calls returned null (transient outage), fall back to the first candidate
@@ -677,6 +682,7 @@ public partial class TmdbSearchService : ITmdbSearchService
                 (true, _, true)  => MatchRating.DateAndTitleMatches,
                 (true, _, false) => MatchRating.TitleMatches,
                 (_, true, true)  => MatchRating.DateAndTitleKindaMatches,
+                (_, _, true)     => MatchRating.DateMatches,
                 (_, true, false) => MatchRating.TitleKindaMatches,
                 _                => MatchRating.FirstAvailable,
             };
@@ -686,6 +692,10 @@ public partial class TmdbSearchService : ITmdbSearchService
                 "Candidate show {ShowName} ({ID}): rating={Rating}, bestSeasonEpisodeDiff={EpisodeDiff}, seasonYearMatch={SeasonYearMatch}",
                 full.Name, full.Id, rating, bestSeasonEpisodeDiff, seasonYearMatch
             );
+
+            // Maximum confidence — no other candidate can outscore this, so skip remaining fetches.
+            if (rating is MatchRating.DateAndTitleMatches)
+                break;
         }
 
         // If all GetTvShowAsync calls returned null (transient outage), fall back to the first candidate

--- a/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
@@ -6,14 +6,18 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Shoko.Abstractions.Extensions;
+using Shoko.Abstractions.Filtering.Services;
 using Shoko.Abstractions.Metadata;
 using Shoko.Abstractions.Metadata.Anidb;
 using Shoko.Abstractions.Metadata.Enums;
 using Shoko.Abstractions.Metadata.Tmdb;
 using Shoko.Abstractions.Metadata.Tmdb.Services;
 using Shoko.Server.Models.AniDB;
+using Shoko.Server.Settings;
+using Shoko.Server.Utilities;
 using TMDbLib.Objects.General;
 using TMDbLib.Objects.Search;
+using TMDbLib.Objects.TvShows;
 
 #nullable enable
 namespace Shoko.Server.Providers.TMDB;
@@ -24,22 +28,28 @@ public partial class TmdbSearchService : ITmdbSearchService
     /// <summary>
     /// This regex might save the day if the local database doesn't contain any prequel metadata, but the title itself contains a suffix that indicates it's a sequel of sorts.
     /// </summary>
-    [GeneratedRegex(@"\(\d{4}\)$|\bs(?:eason)? (?:\d+|(?=[MDCLXVI])M*(?:C[MD]|D?C{0,3})(X[CL]|L?X{0,3})(I[XV]|V?I{0,3}))$|\bs\d+$|第(零〇一二三四五六七八九十百千萬億兆京垓點)+季$|\b(?:second|2nd|third|3rd|fourth|4th|fifth|5th|sixth|6th) season$", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Multiline)]
+    [GeneratedRegex(@"\(\d{4}\)$|\bs(?:eason)? (?:\d+|(?=[MDCLXVI])M*(?:C[MD]|D?C{0,3})(X[CL]|L?X{0,3})(I[XV]|V?I{0,3}))$|\bs\d+$|第(零〇一二三四五六七八九十百千萬億兆京垓點)+[季期]$|\b(?:second|2nd|third|3rd|fourth|4th|fifth|5th|sixth|6th) season$", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Multiline)]
     private partial Regex SequelSuffixRemovalRegex();
 
     private readonly ILogger<TmdbSearchService> _logger;
 
     private readonly TmdbMetadataService _tmdbService;
 
+    private readonly IFuzzySearchService _fuzzySearch;
+
+    private readonly ISettingsProvider _settingsProvider;
+
     /// <summary>
     /// Max days into the future to search for matches against.
     /// </summary>
     private readonly TimeSpan _maxDaysIntoTheFuture = TimeSpan.FromDays(15);
 
-    public TmdbSearchService(ILogger<TmdbSearchService> logger, TmdbMetadataService tmdbService)
+    public TmdbSearchService(ILogger<TmdbSearchService> logger, TmdbMetadataService tmdbService, IFuzzySearchService fuzzySearch, ISettingsProvider settingsProvider)
     {
         _logger = logger;
         _tmdbService = tmdbService;
+        _fuzzySearch = fuzzySearch;
+        _settingsProvider = settingsProvider;
     }
 
     async Task<IReadOnlyList<ITmdbAutoSearchResult>> ITmdbSearchService.SearchForAutoMatch(IAnidbAnime anime)
@@ -225,50 +235,97 @@ public partial class TmdbSearchService : ITmdbSearchService
 
     private async Task<TmdbAutoSearchResult?> AutoSearchMovieUsingTitle(AniDB_Anime anime, AniDB_Episode episode, string query, bool includeRestricted = false, int year = 0)
     {
-        // Brute force attempt #1: With the original title and earliest known aired year.
-        var (results, totalCount) = await SearchMoviesRaw(query, includeRestricted: includeRestricted, year: year).ConfigureAwait(false);
-        var firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
-        if (firstViableResult is not null)
-        {
-            _logger.LogTrace("Found {Count} movie results for search on {Query}, best match; {MovieName} ({ID})", totalCount, query, firstViableResult.OriginalTitle, firstViableResult.Id);
+        var candidateCount = _settingsProvider.GetSettings().TMDB.AutoSearchMovieCandidateCount;
+        var seen = new HashSet<int>();
+        var candidates = new List<SearchMovie>();
 
-            return new(anime, episode, firstViableResult) { IsRemote = true };
-        }
+        List<SearchMovie> results;
 
-        // Brute force attempt #2: With the original title but without the earliest known aired year.
-        (results, totalCount) = await SearchMoviesRaw(query, includeRestricted: includeRestricted).ConfigureAwait(false);
-        firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
-        if (firstViableResult is not null)
-        {
-            _logger.LogTrace("Found {Count} movie results for search on {Query}, best match; {MovieName} ({ID})", totalCount, query, firstViableResult.OriginalTitle, firstViableResult.Id);
+        // Attempt #1: full title + year
+        (results, _) = await SearchMoviesRaw(query, includeRestricted: includeRestricted, year: year).ConfigureAwait(false);
+        CollectMovieCandidates(candidates, results, seen, candidateCount);
 
-            return new(anime, episode, firstViableResult) { IsRemote = true };
-        }
-
-        // Brute force attempt #3-4: Same as above, but after stripping the title of common "sequel endings"
+        // Attempt #2: sequel-suffix stripped + year
         var strippedTitle = SequelSuffixRemovalRegex().Match(query) is { Success: true } regexResult
             ? query[..^regexResult.Length].TrimEnd() : null;
-        if (!string.IsNullOrEmpty(strippedTitle))
+        if (!string.IsNullOrEmpty(strippedTitle) && candidates.Count < candidateCount)
         {
-            (results, totalCount) = await SearchMoviesRaw(strippedTitle, includeRestricted: includeRestricted, year: year).ConfigureAwait(false);
-            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
-            if (firstViableResult is not null)
-            {
-                _logger.LogTrace("Found {Count} movie results for search on {Query}, best match; {MovieName} ({ID})", totalCount, strippedTitle, firstViableResult.OriginalTitle, firstViableResult.Id);
-
-                return new(anime, episode, firstViableResult) { IsRemote = true };
-            }
-            (results, totalCount) = await SearchMoviesRaw(strippedTitle, includeRestricted: includeRestricted).ConfigureAwait(false);
-            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
-            if (firstViableResult is not null)
-            {
-                _logger.LogTrace("Found {Count} movie results for search on {Query}, best match; {MovieName} ({ID})", totalCount, strippedTitle, firstViableResult.OriginalTitle, firstViableResult.Id);
-
-                return new(anime, episode, firstViableResult) { IsRemote = true };
-            }
+            (results, _) = await SearchMoviesRaw(strippedTitle, includeRestricted: includeRestricted, year: year).ConfigureAwait(false);
+            CollectMovieCandidates(candidates, results, seen, candidateCount);
         }
 
-        return null;
+        // Attempts #3–4: year-free fallbacks mirroring #1–2.
+        // Always run regardless of year-filtered candidate count — TMDB's year filter uses
+        // release_date.year, so a movie whose AniDB air date differs from TMDB release year
+        // will be missed entirely by year-filtered searches.
+        var yearFreeCap = candidateCount * 2;
+
+        (results, _) = await SearchMoviesRaw(query, includeRestricted: includeRestricted).ConfigureAwait(false);
+        CollectMovieCandidates(candidates, results, seen, yearFreeCap);
+
+        if (!string.IsNullOrEmpty(strippedTitle) && candidates.Count < yearFreeCap)
+        {
+            (results, _) = await SearchMoviesRaw(strippedTitle, includeRestricted: includeRestricted).ConfigureAwait(false);
+            CollectMovieCandidates(candidates, results, seen, yearFreeCap);
+        }
+
+        if (candidates.Count == 0)
+            return null;
+
+        var scored = new List<(SearchMovie raw, MatchRating rating)>();
+        foreach (var candidate in candidates)
+        {
+            var full = await _tmdbService.UseClient(
+                c => c.GetMovieAsync(candidate.Id, "en-US", null, TMDbLib.Objects.Movies.MovieMethods.Translations | TMDbLib.Objects.Movies.MovieMethods.ReleaseDates),
+                $"Fetch candidate movie {candidate.Id} \"{candidate.OriginalTitle}\" for auto-match scoring"
+            ).ConfigureAwait(false);
+            if (full is null) continue;
+
+            var allTitles = new HashSet<string>(
+                new[] { (string?)full.Title, full.OriginalTitle }
+                    .Concat(full.Translations?.Translations?.Select(t => (string?)t.Data?.Name).WhereNotNull() ?? [])
+                    .WhereNotNull()
+                    .Where(s => !string.IsNullOrWhiteSpace(s))
+            );
+
+            var titleMatch = ScoreQueryVariants([query, strippedTitle], allTitles);
+            var exactTitle = titleMatch is MatchRating.TitleMatches;
+            var fuzzyTitle = titleMatch is MatchRating.TitleKindaMatches;
+            var dateMatch = year > 0 && (
+                full.ReleaseDate?.Year == year ||
+                (full.ReleaseDates?.Results?.Any(r => r.ReleaseDates?.Any(rd => rd.ReleaseDate.Year == year) ?? false) ?? false)
+            );
+
+            var rating = (exactTitle, fuzzyTitle, dateMatch) switch
+            {
+                (true, _, true)  => MatchRating.DateAndTitleMatches,
+                (true, _, false) => MatchRating.TitleMatches,
+                (_, true, true)  => MatchRating.DateAndTitleKindaMatches,
+                (_, true, false) => MatchRating.TitleKindaMatches,
+                _                => MatchRating.FirstAvailable,
+            };
+
+            scored.Add((candidate, rating));
+            _logger.LogTrace(
+                "Candidate movie {MovieName} ({ID}): rating={Rating}, releaseYear={ReleaseYear}",
+                full.Title, full.Id, rating, full.ReleaseDate?.Year
+            );
+        }
+
+        // If all GetMovieAsync calls returned null (transient outage), fall back to the first candidate
+        // at lowest confidence rather than returning null when TMDB did return search results.
+        if (scored.Count == 0)
+            return new(anime, episode, candidates[0]) { IsRemote = true };
+
+        var best = scored
+            .OrderBy(x => ShowMatchPriority(x.rating))
+            .First();
+
+        _logger.LogInformation(
+            "Best match for \"{Query}\": {MovieName} ({ID}) rating={Rating}",
+            query, best.raw.OriginalTitle, best.raw.Id, best.rating
+        );
+        return new(anime, episode, best.raw, best.rating) { IsRemote = true };
     }
 
     #endregion
@@ -402,35 +459,64 @@ public partial class TmdbSearchService : ITmdbSearchService
         // And the last ditch attempt will be to use the main title. We won't try other languages.
         match ??= await AutoSearchForShowUsingTitle(anime, mainTitle.Value, airDate.Value, series.Restricted, false);
 
+        // When the prequel chain was followed, the searches above used the ROOT series title.
+        // If the current anime is a separate TMDB entry (e.g. "Fairy Tail: 100 Years Quest"
+        // is its own TMDB show, not a season of base Fairy Tail), the root-title search will
+        // return the wrong show. Try the current anime's own main title and prefer the result
+        // if it scores better. When the own title wins, treat it as if no prequel was followed
+        // so the root series' stored xrefs are not added as additional matches below.
+        var prequelFollowed = series.ID != anime.AnimeID;
+        if (prequelFollowed)
+        {
+            TmdbAutoSearchResult? ownTitleMatch = null;
+
+            // Try the current anime's own original title first, before falling back to the main title.
+            var ownOriginalTitle = language == mainTitle.Language
+                ? mainTitle.Value
+                : allTitles.FirstOrDefault(t => t.Type is TitleType.Official && t.Language == language)?.Value;
+            if (!string.IsNullOrEmpty(ownOriginalTitle) && !string.Equals(ownOriginalTitle, originalTitle, StringComparison.Ordinal))
+                ownTitleMatch = await AutoSearchForShowUsingTitle(anime, ownOriginalTitle, airDate.Value, anime.IsRestricted, language == TitleLanguage.Japanese).ConfigureAwait(false);
+
+            if (ownTitleMatch is null && !string.Equals(mainTitle.Value, originalTitle, StringComparison.Ordinal) && !string.Equals(mainTitle.Value, ownOriginalTitle, StringComparison.Ordinal))
+                ownTitleMatch = await AutoSearchForShowUsingTitle(anime, mainTitle.Value, airDate.Value, anime.IsRestricted, false).ConfigureAwait(false);
+
+            if (ownTitleMatch is not null && (match is null || ShowMatchPriority(ownTitleMatch.MatchRating) < ShowMatchPriority(match.MatchRating)))
+            {
+                match = ownTitleMatch;
+                prequelFollowed = false;
+            }
+        }
+
         // Also add all locally known matches for the current anime and first prequel anime if available.
         var existingXrefs = anime.TmdbShowCrossReferences.ToList();
-        if (series.ID != anime.AnimeID && series is AniDB_Anime secondAnime && secondAnime.TmdbShowCrossReferences is { Count: > 0 } seriesXrefs)
+        if (prequelFollowed && series is AniDB_Anime secondAnime && secondAnime.TmdbShowCrossReferences is { Count: > 0 } seriesXrefs)
             existingXrefs.AddRange(seriesXrefs);
         if (existingXrefs is { Count: > 0 })
         {
             var remoteSeries = existingXrefs
                 .DistinctBy(x => x.TmdbShowID)
-                .Select(x => x.TmdbShow)
-                .WhereNotNull()
-                .Select(x => new TmdbAutoSearchResult(
+                .Select(x => (xref: x, show: x.TmdbShow))
+                .Where(pair => pair.show is not null)
+                .Select(pair => new TmdbAutoSearchResult(
                     anime,
                     new()
                     {
-                        Id = x.Id,
-                        OriginalName = x.OriginalTitle,
-                        Name = x.EnglishTitle,
-                        FirstAirDate = x.FirstAiredAt?.ToDateTime(),
-                        BackdropPath = x.BackdropPath,
+                        Id = pair.show!.Id,
+                        OriginalName = pair.show.OriginalTitle,
+                        Name = pair.show.EnglishTitle,
+                        FirstAirDate = pair.show.FirstAiredAt?.ToDateTime(),
+                        BackdropPath = pair.show.BackdropPath,
                         GenreIds = [],
                         MediaType = MediaType.Tv,
-                        OriginalLanguage = x.OriginalLanguageCode,
-                        OriginCountry = x.TmdbCompanies.Select(x => x.CountryOfOrigin).Distinct().ToList(),
-                        Overview = x.EnglishOverview,
-                        PosterPath = x.PosterPath,
-                        Popularity = x.UserRating,
-                        VoteAverage = x.UserRating,
-                        VoteCount = x.UserVotes,
-                    }
+                        OriginalLanguage = pair.show.OriginalLanguageCode,
+                        OriginCountry = pair.show.TmdbCompanies.Select(c => c.CountryOfOrigin).Distinct().ToList(),
+                        Overview = pair.show.EnglishOverview,
+                        PosterPath = pair.show.PosterPath,
+                        Popularity = pair.show.UserRating,
+                        VoteAverage = pair.show.UserRating,
+                        VoteCount = pair.show.UserVotes,
+                    },
+                    pair.xref.MatchRating
                 )
                 {
                     IsLocal = true,
@@ -450,94 +536,220 @@ public partial class TmdbSearchService : ITmdbSearchService
 
     private async Task<TmdbAutoSearchResult?> AutoSearchForShowUsingTitle(AniDB_Anime anime, string originalTitle, DateTime airDate, bool restricted, bool isJapanese)
     {
-        // Brute force attempt #1: With the original title and earliest known aired year.
-        var (results, totalFound) = await SearchShowsRaw(originalTitle, includeRestricted: restricted, year: airDate.Year).ConfigureAwait(false);
-        var firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
-        if (firstViableResult is not null)
-        {
-            _logger.LogTrace("Found {Count} show results for search on {Query}, best match; {ShowName} ({ID})", totalFound, originalTitle, firstViableResult.OriginalName, firstViableResult.Id);
+        var candidateCount = _settingsProvider.GetSettings().TMDB.AutoSearchShowCandidateCount;
+        var seen = new HashSet<int>();
+        var candidates = new List<SearchTv>();
 
-            return new(anime, firstViableResult) { IsRemote = true };
-        }
+        List<SearchTv> results;
 
-        // Brute force attempt #2: Same as above, but after stripping the title of common "sequel endings"
+        // Attempt #1: full title + year
+        (results, _) = await SearchShowsRaw(originalTitle, includeRestricted: restricted, year: airDate.Year).ConfigureAwait(false);
+        CollectCandidates(candidates, results, seen, candidateCount);
+
+        // Attempt #2: sequel-suffix stripped + year
         var strippedTitle = SequelSuffixRemovalRegex().Match(originalTitle) is { Success: true } regexResult
             ? originalTitle[..^regexResult.Length].TrimEnd() : null;
-        if (!string.IsNullOrEmpty(strippedTitle))
+        if (!string.IsNullOrEmpty(strippedTitle) && candidates.Count < candidateCount)
         {
-            (results, totalFound) = await SearchShowsRaw(strippedTitle, includeRestricted: restricted, year: airDate.Year).ConfigureAwait(false);
-            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
-            if (firstViableResult is not null)
+            (results, _) = await SearchShowsRaw(strippedTitle, includeRestricted: restricted, year: airDate.Year).ConfigureAwait(false);
+            CollectCandidates(candidates, results, seen, candidateCount);
+        }
+
+        // Attempt #3: subtitle stripped + year.
+        // Compute the subtitle-stripped form once; it is also used by the scoring loop below.
+        // It is only fuzzy-eligible (prefix/edit-distance), not exact-eligible — a parent show
+        // matching via its short title (e.g. "Fairy Tail" from "Fairy Tail: 100 Years Quest")
+        // must not score as high as the specific entry that exact-matches the full title.
+        var baseForSubtitle = strippedTitle ?? originalTitle;
+        var colonIndex = baseForSubtitle.IndexOf(isJapanese ? ' ' : ':');
+        var titleWithoutSubTitle = colonIndex > 0 ? baseForSubtitle[..colonIndex] : null;
+        if (!string.IsNullOrEmpty(titleWithoutSubTitle) && candidates.Count < candidateCount)
+        {
+            (results, _) = await SearchShowsRaw(titleWithoutSubTitle, includeRestricted: restricted, year: airDate.Year).ConfigureAwait(false);
+            CollectCandidates(candidates, results, seen, candidateCount);
+        }
+
+        // Attempts #4–6: year-free fallbacks mirroring #1–3.
+        // These always run regardless of how many year-filtered candidates were collected, because
+        // a multi-season show's first_air_date predates the current season year and will never
+        // appear in year-filtered results (e.g. TenSura S2 2021 vs. main show premiered 2018).
+        // The doubled cap (×2) lets year-free results fill more of the pool — root shows tend to
+        // rank lower in unfiltered searches so a slightly larger window reduces missed matches.
+        var yearFreeCap = candidateCount * 2;
+
+        (results, _) = await SearchShowsRaw(originalTitle, includeRestricted: restricted).ConfigureAwait(false);
+        CollectCandidates(candidates, results, seen, yearFreeCap);
+
+        if (!string.IsNullOrEmpty(strippedTitle) && candidates.Count < yearFreeCap)
+        {
+            (results, _) = await SearchShowsRaw(strippedTitle, includeRestricted: restricted).ConfigureAwait(false);
+            CollectCandidates(candidates, results, seen, yearFreeCap);
+        }
+
+        if (!string.IsNullOrEmpty(titleWithoutSubTitle) && candidates.Count < yearFreeCap)
+        {
+            (results, _) = await SearchShowsRaw(titleWithoutSubTitle, includeRestricted: restricted).ConfigureAwait(false);
+            CollectCandidates(candidates, results, seen, yearFreeCap);
+        }
+
+        if (candidates.Count == 0)
+            return null;
+
+        // Fetch each candidate in full to get translated titles and per-season data, then score.
+        // show.Seasons is included in the base GetTvShowAsync response (no extra per-season fetches needed).
+        var scored = new List<(SearchTv raw, MatchRating rating, int bestSeasonEpisodeDiff)>();
+        foreach (var candidate in candidates)
+        {
+            var full = await _tmdbService.UseClient(
+                c => c.GetTvShowAsync(candidate.Id, TvShowMethods.Translations),
+                $"Fetch candidate show {candidate.Id} \"{candidate.OriginalName}\" for auto-match scoring"
+            ).ConfigureAwait(false);
+            if (full is null) continue;
+
+            var allTitles = new HashSet<string>(
+                new[] { full.Name, full.OriginalName }
+                    .Concat(full.Translations?.Translations?.Select(t => (string?)t.Data?.Name).WhereNotNull() ?? [])
+                    .WhereNotNull()
+                    .Where(s => !string.IsNullOrWhiteSpace(s))
+            );
+
+            // ScoreQueryVariants is exact-eligible; the subtitle-stripped fallback below is fuzzy-only
+            // so a parent title (e.g. "Fairy Tail") cannot outrank the specific entry that exact-matches the full title.
+            var titleMatch = ScoreQueryVariants([originalTitle, strippedTitle], allTitles);
+            if (titleMatch == MatchRating.None && !string.IsNullOrEmpty(titleWithoutSubTitle) &&
+                (PrefixMatchesAnyName(titleWithoutSubTitle, allTitles) ||
+                 _fuzzySearch.FuzzyScoreAnyName(titleWithoutSubTitle, allTitles) is { isNotExact: true }))
+                titleMatch = MatchRating.TitleKindaMatches;
+            var exactTitle = titleMatch is MatchRating.TitleMatches;
+            var fuzzyTitle = titleMatch is MatchRating.TitleKindaMatches;
+
+            // Match against individual seasons rather than the show's total episode count.
+            // A season whose air year and episode count align with the AniDB anime is strong evidence
+            // we have the right show — e.g. AoT S3P2 (10 eps, 2019) matches TMDB season 3 of Attack on
+            // Titan, not the show total (~75 eps).
+            var nonSpecialSeasons = full.Seasons?.Where(s => s.SeasonNumber > 0).ToList() ?? [];
+            var bestSeason = nonSpecialSeasons
+                .OrderBy(s => Math.Abs(anime.EpisodeCountNormal - s.EpisodeCount))
+                .ThenBy(s => s.AirDate?.Year == airDate.Year ? 0 : 1)
+                .FirstOrDefault();
+            var bestSeasonEpisodeDiff = bestSeason is not null
+                ? Math.Abs(anime.EpisodeCountNormal - bestSeason.EpisodeCount)
+                : int.MaxValue;
+            var seasonYearMatch = bestSeason?.AirDate?.Year == airDate.Year;
+
+            // Date match: prefer season-level year alignment, fall back to show first-air year.
+            var dateMatch = seasonYearMatch || full.FirstAirDate?.Year == airDate.Year;
+
+            var rating = (exactTitle, fuzzyTitle, dateMatch) switch
             {
-                _logger.LogTrace("Found {Count} show results for search on {Query}, best match; {ShowName} ({ID})", totalFound, strippedTitle, firstViableResult.OriginalName, firstViableResult.Id);
+                (true, _, true)  => MatchRating.DateAndTitleMatches,
+                (true, _, false) => MatchRating.TitleMatches,
+                (_, true, true)  => MatchRating.DateAndTitleKindaMatches,
+                (_, true, false) => MatchRating.TitleKindaMatches,
+                _                => MatchRating.FirstAvailable,
+            };
 
-                return new(anime, firstViableResult) { IsRemote = true };
-            }
+            scored.Add((candidate, rating, bestSeasonEpisodeDiff));
+            _logger.LogTrace(
+                "Candidate show {ShowName} ({ID}): rating={Rating}, bestSeasonEpisodeDiff={EpisodeDiff}, seasonYearMatch={SeasonYearMatch}",
+                full.Name, full.Id, rating, bestSeasonEpisodeDiff, seasonYearMatch
+            );
         }
 
-        // Brute force attempt #3: Same as above, but with stripped of any sub-titles.
-        var titleWithoutSubTitle = strippedTitle ?? originalTitle;
-        var columIndex = titleWithoutSubTitle.IndexOf(isJapanese ? ' ' : ':');
-        if (columIndex > 0)
-        {
-            titleWithoutSubTitle = titleWithoutSubTitle[..columIndex];
-            (results, totalFound) = await SearchShowsRaw(titleWithoutSubTitle, includeRestricted: restricted, year: airDate.Year).ConfigureAwait(false);
-            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
-            if (firstViableResult is not null)
-            {
-                _logger.LogTrace("Found {Count} show results for search on {Query}, best match; {ShowName} ({ID})", totalFound, titleWithoutSubTitle, firstViableResult.OriginalName, firstViableResult.Id);
+        // If all GetTvShowAsync calls returned null (transient outage), fall back to the first candidate
+        // at lowest confidence rather than returning null when TMDB did return search results.
+        if (scored.Count == 0)
+            return new(anime, candidates[0]) { IsRemote = true };
 
-                return new(anime, firstViableResult) { IsRemote = true };
-            }
-        }
+        // Kinda values (TitleKindaMatches=7, DateAndTitleKindaMatches=8) are numerically above
+        // FirstAvailable=5, so sort by an ordinal priority mapping instead of the raw enum value.
+        var best = scored
+            .OrderBy(x => ShowMatchPriority(x.rating))
+            .ThenBy(x => x.bestSeasonEpisodeDiff)
+            .First();
 
-        // Brute force attempt #4: With the original title but without the earliest known aired year.
-        (results, totalFound) = await SearchShowsRaw(originalTitle, includeRestricted: restricted).ConfigureAwait(false);
-        firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
-        if (firstViableResult is not null)
-        {
-            _logger.LogTrace("Found {Count} show results for search on {Query}, best match; {ShowName} ({ID})", totalFound, originalTitle, firstViableResult.OriginalName, firstViableResult.Id);
-
-            return new(anime, firstViableResult) { IsRemote = true };
-        }
-
-        // Brute force attempt #5: Same as above, but after stripping the title of common "sequel endings"
-        if (!string.IsNullOrEmpty(strippedTitle))
-        {
-            (results, totalFound) = await SearchShowsRaw(strippedTitle, includeRestricted: restricted).ConfigureAwait(false);
-            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
-            if (firstViableResult is not null)
-            {
-                _logger.LogTrace("Found {Count} show results for search on {Query}, best match; {ShowName} ({ID})", totalFound, strippedTitle, firstViableResult.OriginalName, firstViableResult.Id);
-
-                return new(anime, firstViableResult) { IsRemote = true };
-            }
-        }
-
-        // Brute force attempt #6: Same as above, but with stripped of any sub-titles.
-        titleWithoutSubTitle = strippedTitle ?? originalTitle;
-        columIndex = titleWithoutSubTitle.IndexOf(isJapanese ? ' ' : ':');
-        if (columIndex > 0)
-        {
-            titleWithoutSubTitle = titleWithoutSubTitle[..columIndex];
-            (results, totalFound) = await SearchShowsRaw(titleWithoutSubTitle, includeRestricted: restricted).ConfigureAwait(false);
-            firstViableResult = results.FirstOrDefault(result => IsAnimation(result.GetGenres()));
-            if (firstViableResult is not null)
-            {
-                _logger.LogTrace("Found {Count} show results for search on {Query}, best match; {ShowName} ({ID})", totalFound, titleWithoutSubTitle, firstViableResult.OriginalName, firstViableResult.Id);
-
-                return new(anime, firstViableResult) { IsRemote = true };
-            }
-        }
-
-        return null;
+        _logger.LogInformation(
+            "Best match for \"{Query}\": {ShowName} ({ID}) rating={Rating}",
+            originalTitle, best.raw.OriginalName, best.raw.Id, best.rating
+        );
+        return new(anime, best.raw, best.rating) { IsRemote = true };
     }
 
     #endregion
 
     #region Helpers
 
+    private static int ShowMatchPriority(MatchRating r) => r switch
+    {
+        MatchRating.UserVerified             => 0,
+        MatchRating.DateAndTitleMatches      => 1,
+        MatchRating.TitleMatches             => 2,
+        MatchRating.DateAndTitleKindaMatches => 3,
+        MatchRating.DateMatches              => 4,
+        MatchRating.TitleKindaMatches        => 5,
+        _                                    => 6,
+    };
+
+    private static void CollectCandidates(List<SearchTv> candidates, List<SearchTv> results, HashSet<int> seen, int candidateCount)
+    {
+        foreach (var result in results)
+        {
+            if (candidates.Count >= candidateCount) break;
+            if (!seen.Add(result.Id)) continue;
+            if (!result.GetGenres().Contains("animation", StringComparer.OrdinalIgnoreCase)) continue;
+            candidates.Add(result);
+        }
+    }
+
+    private static void CollectMovieCandidates(List<SearchMovie> candidates, List<SearchMovie> results, HashSet<int> seen, int candidateCount)
+    {
+        foreach (var result in results)
+        {
+            if (candidates.Count >= candidateCount) break;
+            if (!seen.Add(result.Id)) continue;
+            if (!result.GetGenres().Contains("animation", StringComparer.OrdinalIgnoreCase)) continue;
+            candidates.Add(result);
+        }
+    }
+
     private bool IsAnimation(IReadOnlyList<string> genres) => genres.Contains("animation", StringComparer.OrdinalIgnoreCase);
+
+    private static bool ExactMatchesAnyName(string query, IReadOnlySet<string> names)
+    {
+        var normalizedQuery = SeriesSearch.NormalizeForIndex(query);
+        return !string.IsNullOrWhiteSpace(normalizedQuery) &&
+            names.Where(name => !string.IsNullOrWhiteSpace(name))
+                .Any(name => string.Equals(normalizedQuery, SeriesSearch.NormalizeForIndex(name), StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool PrefixMatchesAnyName(string query, IReadOnlySet<string> names)
+    {
+        var normalizedQuery = SeriesSearch.NormalizeForIndex(query);
+        if (string.IsNullOrWhiteSpace(normalizedQuery))
+            return false;
+        // Whole-word boundary: query must be followed by a space or be the entire name.
+        return names.Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(SeriesSearch.NormalizeForIndex)
+            .Any(normalizedName =>
+                normalizedName.StartsWith(normalizedQuery, StringComparison.OrdinalIgnoreCase) &&
+                (normalizedName.Length == normalizedQuery.Length || normalizedName[normalizedQuery.Length] == ' '));
+    }
+
+    private MatchRating ScoreQueryVariants(IReadOnlyList<string?> queryVariants, IReadOnlySet<string> names)
+    {
+        var result = MatchRating.None;
+        foreach (var variant in queryVariants)
+        {
+            if (string.IsNullOrEmpty(variant))
+                continue;
+            if (ExactMatchesAnyName(variant, names))
+                return MatchRating.TitleMatches;
+            if (result is MatchRating.None &&
+                (_fuzzySearch.FuzzyScoreAnyName(variant, names) is { isNotExact: true } || PrefixMatchesAnyName(variant, names)))
+                result = MatchRating.TitleKindaMatches;
+        }
+        return result;
+    }
 
     #endregion
 }

--- a/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
@@ -282,8 +282,8 @@ public partial class TmdbSearchService : ITmdbSearchService
             if (full is null) continue;
 
             var allTitles = new HashSet<string>(
-                new[] { (string?)full.Title, full.OriginalTitle }
-                    .Concat(full.Translations?.Translations?.Select(t => (string?)t.Data?.Name).WhereNotNull() ?? [])
+                new[] { full.Title, full.OriginalTitle }
+                    .Concat(full.Translations?.Translations?.Select(t => t.Data?.Name).WhereNotNull() ?? [])
                     .WhereNotNull()
                     .Where(s => !string.IsNullOrWhiteSpace(s))
             );
@@ -608,7 +608,7 @@ public partial class TmdbSearchService : ITmdbSearchService
 
             var allTitles = new HashSet<string>(
                 new[] { full.Name, full.OriginalName }
-                    .Concat(full.Translations?.Translations?.Select(t => (string?)t.Data?.Name).WhereNotNull() ?? [])
+                    .Concat(full.Translations?.Translations?.Select(t => t.Data?.Name).WhereNotNull() ?? [])
                     .WhereNotNull()
                     .Where(s => !string.IsNullOrWhiteSpace(s))
             );

--- a/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
@@ -595,6 +595,15 @@ public partial class TmdbSearchService : ITmdbSearchService
         if (candidates.Count == 0)
             return null;
 
+        // AniDB episode 1's specific air date, used only for the episode-level date check below.
+        // Nullable — when absent, the episode-level check is skipped entirely rather than falling
+        // back to anime.AirDate, which is a series-level date and not the right point of truth
+        // for an episode-to-episode comparison.
+        var anidbEp1Date = anime.AniDBEpisodes
+            .Where(e => e.EpisodeType is EpisodeType.Episode && e.EpisodeNumber == 1)
+            .Select(e => e.GetAirDateAsDate())
+            .FirstOrDefault();
+
         // Fetch each candidate in full to get translated titles and per-season data, then score.
         // show.Seasons is included in the base GetTvShowAsync response (no extra per-season fetches needed).
         var scored = new List<(SearchTv raw, MatchRating rating, int bestSeasonEpisodeDiff)>();
@@ -639,6 +648,29 @@ public partial class TmdbSearchService : ITmdbSearchService
 
             // Date match: prefer season-level year alignment, fall back to show first-air year.
             var dateMatch = seasonYearMatch || full.FirstAirDate?.Year == airDate.Year;
+
+            // Episode-level date check: if year-level matching failed and AniDB episode 1 has a
+            // known air date, compare TMDB season episode 1's air date against it. A close match
+            // (±3 days) is a strong signal that this is the correct season — catches cases where
+            // the season year check fails (split-cour, year-boundary premieres) but actual dates align.
+            if (!dateMatch && bestSeason is not null && anidbEp1Date.HasValue)
+            {
+                var tmdbSeason = await _tmdbService.UseClient(
+                    c => c.GetTvSeasonAsync(candidate.Id, bestSeason.SeasonNumber),
+                    $"Fetch season {bestSeason.SeasonNumber} of show {candidate.Id} \"{candidate.OriginalName}\" for episode-date check"
+                ).ConfigureAwait(false);
+                var tmdbEp1Date = tmdbSeason?.Episodes?
+                    .OrderBy(e => e.EpisodeNumber)
+                    .FirstOrDefault()?.AirDate;
+                if (tmdbEp1Date.HasValue)
+                {
+                    dateMatch = Math.Abs((tmdbEp1Date.Value - anidbEp1Date.Value).TotalDays) <= 3;
+                    _logger.LogTrace(
+                        "Episode-date check for show {ShowName} ({ID}) S{Season}E1: tmdb={TmdbDate}, anidb={AnidbDate}, match={Match}",
+                        full.Name, full.Id, bestSeason.SeasonNumber, tmdbEp1Date.Value.ToString("yyyy-MM-dd"), anidbEp1Date.Value.ToString("yyyy-MM-dd"), dateMatch
+                    );
+                }
+            }
 
             var rating = (exactTitle, fuzzyTitle, dateMatch) switch
             {
@@ -711,8 +743,6 @@ public partial class TmdbSearchService : ITmdbSearchService
             candidates.Add(result);
         }
     }
-
-    private bool IsAnimation(IReadOnlyList<string> genres) => genres.Contains("animation", StringComparer.OrdinalIgnoreCase);
 
     private static bool ExactMatchesAnyName(string query, IReadOnlySet<string> names)
     {

--- a/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
@@ -291,10 +291,7 @@ public partial class TmdbSearchService : ITmdbSearchService
             var titleMatch = ScoreQueryVariants([query, strippedTitle], allTitles);
             var exactTitle = titleMatch is MatchRating.TitleMatches;
             var fuzzyTitle = titleMatch is MatchRating.TitleKindaMatches;
-            var dateMatch = year > 0 && (
-                full.ReleaseDate?.Year == year ||
-                (full.ReleaseDates?.Results?.Any(r => r.ReleaseDates?.Any(rd => rd.ReleaseDate.Year == year) ?? false) ?? false)
-            );
+            var dateMatch = MovieMatchesYear(full, year);
 
             var rating = (exactTitle, fuzzyTitle, dateMatch) switch
             {
@@ -720,6 +717,9 @@ public partial class TmdbSearchService : ITmdbSearchService
     #endregion
 
     #region Helpers
+
+    private static bool MovieMatchesYear(TMDbLib.Objects.Movies.Movie movie, int year) =>
+        year > 0 && (movie.ReleaseDate?.Year == year || (movie.ReleaseDates?.Results?.Any(r => r.ReleaseDates?.Any(rd => rd.ReleaseDate.Year == year) ?? false) ?? false));
 
     private static int ShowMatchPriority(MatchRating r) => r switch
     {

--- a/Shoko.Server/Settings/TMDBSettings.cs
+++ b/Shoko.Server/Settings/TMDBSettings.cs
@@ -253,6 +253,30 @@ public class TMDBSettings
     public int IncrementalChangesWindowDays { get; set; } = 14;
 
     /// <summary>
+    /// The maximum number of TMDB search candidates to evaluate per auto-search
+    /// attempt for shows. Each candidate that passes the animation filter is fetched
+    /// in full (title translations + episode count) and scored; the highest-scoring
+    /// result is used. Higher values improve accuracy at the cost of more TMDB
+    /// API calls. All calls are paced by <c>TmdbRateLimiter</c> (sliding-window,
+    /// ~40 req/sec) with automatic 429 backoff, so increasing this value slows
+    /// searches but will not trigger rate-limit errors.
+    /// </summary>
+    [Range(1, 10)]
+    public int AutoSearchShowCandidateCount { get; set; } = 5;
+
+    /// <summary>
+    /// The maximum number of TMDB search candidates to evaluate per auto-search
+    /// attempt for movies. Each candidate that passes the animation filter is fetched
+    /// in full (title translations + release dates) and scored; the highest-scoring
+    /// result is used. Higher values improve accuracy at the cost of more TMDB
+    /// API calls. All calls are paced by <c>TmdbRateLimiter</c> (sliding-window,
+    /// ~40 req/sec) with automatic 429 backoff, so increasing this value slows
+    /// searches but will not trigger rate-limit errors.
+    /// </summary>
+    [Range(1, 10)]
+    public int AutoSearchMovieCandidateCount { get; set; } = 5;
+
+    /// <summary>
     /// Rate limit settings for the TMDB API.
     /// </summary>
     public TmdbRateLimitSettings RateLimit { get; set; } = new();

--- a/Shoko.Server/Settings/TMDBSettings.cs
+++ b/Shoko.Server/Settings/TMDBSettings.cs
@@ -260,6 +260,11 @@ public class TMDBSettings
     /// API calls. All calls are paced by <c>TmdbRateLimiter</c> (sliding-window,
     /// ~40 req/sec) with automatic 429 backoff, so increasing this value slows
     /// searches but will not trigger rate-limit errors.
+    /// <para>
+    /// The year-free candidate pool cap is <c>2 × this value</c>. At the minimum
+    /// of 1, year-free searches collect at most 2 candidates total — sufficient for
+    /// most titles, but edge cases may benefit from a higher value.
+    /// </para>
     /// </summary>
     [Range(1, 10)]
     public int AutoSearchShowCandidateCount { get; set; } = 5;
@@ -272,6 +277,11 @@ public class TMDBSettings
     /// API calls. All calls are paced by <c>TmdbRateLimiter</c> (sliding-window,
     /// ~40 req/sec) with automatic 429 backoff, so increasing this value slows
     /// searches but will not trigger rate-limit errors.
+    /// <para>
+    /// The year-free candidate pool cap is <c>2 × this value</c>. At the minimum
+    /// of 1, year-free searches collect at most 2 candidates total — sufficient for
+    /// most titles, but edge cases may benefit from a higher value.
+    /// </para>
     /// </summary>
     [Range(1, 10)]
     public int AutoSearchMovieCandidateCount { get; set; } = 5;

--- a/Shoko.Server/Utilities/SeriesSearch.cs
+++ b/Shoko.Server/Utilities/SeriesSearch.cs
@@ -99,7 +99,8 @@ public static class SeriesSearch
         {
             if (CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.NonSpacingMark)
                 continue;
-            sb.Append(c is '-' or '_' or '.' or ':' or ',' or '!' or ';' or '/' or '\\' or '(' or ')' or '[' or ']' ? ' ' : c);
+            // U+301C 〜 (wave dash) survives NFKD unchanged and must be mapped explicitly.
+            sb.Append(c is '-' or '_' or '.' or ':' or ',' or '!' or ';' or '/' or '\\' or '(' or ')' or '[' or ']' or '〜' ? ' ' : c);
         }
 
         return sb.ToString().Normalize(NormalizationForm.FormKC).ToLowerInvariant().CompactWhitespaces();

--- a/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
@@ -167,8 +167,8 @@ public class TmdbSearchServiceTests
 
         // The full title normalizes differently, so the specific TMDB entry that
         // exact-matches the full title can score TitleMatches and win.
-        var fullTitle = SeriesSearch.NormalizeForIndex("Fairy Tail: 100 Years Quest");
-        Assert.NotEqual(stripped, fullTitle);
+        var normalizedFullTitle = SeriesSearch.NormalizeForIndex("Fairy Tail: 100 Years Quest");
+        Assert.NotEqual(strippedFromFull, normalizedFullTitle);
     }
 
     // ── NormalizeForIndex: exclamation collision in movie context ─────────────

--- a/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
@@ -171,8 +171,8 @@ public class TmdbSearchServiceTests
 
     // ── NormalizeForIndex: exclamation collision in movie context ─────────────
     // Movies lack an episode-count tiebreaker, so when two candidates collide on
-    // normalized title the scorer falls through to vote count descending.
-    // The correct movie should have significantly more votes than an OVA/extra
+    // normalized title the scorer falls back to the first result in rating order.
+    // The correct movie should score DateAndTitleMatches over the OVA/extra
     // carrying the same base title, but this test documents the collision so any
     // future change to punctuation handling is intentional.
 
@@ -182,8 +182,8 @@ public class TmdbSearchServiceTests
         // e.g. "Precure All Stars Movie: Haru no Carnival♪" and a variant with
         // different punctuation would both normalize the same way.
         // More concretely: a main movie and a bonus short sharing a base title
-        // that differs only in trailing punctuation score identically — vote count
-        // is the only lever to break the tie.
+        // that differs only in trailing punctuation score identically — the date
+        // match is the lever to break the tie.
         var mainMovie = SeriesSearch.NormalizeForIndex("Fairy Tail: Phoenix Priestess");
         var bonusShort = SeriesSearch.NormalizeForIndex("Fairy Tail: Phoenix Priestess!");
         Assert.Equal(mainMovie, bonusShort);

--- a/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
@@ -159,9 +159,11 @@ public class TmdbSearchServiceTests
         // The stripped form normalizes the same as the parent show title, confirming
         // PrefixMatchesAnyName would fire — but since it's fuzzy-only it cannot
         // produce ExactMatch and the parent scores at most TitleKindaMatches.
-        var stripped = SeriesSearch.NormalizeForIndex("Fairy Tail");
+        const string fullTitle = "Fairy Tail: 100 Years Quest";
+        var colonIndex = fullTitle.IndexOf(':');
+        var strippedFromFull = SeriesSearch.NormalizeForIndex(fullTitle[..colonIndex].TrimEnd());
         var parentTitle = SeriesSearch.NormalizeForIndex("Fairy Tail");
-        Assert.Equal(stripped, parentTitle);
+        Assert.Equal(parentTitle, strippedFromFull);
 
         // The full title normalizes differently, so the specific TMDB entry that
         // exact-matches the full title can score TitleMatches and win.

--- a/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
@@ -1,0 +1,191 @@
+using System.Collections.Generic;
+using Shoko.Server.Filters;
+using Shoko.Server.Utilities;
+using Xunit;
+
+// ReSharper disable StringLiteralTypo
+
+namespace Shoko.Tests.Providers.TMDB;
+
+/// <summary>
+/// Tests for <see cref="FuzzySearchService.FuzzyScoreAnyName"/> and
+/// <see cref="SeriesSearch.NormalizeForIndex"/> behaviour relevant to TMDB auto-match scoring
+/// for both shows and movies.
+///</summary>
+public class TmdbSearchServiceTests
+{
+    private static readonly FuzzySearchService Service = new();
+
+    // ── FuzzyScoreAnyName: isNotExact gate ─────────────────────────────────
+    // The scoring pass uses FuzzyScoreAnyName and only accepts results where
+    // isNotExact==true (genuine edit-distance hit). Substring hits (isNotExact==false)
+    // are excluded so spinoffs don't score TitleKindaMatches via prefix containment.
+
+    [Fact]
+    public void FuzzyScoreAnyName_SubstringHit_IsNotExactFalse()
+    {
+        // "Tensura" is a substring of "Tensura Nikki" — isNotExact should be false,
+        // meaning the scoring path will NOT count this as fuzzyTitle=true.
+        var names = new HashSet<string> { "Tensura Nikki: Tensei shitara Slime Datta Ken" };
+        var score = Service.FuzzyScoreAnyName("Tensura", names);
+        Assert.NotNull(score);
+        Assert.False(score!.Value.isNotExact);
+    }
+
+    [Fact]
+    public void FuzzyScoreAnyName_EditDistanceHit_IsNotExactTrue()
+    {
+        // "Kimetzu no Yaiba" is 1 edit from "Kimetsu no Yaiba" — isNotExact should be true,
+        // meaning the scoring path WILL count this as fuzzyTitle=true.
+        var names = new HashSet<string> { "Kimetsu no Yaiba" };
+        var score = Service.FuzzyScoreAnyName("Kimetzu no Yaiba", names);
+        Assert.NotNull(score);
+        Assert.True(score!.Value.isNotExact);
+    }
+
+    [Fact]
+    public void FuzzyScoreAnyName_OnePunchManSequel_IsNotExactFalse()
+    {
+        var names = new HashSet<string> { "One Punch Man 2nd Season" };
+        var score = Service.FuzzyScoreAnyName("One Punch Man", names);
+        Assert.NotNull(score);
+        Assert.False(score!.Value.isNotExact);
+    }
+
+    // ── FuzzyScoreAnyName: Blood+ edge case ────────────────────────────────
+
+    [Fact]
+    public void FuzzyScoreAnyName_BloodPlus_SubstringHitAgainstBloodC()
+    {
+        // MinEditDistInText is a substring distance: "blood+" matches the prefix "blood " of
+        // "blood c" at 1 edit (+ → space), within budget (GetMaxErrors(6) = 1).
+        // Blood-C therefore scores TitleKindaMatches when the query is "Blood+".
+        // This is acceptable because the correct Blood+ TMDB entry scores TitleMatches
+        // via exact match — SortPriority(TitleMatches)=3 beats TitleKindaMatches=5.
+        var names = new HashSet<string> { "Blood-C" };
+        var score = Service.FuzzyScoreAnyName("Blood+", names);
+        Assert.NotNull(score);
+        Assert.True(score!.Value.isNotExact); // edit-distance hit, not substring
+    }
+
+    // ── FuzzyScoreAnyName: Re:Zero abbreviated title ────────────────────────
+
+    [Fact]
+    public void FuzzyScoreAnyName_ReZero_ShortTitleSubstringHitOnly()
+    {
+        // "re zero" is a prefix of the long form → substring hit (isNotExact:false).
+        // The edit-distance path does not fire; PrefixMatchesAnyName is what saves the match.
+        var names = new HashSet<string> { "Re:Zero Starting Life in Another World" };
+        var score = Service.FuzzyScoreAnyName("Re:Zero", names);
+        Assert.NotNull(score);
+        Assert.False(score!.Value.isNotExact);
+    }
+
+    // ── FuzzyScoreAnyName: single-character query gap (known limitation) ────
+
+    [Fact]
+    public void FuzzyScoreAnyName_SingleCharTitle_OnlySubstringHit()
+    {
+        // "C" is a substring of the TMDB title → isNotExact:false.
+        // The scoring path excludes these (it gates on isNotExact:true),
+        // so the match does not contribute to fuzzyTitle.
+        var names = new HashSet<string> { "[C] - The Money of Soul and Possibility Control" };
+        var score = Service.FuzzyScoreAnyName("C", names);
+        Assert.NotNull(score);
+        Assert.False(score!.Value.isNotExact);
+    }
+
+    // ── NormalizeForIndex: wave dash U+301C ─────────────────────────────────
+
+    [Theory]
+    [InlineData("〜", "")]                                        // solo wave dash → space, collapses to empty after trim
+    [InlineData("Monogatari〜Series", "monogatari series")]       // wave dash as separator
+    [InlineData("〜Series〜", "series")]                          // leading/trailing wave dash stripped by whitespace collapse
+    public void NormalizeForIndex_WaveDash_MapsToSpace(string input, string expected)
+        => Assert.Equal(expected, SeriesSearch.NormalizeForIndex(input).Trim());
+
+    // ── NormalizeForIndex: fullwidth tilde U+FF5E (known gap) ───────────────
+
+    [Fact]
+    public void NormalizeForIndex_FullwidthTilde_NotMappedToSpace()
+    {
+        // U+FF5E ～ is converted by NFKC to ASCII tilde ~ (not a space).
+        // This is a known gap — it does not get the same treatment as U+301C 〜.
+        // This test documents the current behavior so any future change is intentional.
+        var result = SeriesSearch.NormalizeForIndex("Foo～Bar");
+        Assert.NotEqual("foo bar", result);  // tilde survives, space not inserted
+    }
+
+    // ── NormalizeForIndex: superscript decomposition ─────────────────────────
+
+    [Fact]
+    public void NormalizeForIndex_SuperscriptThree_DecomposesToDigit()
+    {
+        // U+00B3 ³ decomposes to '3' under NFKD — "C³" → "c3".
+        Assert.Equal("c3", SeriesSearch.NormalizeForIndex("C³"));
+    }
+
+    // ── NormalizeForIndex: exclamation-mark collision (known limitation) ─────
+    // '!' is in the punctuation-to-space map, so K-On! and K-On!! both normalize
+    // to "k on". Disambiguation must fall back to air date and episode count.
+
+    [Fact]
+    public void NormalizeForIndex_KOn_SingleAndDoubleExclamationCollide()
+    {
+        Assert.Equal(SeriesSearch.NormalizeForIndex("K-On!"), SeriesSearch.NormalizeForIndex("K-On!!"));
+    }
+
+    [Fact]
+    public void NormalizeForIndex_Working_AllExclamationVariantsCollide()
+    {
+        var s2 = SeriesSearch.NormalizeForIndex("Working!!");
+        var s3 = SeriesSearch.NormalizeForIndex("Working!!!");
+        Assert.Equal(s2, s3);
+    }
+
+    // ── NormalizeForIndex: subtitle-stripped colon split ─────────────────────
+    // The show scorer strips the subtitle at the first colon for non-Japanese titles
+    // (e.g. "Fairy Tail: 100 Years Quest" → "Fairy Tail"). This stripped form is
+    // fuzzy-eligible only — it cannot produce ExactMatch — so a parent show that
+    // matches via its short name scores TitleKindaMatches at most, while a specific
+    // TMDB entry whose title exact-matches the full title scores TitleMatches and wins.
+    // The prequel-traversal layer also tries the current anime's own main title when
+    // the root-series search is tried, and prefers whichever scores better.
+
+    [Fact]
+    public void NormalizeForIndex_SubtitleStrippedAtColon_ParentTitleIsolated()
+    {
+        // "Fairy Tail: 100 Years Quest" strips to "Fairy Tail" at the colon.
+        // The stripped form normalizes the same as the parent show title, confirming
+        // PrefixMatchesAnyName would fire — but since it's fuzzy-only it cannot
+        // produce ExactMatch and the parent scores at most TitleKindaMatches.
+        var stripped = SeriesSearch.NormalizeForIndex("Fairy Tail");
+        var parentTitle = SeriesSearch.NormalizeForIndex("Fairy Tail");
+        Assert.Equal(stripped, parentTitle);
+
+        // The full title normalizes differently, so the specific TMDB entry that
+        // exact-matches the full title can score TitleMatches and win.
+        var fullTitle = SeriesSearch.NormalizeForIndex("Fairy Tail: 100 Years Quest");
+        Assert.NotEqual(stripped, fullTitle);
+    }
+
+    // ── NormalizeForIndex: exclamation collision in movie context ─────────────
+    // Movies lack an episode-count tiebreaker, so when two candidates collide on
+    // normalized title the scorer falls through to vote count descending.
+    // The correct movie should have significantly more votes than an OVA/extra
+    // carrying the same base title, but this test documents the collision so any
+    // future change to punctuation handling is intentional.
+
+    [Fact]
+    public void NormalizeForIndex_MovieExclamationCollision_TitlesTieOnNormalized()
+    {
+        // e.g. "Precure All Stars Movie: Haru no Carnival♪" and a variant with
+        // different punctuation would both normalize the same way.
+        // More concretely: a main movie and a bonus short sharing a base title
+        // that differs only in trailing punctuation score identically — vote count
+        // is the only lever to break the tie.
+        var mainMovie = SeriesSearch.NormalizeForIndex("Fairy Tail: Phoenix Priestess");
+        var bonusShort = SeriesSearch.NormalizeForIndex("Fairy Tail: Phoenix Priestess!");
+        Assert.Equal(mainMovie, bonusShort);
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the first-match strategy in \`AutoSearchForShowUsingTitle\` and \`AutoSearchMovieUsingTitle\` with a top-N candidate pool scored by title quality and date match before a winner is chosen. \`TMDBSettings.AutoSearchShowCandidateCount\` and \`TMDBSettings.AutoSearchMovieCandidateCount\` control pool size independently (default 5, range 1–10).

**Fixes:**
- **Spinoff/season mismatches** (e.g. TenSura S2 linking to The Slime Diaries): year-free searches always run so the root show is always a candidate even when its \`first_air_date\` predates the season year.
- **#1285** (One Punch Man S3 co-matching an unrelated show): scoring prefers the entry that reaches \`TitleMatches\` over one that only scores \`FirstAvailable\`.
- **Subtitle-stripped parent show mismatches** (e.g. \"Fairy Tail: 100 Years Quest\" matching base Fairy Tail): \`titleWithoutSubTitle\` (colon-split) is fuzzy-only and can score at most \`TitleKindaMatches\`, so the specific entry that exact-matches the full title wins.
- **Prequel-traversal double match** (e.g. 100 Years Quest returning both s248947 and s46261): when the prequel chain is followed to the root, the current anime's own original title is tried first, then the main title; if either scores better than the root-title result, the root series' stored xrefs are suppressed via a \`prequelFollowed\` flag.
- **Local xref path losing \`MatchRating\`**: existing cross-references now preserve their rating.

**Other changes:**
- \`SequelSuffixRemovalRegex\` extended to strip \`第X期\` alongside \`第X季\`, \`2nd Season\`, \`(YYYY)\`.
- Wave-dash U+301C \`〜\` added to \`SeriesSearch.NormalizeForIndex\` punctuation-to-space map.
- 15 unit tests covering \`isNotExact\` gate, \`NormalizeForIndex\` edge cases, and subtitle colon-split behaviour.

## Scoring

```
exactTitle  + dateMatch  → DateAndTitleMatches
exactTitle  only         → TitleMatches
fuzzyTitle  + dateMatch  → DateAndTitleKindaMatches
date only               → DateMatches
fuzzyTitle  only         → TitleKindaMatches
none                     → FirstAvailable
```

\`originalTitle\` and \`strippedTitle\` are exact-eligible; \`titleWithoutSubTitle\` is fuzzy-only. Shows use season-level air year + episode-count diff as tiebreaker. Movies fetch all regional release dates (\`MovieMethods.ReleaseDates\`) and match on any region's year rather than only the primary \`ReleaseDate\`.

Priority order (highest to lowest): \`DateAndTitleMatches\` → \`TitleMatches\` → \`DateAndTitleKindaMatches\` → \`DateMatches\` → \`TitleKindaMatches\` → \`FirstAvailable\`. \`MatchRating\` has a numeric ordering inversion so an explicit \`ShowMatchPriority\` helper is used instead of sorting by raw enum value. The private \`TitleMatchKind\` enum has been removed; \`ScoreQueryVariants\` now returns \`MatchRating\` directly (\`None\` / \`TitleKindaMatches\` / \`TitleMatches\`).

Both scoring loops break early when a \`DateAndTitleMatches\` result is found — no remaining candidate can outscore it, so further show and season fetches are skipped.

## Episode-level date check (show scoring)

When the year-level date check fails for a show candidate — i.e. neither the best season's air year nor the show's \`first_air_date\` year matches the AniDB air date — the scorer fetches the best-matching season's first episode from TMDB and compares its air date against AniDB episode 1's specific air date (±3 days). A close match promotes \`dateMatch\` to \`true\` before the rating switch.

This catches premieres that straddle a year boundary or split-cour shows where the season-level year metadata would miss the correct entry. The check is skipped entirely when AniDB has no episode 1 date. \`GetTvSeasonAsync\` is called with no extra methods; episode air dates are included in the base season response. Episodes are ordered by \`EpisodeNumber\` before taking the first so TMDB data ordering differences cannot produce the wrong episode.

## Known limitations

- **Exclamation-mark title collision** (\`K-On!\` vs \`K-On!!\`, \`Working!!\` vs \`Working!!!\`): \`!\` is in the punctuation-to-space map, so both forms normalize identically and score the same \`TitleMatches\` rating. Disambiguation falls through to the tiebreaker — episode count diff for shows, search-result order for movies. In practice the correct entry has the right episode count or ranks higher in TMDB's relevance order, so this resolves correctly but is not guaranteed for edge cases.
- **Single-character title queries** (e.g. \`C\` from \`[C] - The Money of Soul and Possibility Control\`): \`GetMaxErrors(1) = 0\` so the edit-distance path never fires for 1-character strings. The scorer falls through to prefix/substring matching only; the correct TMDB entry is still found via \`PrefixMatchesAnyName\` if the short title appears as a prefix, but any edit-distance fuzzy match is unavailable.
- **Year-free pool cap**: the year-free candidate pool is capped at \`2 × candidateCount\`. At the minimum setting of 1, this allows at most 2 year-free candidates. Sufficient for most titles; increase \`AutoSearchShowCandidateCount\` / \`AutoSearchMovieCandidateCount\` if edge cases arise.