### PR TITLE
feat(tmdb,scheduling): add daily job to purge orphaned TMDB data

### DIFF
--- a/Shoko.Abstractions/Metadata/Tmdb/Services/ITmdbMetadataService.cs
+++ b/Shoko.Abstractions/Metadata/Tmdb/Services/ITmdbMetadataService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -56,7 +57,8 @@ public interface ITmdbMetadataService
     /// <summary>
     /// Schedules all unused movies to be purged.
     /// </summary>
-    Task PurgeAllUnusedMovies();
+    /// <param name="olderThan">When set, only purge movies whose <c>LastUpdatedAt</c> is older than this value.</param>
+    Task PurgeAllUnusedMovies(DateTime? olderThan = null);
 
     /// <summary>
     /// Schedules a movie purge job.
@@ -109,7 +111,8 @@ public interface ITmdbMetadataService
     /// <summary>
     /// Schedules all unused shows to be purged.
     /// </summary>
-    Task PurgeAllUnusedShows();
+    /// <param name="olderThan">When set, only purge shows whose <c>LastUpdatedAt</c> is older than this value.</param>
+    Task PurgeAllUnusedShows(DateTime? olderThan = null);
 
     /// <summary>
     /// Schedules a show purge job.

--- a/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbMetadataService.cs
@@ -885,7 +885,7 @@ public class TmdbMetadataService : ITmdbMetadataService
 
     #region Purge (Movies)
 
-    public async Task PurgeAllUnusedMovies()
+    public async Task PurgeAllUnusedMovies(DateTime? olderThan = null)
     {
         var toKeep = _xrefAnidbTmdbMovies.GetAll().Select(xref => xref.TmdbMovieID).ToHashSet();
         // Seeded with toKeep so AllCount in the log includes xref-linked IDs that have no TMDB_Movie row yet.
@@ -897,6 +897,11 @@ public class TmdbMetadataService : ITmdbMetadataService
         allMovies.UnionWith(_tmdbMovieCrew.GetAll().Select(x => x.TmdbMovieID));
         allMovies.UnionWith(_xrefTmdbCollectionMovies.GetAll().Select(x => x.TmdbMovieID));
         var toBePurged = allMovies.Except(toKeep).ToHashSet();
+
+        if (olderThan.HasValue)
+            toBePurged = toBePurged
+                .Where(id => _tmdbMovies.GetByTmdbMovieID(id) is not { LastUpdatedAt: var t } || t < olderThan.Value)
+                .ToHashSet();
 
         _logger.LogInformation("Scheduling {Count} out of {AllCount} movies to be purged.", toBePurged.Count, allMovies.Count);
         foreach (var movieID in toBePurged)
@@ -2116,7 +2121,7 @@ public class TmdbMetadataService : ITmdbMetadataService
 
     #region Purge (Shows)
 
-    public async Task PurgeAllUnusedShows()
+    public async Task PurgeAllUnusedShows(DateTime? olderThan = null)
     {
         var toKeep = _xrefAnidbTmdbShows.GetAll().Select(xref => xref.TmdbShowID).ToHashSet();
         // Seeded with toKeep so AllCount in the log includes xref-linked IDs that have no TMDB_Show row yet.
@@ -2131,6 +2136,11 @@ public class TmdbMetadataService : ITmdbMetadataService
         allShows.UnionWith(_tmdbAlternateOrderingSeasons.GetAll().Select(x => x.TmdbShowID));
         allShows.UnionWith(_tmdbAlternateOrderingEpisodes.GetAll().Select(x => x.TmdbShowID));
         var toBePurged = allShows.Except(toKeep).ToHashSet();
+
+        if (olderThan.HasValue)
+            toBePurged = toBePurged
+                .Where(id => _tmdbShows.GetByTmdbShowID(id) is not { LastUpdatedAt: var t } || t < olderThan.Value)
+                .ToHashSet();
 
         _logger.LogInformation("Scheduling {Count} out of {AllCount} shows to be purged.", toBePurged.Count, allShows.Count);
         foreach (var showID in toBePurged)

--- a/Shoko.Server/Scheduling/Jobs/Actions/PurgeOrphanedTmdbDataJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Actions/PurgeOrphanedTmdbDataJob.cs
@@ -1,0 +1,47 @@
+#pragma warning disable CS8618
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Shoko.Abstractions.Metadata.Tmdb.Services;
+using Shoko.QueueProcessor.Acquisition.Attributes;
+using Shoko.QueueProcessor.Builder;
+using Shoko.QueueProcessor.Concurrency;
+using Shoko.Server.Settings;
+
+namespace Shoko.Server.Scheduling.Jobs.Actions;
+
+[DatabaseRequired]
+[DisallowConcurrentExecution]
+[JobKeyGroup(JobKeyGroup.Actions)]
+public class PurgeOrphanedTmdbDataJob : BaseJob
+{
+    private readonly ISettingsProvider _settingsProvider;
+    private readonly ITmdbMetadataService _tmdbMetadataService;
+
+    public override string TypeName => "Purge Orphaned TMDB Data";
+
+    public override string Title => "Purging Orphaned TMDB Data";
+
+    public override async Task Execute()
+    {
+        var threshold = _settingsProvider.GetSettings().TMDB.AutoPurgeUnlinkedAfterDays;
+        if (threshold <= 0)
+        {
+            _logger.LogTrace("Auto-purge disabled (AutoPurgeUnlinkedAfterDays=0). Skipping.");
+            return;
+        }
+
+        var cutoff = DateTime.Now.AddDays(-threshold);
+        await _tmdbMetadataService.PurgeAllUnusedShows(cutoff);
+        await _tmdbMetadataService.PurgeAllUnusedMovies(cutoff);
+    }
+
+    public PurgeOrphanedTmdbDataJob(ISettingsProvider settingsProvider, ITmdbMetadataService tmdbMetadataService)
+    {
+        _settingsProvider = settingsProvider;
+        _tmdbMetadataService = tmdbMetadataService;
+    }
+
+    protected PurgeOrphanedTmdbDataJob() { }
+}

--- a/Shoko.Server/Services/SystemService.cs
+++ b/Shoko.Server/Services/SystemService.cs
@@ -336,7 +336,7 @@ public class SystemService : ISystemService
             if (!FileSystem.AlternateDataStreamExists(dllFile, "Zone.Identifier"))
                 continue;
 
-            _logger.LogError("Found blocked DLL file: " + dllFile);
+            _logger.LogError("Found blocked DLL file: {DllFile}", dllFile);
             result = false;
         }
 
@@ -487,6 +487,7 @@ public class SystemService : ISystemService
             registry.Register<ScanForMissingReleaseInfoJob>(TimeSpan.FromHours(24), runImmediately: false);
             registry.Register<PeriodicImageMaintenanceJob>(TimeSpan.FromHours(24), runImmediately: false);
             registry.Register<CleanupExpiredTokensJob>(TimeSpan.FromHours(24), runImmediately: false);
+            registry.Register<PurgeOrphanedTmdbDataJob>(TimeSpan.FromHours(24), runImmediately: false);
 
             // Register settings-driven recurring jobs. Jobs whose frequency is Never are skipped
             // entirely at startup; they are registered on-demand when settings change.

--- a/Shoko.Server/Settings/TMDBSettings.cs
+++ b/Shoko.Server/Settings/TMDBSettings.cs
@@ -290,4 +290,15 @@ public class TMDBSettings
     /// Rate limit settings for the TMDB API.
     /// </summary>
     public TmdbRateLimitSettings RateLimit { get; set; } = new();
+
+    /// <summary>
+    /// Number of days a TMDB show or movie can remain in the local database
+    /// without any AniDB cross-reference before it is automatically purged.
+    /// Set to <c>0</c> to disable automatic purging.
+    /// </summary>
+    [Visibility(Size = DisplayElementSize.Large)]
+    [EnvironmentVariable("TMDB_AUTO_PURGE_UNLINKED_AFTER_DAYS")]
+    [Range(0, 365)]
+    [DefaultValue(14)]
+    public int AutoPurgeUnlinkedAfterDays { get; set; } = 14;
 }

--- a/Shoko.Tests/Scheduling/Jobs/Actions/PurgeOrphanedTmdbDataJobTests.cs
+++ b/Shoko.Tests/Scheduling/Jobs/Actions/PurgeOrphanedTmdbDataJobTests.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Shoko.Abstractions.Metadata.Tmdb.Services;
+using Shoko.Server.Scheduling.Jobs.Actions;
+using Shoko.Server.Settings;
+using Xunit;
+
+namespace Shoko.Tests.Scheduling.Jobs.Actions;
+
+public class PurgeOrphanedTmdbDataJobTests
+{
+    private static PurgeOrphanedTmdbDataJob MakeJob(
+        int thresholdDays,
+        out Mock<ITmdbMetadataService> serviceMock)
+    {
+        var settings = new ServerSettings { TMDB = new TMDBSettings { AutoPurgeUnlinkedAfterDays = thresholdDays } };
+        var settingsMock = new Mock<ISettingsProvider>();
+        settingsMock.Setup(p => p.GetSettings()).Returns(settings);
+
+        serviceMock = new Mock<ITmdbMetadataService>();
+
+        var serviceProviderMock = new Mock<IServiceProvider>();
+        serviceProviderMock.Setup(sp => sp.GetService(typeof(ILoggerFactory))).Returns(NullLoggerFactory.Instance);
+
+        var job = new PurgeOrphanedTmdbDataJob(settingsMock.Object, serviceMock.Object);
+        job.Setup(serviceProviderMock.Object);
+        return job;
+    }
+
+    [Fact]
+    public async Task Execute_ThresholdZero_NeitherServiceMethodCalled()
+    {
+        var job = MakeJob(0, out var service);
+
+        await job.Execute();
+
+        service.Verify(s => s.PurgeAllUnusedShows(It.IsAny<DateTime?>()), Times.Never);
+        service.Verify(s => s.PurgeAllUnusedMovies(It.IsAny<DateTime?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_ThresholdPositive_BothServiceMethodsCalledWithCorrectCutoff()
+    {
+        var before = DateTime.Now.AddDays(-14);
+        var job = MakeJob(14, out var service);
+
+        await job.Execute();
+
+        service.Verify(s => s.PurgeAllUnusedShows(It.Is<DateTime?>(d => d.HasValue && d.Value >= before && d.Value <= DateTime.Now)), Times.Once);
+        service.Verify(s => s.PurgeAllUnusedMovies(It.Is<DateTime?>(d => d.HasValue && d.Value >= before && d.Value <= DateTime.Now)), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a background job that automatically purges TMDB shows and movies from the local database when they have no AniDB cross-references and have not been updated within a configurable threshold period.

- **New setting** `AutoPurgeUnlinkedAfterDays` (default: 14, range: 0–365, env: `TMDB_AUTO_PURGE_UNLINKED_AFTER_DAYS`) — set to `0` to disable automatic purging entirely
- **`PurgeAllUnusedShows` / `PurgeAllUnusedMovies`** on `ITmdbMetadataService` and `TmdbMetadataService` gain an optional `DateTime? olderThan` parameter; the age filter is applied after the full cross-reference check (all 9 xref types) so orphan detection is not duplicated
- **`PurgeOrphanedTmdbDataJob`** delegates to those service methods, reads the threshold from settings, computes the cutoff date, and returns early when purging is disabled
- Registered as a 24-hour recurring job alongside the other daily maintenance jobs in `SystemService`

## Notes

The `olderThan` filter uses an `is not { LastUpdatedAt: var t }` pattern — a null return from the repository (orphan ID with no local row) is treated as always eligible for purging, which is the correct fallback.