### PR TITLE
fix(tmdb): guard against null Translations in Populate for show and movie models

### DIFF
--- a/Shoko.Server/Models/TMDB/TMDB_Movie.cs
+++ b/Shoko.Server/Models/TMDB/TMDB_Movie.cs
@@ -223,7 +223,7 @@ public class TMDB_Movie : TMDB_Base<int>, IEntityMetadata, IMovie, ITmdbMovie
     /// <returns>True if any of the fields have been updated.</returns>
     public bool Populate(Movie movie, HashSet<TitleLanguage>? crLanguages)
     {
-        var translation = movie.Translations!.Translations!.FirstOrDefault(translation => translation.Iso_639_1 == "en");
+        var translation = movie.Translations?.Translations?.FirstOrDefault(translation => translation.Iso_639_1 == "en");
         var lang = movie.ProductionCountries!.FirstOrDefault()?.Iso_3166_1;
         var releaseDate = !string.IsNullOrEmpty(lang) && movie.ReleaseDates!.Results!.FirstOrDefault(obj0 => obj0.Iso_3166_1 == lang) is { ReleaseDates: { } } obj1
             ? obj1.ReleaseDates.FirstOrDefault(obj2 => obj2.Type is ReleaseDateType.TheatricalLimited or ReleaseDateType.Theatrical)?.ReleaseDate ??

--- a/Shoko.Server/Models/TMDB/TMDB_Show.cs
+++ b/Shoko.Server/Models/TMDB/TMDB_Show.cs
@@ -224,7 +224,7 @@ public class TMDB_Show : TMDB_Base<int>, IEntityMetadata, ISeries, ITmdbShow, IT
     {
         // Don't trust 'show.Name' for the English title since it will fall-back
         // to the original language if there is no title in English.
-        var translation = show.Translations!.Translations!.FirstOrDefault(translation => translation.Iso_639_1 == "en");
+        var translation = show.Translations?.Translations?.FirstOrDefault(translation => translation.Iso_639_1 == "en");
         var updates = new[]
         {
             UpdateProperty(PosterPath, show.PosterPath!, v => PosterPath = v),


### PR DESCRIPTION
## Summary

- `TMDB_Show.Populate` and `TMDB_Movie.Populate` both accessed `Translations!.Translations!` using null-forgiving operators, which suppress compiler warnings but crash at runtime if the TMDB API returns a response where `Translations` is not populated.
- Changed both to `?.Translations?.FirstOrDefault(...)` — `translation` is already consumed with null-conditional operators downstream so returning `null` is safe.

## Reproduction

`NullReferenceException` thrown from `TMDB_Show.Populate` at line 228 during `UpdateTmdbShowJob` for show 82684 (転生したらスライムだった件), observed in production logs 2026-06-27.