### PR TITLE
chore: update sharp compress

### DIFF
--- a/Shoko.Server/Services/SystemUpdateService.cs
+++ b/Shoko.Server/Services/SystemUpdateService.cs
@@ -403,7 +403,7 @@ public partial class SystemUpdateService(
 
         // Extract the zip contents into the folder.
         using var stream = new MemoryStream(zipContent);
-        using var reader = ReaderFactory.Open(stream);
+        using var reader = ReaderFactory.OpenReader(stream);
         while (reader.MoveToNextEntry())
         {
             if (!reader.Entry.IsDirectory)

--- a/Shoko.Server/Shoko.Server.csproj
+++ b/Shoko.Server/Shoko.Server.csproj
@@ -89,7 +89,7 @@
     <PackageReference Include="Sentry.AspNetCore" Version="6.6.0" />
     <PackageReference Include="Sentry.Extensions.Logging" Version="6.6.0" />
     <PackageReference Include="Sentry.NLog" Version="6.6.0" />
-    <PackageReference Include="SharpCompress" Version="1.0.0" />
+    <PackageReference Include="SharpCompress" Version="0.49.1" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.3" />

--- a/Shoko.Server/Utilities/AVDumpHelper.cs
+++ b/Shoko.Server/Utilities/AVDumpHelper.cs
@@ -424,7 +424,7 @@ public static partial class AVDumpHelper
                 // Then add the new version.
                 Directory.CreateDirectory(WorkingDirectory);
                 using Stream stream = File.OpenRead(ArchivePath);
-                using var reader = ReaderFactory.Open(stream);
+                using var reader = ReaderFactory.OpenReader(stream);
                 while (reader.MoveToNextEntry())
                 {
                     if (!reader.Entry.IsDirectory)


### PR DESCRIPTION
- yes, this looks like a version downgrade. in reality, 1.0 has been marked as [deprecated and unlisted](https://www.nuget.org/packages/SharpCompress/1.0.0)