### PR TITLE
fix(tmdb): try movie search first for short OVA/Web entries

### DIFF
--- a/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbSearchService.cs
@@ -65,8 +65,24 @@ public partial class TmdbSearchService : ITmdbSearchService
             // Music videos are not allowed on TMDB, and the other and unknown types are hard to auto-map, so just don't.
             AnimeType.MusicVideo or AnimeType.Other or AnimeType.Unknown => [],
             AnimeType.Movie => await AutoSearchForMovies(anime).ConfigureAwait(false),
+            // OVA/Web entries with ≤4 main episodes may be standalone movies on TMDB even though AniDB models them as a series.
+            // Try movie search first; fall back to show search if nothing matches.
+            AnimeType.OVA or AnimeType.Web when IsShortFormAnime(anime) => await AutoSearchForMoviesWithShowFallback(anime).ConfigureAwait(false),
             _ => await AutoSearchForShow(anime).ConfigureAwait(false)
         };
+
+    internal static bool IsShortFormAnime(AniDB_Anime anime)
+        => IsShortFormByEpisodeCount(anime.AniDBEpisodes.Count(e => e.EpisodeType is EpisodeType.Episode));
+
+    internal static bool IsShortFormByEpisodeCount(int mainEpisodeCount) => mainEpisodeCount <= 4;
+
+    private async Task<IReadOnlyList<TmdbAutoSearchResult>> AutoSearchForMoviesWithShowFallback(AniDB_Anime anime)
+    {
+        var movieResults = await AutoSearchForMovies(anime).ConfigureAwait(false);
+        if (movieResults.Count > 0)
+            return movieResults;
+        return await AutoSearchForShow(anime).ConfigureAwait(false);
+    }
 
     #region Movie
 

--- a/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Shoko.Server.Filters;
+using Shoko.Server.Providers.TMDB;
 using Shoko.Server.Utilities;
 using Xunit;
 
@@ -170,6 +171,21 @@ public class TmdbSearchServiceTests
         var normalizedFullTitle = SeriesSearch.NormalizeForIndex("Fairy Tail: 100 Years Quest");
         Assert.NotEqual(strippedFromFull, normalizedFullTitle);
     }
+
+    // ── IsShortFormByEpisodeCount: OVA/Web movie routing threshold ───────────
+    // OVA and Web anime with ≤4 main episodes route to movie search first,
+    // because TMDB may model them as standalone films even though AniDB treats
+    // them as a series (e.g. "Grudge of Edinburgh" = 2 AniDB episodes → 2 TMDB movies).
+
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(1, true)]
+    [InlineData(2, true)]   // two-part film like Grudge of Edinburgh
+    [InlineData(4, true)]   // upper bound of short-form heuristic
+    [InlineData(5, false)]  // five-episode OVA stays on show search path
+    [InlineData(13, false)]
+    public void IsShortFormByEpisodeCount_Threshold(int count, bool expected)
+        => Assert.Equal(expected, TmdbSearchService.IsShortFormByEpisodeCount(count));
 
     // ── NormalizeForIndex: exclamation collision in movie context ─────────────
     // Movies lack an episode-count tiebreaker, so when two candidates collide on


### PR DESCRIPTION
## Summary

- Short OVA and Web anime (≤4 main episodes) were routed exclusively to show search, causing mis-links to the parent franchise's TMDB show when TMDB models them as standalone movies (e.g. a two-part film that AniDB treats as an OVA series with 2 episodes, each mapping to a separate TMDB movie)
- Added `IsShortFormAnime` heuristic: for `AnimeType.OVA`/`AnimeType.Web` with ≤4 `EpisodeType.Episode` entries, movie search runs first; if it finds matches, each episode links independently to its TMDB movie via the existing per-episode `AutoSearchForMovies` path
- If movie search returns nothing, falls through to normal show search so well-formed OVA seasons still link correctly