### PR TITLE
Fix Dropped ForceScan Parameter In Managed Folder Scans

### DIFF
--- a/Shoko.Server/Services/VideoService.cs
+++ b/Shoko.Server/Services/VideoService.cs
@@ -1086,9 +1086,9 @@ public class VideoService : IVideoService
         if (!onlyNewFiles.HasValue)
         {
             foreach (var source in sources)
-                await ScheduleScanForManagedFolder(source, skipEvents: skipEvents, cleanUpStructure: cleanUpStructure, prioritize: prioritize);
+                await ScheduleScanForManagedFolder(source, skipEvents: skipEvents, cleanUpStructure: cleanUpStructure, forceScan: forceScan, prioritize: prioritize);
             foreach (var folder in rest)
-                await ScheduleScanForManagedFolder(folder, onlyNewFiles: true, skipEvents: skipEvents, cleanUpStructure: cleanUpStructure, prioritize: prioritize);
+                await ScheduleScanForManagedFolder(folder, onlyNewFiles: true, skipEvents: skipEvents, cleanUpStructure: cleanUpStructure, forceScan: forceScan, prioritize: prioritize);
             return;
         }
 


### PR DESCRIPTION
- Pass the forceScan parameter to ScheduleScanForManagedFolder during the default fallback logic when onlyNewFiles is null
- Ensure that manual import commands can properly force re-evaluation of unrecognized files that have exceeded the maximum auto-scan attempts