### PR TITLE
fix(tmdb): correct AniDB↔TMDB episode cross-reference accuracy bugs

### DIFF
--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -764,6 +764,8 @@ public class TmdbLinkingService : ITmdbLinkingService
             }
         }
 
+        ReconcileEpisodeOrderInversions(anidbEpisodes, tmdbEpisodeDict, toAdd);
+
         if (!saveToDatabase)
         {
             _logger.LogDebug(
@@ -900,6 +902,50 @@ public class TmdbLinkingService : ITmdbLinkingService
 
     private static string ReplaceTitle(string title) =>
         _characterReplacementDict.Aggregate(title, (current, kv) => current.Replace(kv.Key, kv.Value));
+
+    // Ratings assigned without any title evidence — pure air-date coincidence or the last-resort
+    // positional fallback. Both are cheap to get backwards when TMDB's own episode dates are shifted
+    // relative to AniDB's (e.g. an early exclusive-stream premiere AniDB tracked but TMDB never listed),
+    // since a date-only match can grab the wrong TMDB episode before its true AniDB neighbor gets a turn.
+    private static readonly HashSet<MatchRating> _weakOrderRatings = [MatchRating.DateMatches, MatchRating.FirstAvailable];
+
+    // AniDB's episode order is the point of truth. If two AniDB-adjacent episodes both matched on
+    // weak evidence alone and their TMDB assignments came out in the wrong order, swap them back into
+    // AniDB order instead of trusting TMDB's (possibly mis-dated) episode numbering.
+    internal static void ReconcileEpisodeOrderInversions(IReadOnlyDictionary<int, AniDB_Episode> anidbEpisodes, IReadOnlyDictionary<int, TMDB_Episode> tmdbEpisodeDict, IReadOnlyList<CrossRef_AniDB_TMDB_Episode> toAdd)
+    {
+        var groups = toAdd
+            .Where(xref => xref.TmdbEpisodeID != 0 && _weakOrderRatings.Contains(xref.MatchRating) && anidbEpisodes.ContainsKey(xref.AnidbEpisodeID))
+            .GroupBy(xref => anidbEpisodes[xref.AnidbEpisodeID].EpisodeType);
+
+        foreach (var group in groups)
+        {
+            var ordered = group.OrderBy(xref => anidbEpisodes[xref.AnidbEpisodeID].EpisodeNumber).ToList();
+
+            // A single left-to-right pass only bubbles one inversion at a time, so a run of 3+
+            // weak matches in reverse order (e.g. T3,T2,T1) needs more than one pass to fully
+            // untangle. Repeat until a full pass makes no swaps.
+            bool swapped;
+            do
+            {
+                swapped = false;
+                for (var i = 0; i < ordered.Count - 1; i++)
+                {
+                    var a = ordered[i];
+                    var b = ordered[i + 1];
+                    if (!tmdbEpisodeDict.TryGetValue(a.TmdbEpisodeID, out var tmdbA) || !tmdbEpisodeDict.TryGetValue(b.TmdbEpisodeID, out var tmdbB))
+                        continue;
+
+                    if ((tmdbA.SeasonNumber, tmdbA.EpisodeNumber).CompareTo((tmdbB.SeasonNumber, tmdbB.EpisodeNumber)) <= 0)
+                        continue;
+
+                    (a.TmdbEpisodeID, b.TmdbEpisodeID) = (b.TmdbEpisodeID, a.TmdbEpisodeID);
+                    (a.TmdbShowID, b.TmdbShowID) = (b.TmdbShowID, a.TmdbShowID);
+                    swapped = true;
+                }
+            } while (swapped);
+        }
+    }
 
     #endregion
 }

--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -511,15 +511,76 @@ public class TmdbLinkingService : ITmdbLinkingService
             .Where(episode => episode.SeasonNumber == 0)
             .OrderBy(episode => episode.EpisodeNumber)
             .ToList();
+        bool IsSpecialEpisode(AniDB_Episode ep) => ep.EpisodeType is EpisodeType.Special || anime.AnimeType is not AnimeType.TVSeries and not AnimeType.Web;
+
+        List<TMDB_Episode> GetEpisodeList(AniDB_Episode ep) => IsSpecialEpisode(ep) ? tmdbSpecialEpisodes : tmdbNormalEpisodes;
+
         // Ranks an AniDB episode's best candidate match without consuming it, so passes can process
         // the strongest matches first and let weaker duplicate claims fall back to their next-best
         // candidate instead of losing a shared TMDB episode purely by AniDB episode order.
         double PeekMatchConfidence(AniDB_Episode ep)
         {
-            var isSpecialEpisode = ep.EpisodeType is EpisodeType.Special || anime.AnimeType is not AnimeType.TVSeries and not AnimeType.Web;
-            var candidates = isSpecialEpisode ? tmdbSpecialEpisodes : tmdbNormalEpisodes;
-            TryFindAnidbAndTmdbMatch(anime, ep, candidates, isSpecialEpisode && !isOVA, out var episodeConfidence);
+            TryFindAnidbAndTmdbMatch(anime, ep, GetEpisodeList(ep), IsSpecialEpisode(ep) && !isOVA, out var episodeConfidence);
             return episodeConfidence;
+        }
+
+        // Narrows the TMDB candidate pool to seasons already established by an existing/new OV/DT
+        // link, so later passes can't stray into an unrelated season once one has been established.
+        void FilterToCurrentSeasons(int passNumber)
+        {
+            var currentSessions = crossReferences
+                .Select(NormalEpisodeSeasonNumberSelector)
+                .Except([-1])
+                .ToHashSet();
+            if (currentSessions.Count == 0)
+                return;
+
+            if (!isOVA)
+                currentSessions.Add(0);
+            _logger.LogTrace("Filtering available episodes by currently in use seasons. (Current Sessions: {CurrentSessions}, Pass: {PassNumber}/4)", string.Join(", ", currentSessions), passNumber);
+            tmdbEpisodes = (isOVA ? tmdbEpisodes : tmdbNormalEpisodes.Concat(tmdbSpecialEpisodes))
+                .Where(episode => currentSessions.Contains(episode.SeasonNumber))
+                .ToList();
+            tmdbNormalEpisodes = isOVA ? tmdbEpisodes : tmdbEpisodes
+                .Where(episode => episode.SeasonNumber != 0)
+                .OrderBy(episode => episode.SeasonNumber)
+                .ThenBy(episode => episode.EpisodeNumber)
+                .ToList();
+            tmdbSpecialEpisodes = isOVA ? tmdbEpisodes : tmdbEpisodes
+                .Where(episode => episode.SeasonNumber == 0)
+                .OrderBy(episode => episode.EpisodeNumber)
+                .ToList();
+        }
+
+        // Runs a deferred pass: episodes whose match satisfies `accepts` are linked and removed from
+        // the shared candidate pool; the rest are queued into `overflow` for the next pass.
+        void RunDeferredPass(int passNumber, string passLabel, List<AniDB_Episode> episodes, Func<MatchRating, bool> accepts, List<AniDB_Episode> overflow)
+        {
+            FilterToCurrentSeasons(passNumber);
+
+            var passCurrent = 0;
+            foreach (var episode in episodes.OrderByDescending(PeekMatchConfidence))
+            {
+                passCurrent++;
+                _logger.LogTrace("Linking episode {EpisodeType} {EpisodeNumber}. (AniDB ID: {EpisodeID}, Progress: {Current}/{Total}, Pass: {PassNumber}/4)", episode.EpisodeType, episode.EpisodeNumber, episode.EpisodeID, passCurrent, episodes.Count, passNumber);
+                var episodeList = GetEpisodeList(episode);
+                var crossRef = TryFindAnidbAndTmdbMatch(anime, episode, episodeList, IsSpecialEpisode(episode) && !isOVA);
+                if (accepts(crossRef.MatchRating))
+                {
+                    var index = episodeList.FindIndex(episode => episode.TmdbEpisodeID == crossRef.TmdbEpisodeID);
+                    if (index != -1)
+                        episodeList.RemoveAt(index);
+
+                    crossReferences.Add(crossRef);
+                    toAdd.Add(crossRef);
+                    _logger.LogTrace("Adding new link for episode. (AniDB ID: {AnidbEpisodeID}, TMDB ID: {TMDbEpisodeID}, Rating: {MatchRating}, Pass: {PassNumber}/4)", episode.EpisodeID, crossRef.TmdbEpisodeID, crossRef.MatchRating, passNumber);
+                }
+                else
+                {
+                    _logger.LogTrace("Skipping episode in the {PassLabel} pass. (AniDB ID: {AnidbEpisodeID}, TMDB ID: {TMDbEpisodeID}, Rating: {MatchRating}, Pass: {PassNumber}/4)", passLabel, episode.EpisodeID, crossRef.TmdbEpisodeID, crossRef.MatchRating, passNumber);
+                    overflow.Add(episode);
+                }
+            }
         }
 
         var current = 0;
@@ -593,9 +654,8 @@ public class TmdbLinkingService : ITmdbLinkingService
 
                 // Else try find a match.
                 _logger.LogTrace("Linking episode. (AniDB ID: {AnidbEpisodeID}, Pass: 1/4)", episode.EpisodeID);
-                var isSpecial = episode.EpisodeType is EpisodeType.Special || anime.AnimeType is not AnimeType.TVSeries and not AnimeType.Web;
-                var episodeList = isSpecial ? tmdbSpecialEpisodes : tmdbNormalEpisodes;
-                var crossRef = TryFindAnidbAndTmdbMatch(anime, episode, episodeList, isSpecial && !isOVA);
+                var episodeList = GetEpisodeList(episode);
+                var crossRef = TryFindAnidbAndTmdbMatch(anime, episode, episodeList, IsSpecialEpisode(episode) && !isOVA);
                 if (crossRef.MatchRating is MatchRating.DateAndTitleMatches)
                 {
                     var index = episodeList.FindIndex(episode => episode.TmdbEpisodeID == crossRef.TmdbEpisodeID);
@@ -616,138 +676,16 @@ public class TmdbLinkingService : ITmdbLinkingService
 
         // Run a second pass on the episodes that weren't OV and DT links in the first pass.
         if (secondPass.Count > 0)
-        {
-            // Filter the new links by the currently in use seasons from the existing (and/or new) OV/DT links.
-            var currentSessions = crossReferences
-                .Select(NormalEpisodeSeasonNumberSelector)
-                .Except([-1])
-                .ToHashSet();
-            if (currentSessions.Count > 0)
-            {
-                if (!isOVA)
-                    currentSessions.Add(0);
-                _logger.LogTrace("Filtering available episodes by currently in use seasons. (Current Sessions: {CurrentSessions}, Pass: 2/4)", string.Join(", ", currentSessions));
-                tmdbEpisodes = (isOVA ? tmdbEpisodes : tmdbNormalEpisodes.Concat(tmdbSpecialEpisodes))
-                    .Where(episode => currentSessions.Contains(episode.SeasonNumber))
-                    .ToList();
-                tmdbNormalEpisodes = isOVA ? tmdbEpisodes : tmdbEpisodes
-                    .Where(episode => episode.SeasonNumber != 0)
-                    .OrderBy(episode => episode.SeasonNumber)
-                    .ThenBy(episode => episode.EpisodeNumber)
-                    .ToList();
-                tmdbSpecialEpisodes = isOVA ? tmdbEpisodes : tmdbEpisodes
-                    .Where(episode => episode.SeasonNumber == 0)
-                    .OrderBy(episode => episode.EpisodeNumber)
-                    .ToList();
-            }
-
-            current = 0;
-            foreach (var episode in secondPass.OrderByDescending(PeekMatchConfidence))
-            {
-                // Try find a match.
-                current++;
-                _logger.LogTrace("Linking episode {EpisodeType} {EpisodeNumber}. (AniDB ID: {EpisodeID}, Progress: {Current}/{Total}, Pass: 2/4)", episode.EpisodeType, episode.EpisodeNumber, episode.EpisodeID, current, secondPass.Count);
-                var isSpecial = episode.EpisodeType is EpisodeType.Special || anime.AnimeType is not AnimeType.TVSeries and not AnimeType.Web;
-                var episodeList = isSpecial ? tmdbSpecialEpisodes : tmdbNormalEpisodes;
-                var crossRef = TryFindAnidbAndTmdbMatch(anime, episode, episodeList, isSpecial && !isOVA);
-                if (crossRef.MatchRating is MatchRating.TitleMatches)
-                {
-                    var index = episodeList.FindIndex(episode => episode.TmdbEpisodeID == crossRef.TmdbEpisodeID);
-                    if (index != -1)
-                        episodeList.RemoveAt(index);
-
-                    crossReferences.Add(crossRef);
-                    toAdd.Add(crossRef);
-                    _logger.LogTrace("Adding new link for episode. (AniDB ID: {AnidbEpisodeID}, TMDB ID: {TMDbEpisodeID}, Rating: {MatchRating}, Pass: 2/4)", episode.EpisodeID, crossRef.TmdbEpisodeID, crossRef.MatchRating);
-                }
-                else
-                {
-                    _logger.LogTrace("Skipping episode in the second pass. (AniDB ID: {AnidbEpisodeID}, TMDB ID: {TMDbEpisodeID}, Rating: {MatchRating}, Pass: 2/4)", episode.EpisodeID, crossRef.TmdbEpisodeID, crossRef.MatchRating);
-                    thirdPass.Add(episode);
-                }
-            }
-        }
+            RunDeferredPass(2, "second", secondPass, rating => rating is MatchRating.TitleMatches, thirdPass);
 
         // Run a third pass on the episodes that weren't OV, DT or T links in the first pass.
         if (thirdPass.Count > 0)
-        {
-            // Filter the new links by the currently in use seasons from the existing (and/or new) OV/DT links.
-            var currentSessions = crossReferences
-                .Select(NormalEpisodeSeasonNumberSelector)
-                .Except([-1])
-                .ToHashSet();
-            if (currentSessions.Count > 0)
-            {
-                if (!isOVA)
-                    currentSessions.Add(0);
-                _logger.LogTrace("Filtering available episodes by currently in use seasons. (Current Sessions: {CurrentSessions}, Pass: 3/4)", string.Join(", ", currentSessions));
-                tmdbEpisodes = (isOVA ? tmdbEpisodes : tmdbNormalEpisodes.Concat(tmdbSpecialEpisodes))
-                    .Where(episode => currentSessions.Contains(episode.SeasonNumber))
-                    .ToList();
-                tmdbNormalEpisodes = isOVA ? tmdbEpisodes : tmdbEpisodes
-                    .Where(episode => episode.SeasonNumber != 0)
-                    .OrderBy(episode => episode.SeasonNumber)
-                    .ThenBy(episode => episode.EpisodeNumber)
-                    .ToList();
-                tmdbSpecialEpisodes = isOVA ? tmdbEpisodes : tmdbEpisodes
-                    .Where(episode => episode.SeasonNumber == 0)
-                    .OrderBy(episode => episode.EpisodeNumber)
-                    .ToList();
-            }
-
-            current = 0;
-            foreach (var episode in thirdPass.OrderByDescending(PeekMatchConfidence))
-            {
-                // Try find a match.
-                current++;
-                _logger.LogTrace("Linking episode {EpisodeType} {EpisodeNumber}. (AniDB ID: {EpisodeID}, Progress: {Current}/{Total}, Pass: 3/4)", episode.EpisodeType, episode.EpisodeNumber, episode.EpisodeID, current, thirdPass.Count);
-                var isSpecial = episode.EpisodeType is EpisodeType.Special || anime.AnimeType is not AnimeType.TVSeries and not AnimeType.Web;
-                var episodeList = isSpecial ? tmdbSpecialEpisodes : tmdbNormalEpisodes;
-                var crossRef = TryFindAnidbAndTmdbMatch(anime, episode, episodeList, isSpecial && !isOVA);
-                if (crossRef.MatchRating is not MatchRating.FirstAvailable and not MatchRating.None)
-                {
-                    var index = episodeList.FindIndex(episode => episode.TmdbEpisodeID == crossRef.TmdbEpisodeID);
-                    if (index != -1)
-                        episodeList.RemoveAt(index);
-
-                    crossReferences.Add(crossRef);
-                    toAdd.Add(crossRef);
-                    _logger.LogTrace("Adding new link for episode. (AniDB ID: {AnidbEpisodeID}, TMDB ID: {TMDbEpisodeID}, Rating: {MatchRating}, Pass: 3/4)", episode.EpisodeID, crossRef.TmdbEpisodeID, crossRef.MatchRating);
-                }
-                else
-                {
-                    _logger.LogTrace("Skipping episode in the third pass. (AniDB ID: {AnidbEpisodeID}, TMDB ID: {TMDbEpisodeID}, Rating: {MatchRating}, Pass: 3/4)", episode.EpisodeID, crossRef.TmdbEpisodeID, crossRef.MatchRating);
-                    fourthPass.Add(episode);
-                }
-            }
-        }
+            RunDeferredPass(3, "third", thirdPass, rating => rating is not MatchRating.FirstAvailable and not MatchRating.None, fourthPass);
 
         // Run a fourth pass on the episodes on the remaining episodes.
         if (fourthPass.Count > 0)
         {
-            // Filter the new links by the currently in use seasons from the existing (and/or new) OV/DT links.
-            var currentSessions = crossReferences
-                .Select(NormalEpisodeSeasonNumberSelector)
-                .Except([-1])
-                .ToHashSet();
-            if (currentSessions.Count > 0)
-            {
-                if (!isOVA)
-                    currentSessions.Add(0);
-                _logger.LogTrace("Filtering available episodes by currently in use seasons. (Current Sessions: {CurrentSessions}, Pass: 4/4)", string.Join(", ", currentSessions));
-                tmdbEpisodes = (isOVA ? tmdbEpisodes : tmdbNormalEpisodes.Concat(tmdbSpecialEpisodes))
-                    .Where(episode => currentSessions.Contains(episode.SeasonNumber))
-                    .ToList();
-                tmdbNormalEpisodes = isOVA ? tmdbEpisodes : tmdbEpisodes
-                    .Where(episode => episode.SeasonNumber != 0)
-                    .OrderBy(episode => episode.SeasonNumber)
-                    .ThenBy(episode => episode.EpisodeNumber)
-                    .ToList();
-                tmdbSpecialEpisodes = isOVA ? tmdbEpisodes : tmdbEpisodes
-                    .Where(episode => episode.SeasonNumber == 0)
-                    .OrderBy(episode => episode.EpisodeNumber)
-                    .ToList();
-            }
+            FilterToCurrentSeasons(4);
 
             current = 0;
             foreach (var episode in fourthPass.OrderByDescending(PeekMatchConfidence))
@@ -755,9 +693,8 @@ public class TmdbLinkingService : ITmdbLinkingService
                 // Try find a match.
                 current++;
                 _logger.LogTrace("Linking episode {EpisodeType} {EpisodeNumber}. (AniDB ID: {EpisodeID}, Progress: {Current}/{Total}, Pass: 4/4)", episode.EpisodeType, episode.EpisodeNumber, episode.EpisodeID, current, fourthPass.Count);
-                var isSpecial = episode.EpisodeType is EpisodeType.Special || anime.AnimeType is not AnimeType.TVSeries and not AnimeType.Web;
-                var episodeList = isSpecial ? tmdbSpecialEpisodes : tmdbNormalEpisodes;
-                var crossRef = TryFindAnidbAndTmdbMatch(anime, episode, episodeList, isSpecial && !isOVA);
+                var episodeList = GetEpisodeList(episode);
+                var crossRef = TryFindAnidbAndTmdbMatch(anime, episode, episodeList, IsSpecialEpisode(episode) && !isOVA);
                 if (crossRef.TmdbEpisodeID != 0)
                 {
                     _logger.LogTrace("Adding new link for episode. (AniDB ID: {AnidbEpisodeID}, TMDB ID: {TMDbEpisodeID}, Rating: {MatchRating}, Pass: 4/4)", episode.EpisodeID, crossRef.TmdbEpisodeID, crossRef.MatchRating);
@@ -823,23 +760,9 @@ public class TmdbLinkingService : ITmdbLinkingService
     {
         confidence = 0;
 
-        // Skip matching if we try to match a music video or complete movie.
-        var anidbTitle = _anidbEpisodeTitles.GetByEpisodeIDAndLanguage(anidbEpisode.EpisodeID, TitleLanguage.English)
-            .FirstOrDefault(title => !IsGenericEpisodeTitle(title.Title, anidbEpisode.EpisodeType, anidbEpisode.EpisodeNumber))?.Title;
-        var titlesToNotSearch = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { "Complete Movie", "Music Video" };
-        if (!string.IsNullOrEmpty(anidbTitle) && titlesToNotSearch.Any(title => anidbTitle.Contains(title, StringComparison.InvariantCultureIgnoreCase)))
+        var anidbTitle = ResolveAnidbSearchTitle(anime, anidbEpisode, out var isExcludedTitle);
+        if (isExcludedTitle)
             return new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, 0, 0, MatchRating.None);
-
-        // Fix up the title for the first/single episode of a few anime types.
-        if (!string.IsNullOrEmpty(anidbTitle) && _titlesToSearch.Contains(anidbTitle))
-        {
-            var englishAnimeTitle = anime.Titles.FirstOrDefault(title => title.TitleType == TitleType.Official && title.Language == TitleLanguage.English)?.Title;
-            if (englishAnimeTitle is not null)
-            {
-                var i = englishAnimeTitle.IndexOf(':');
-                anidbTitle = i > 0 && i < englishAnimeTitle.Length - 1 ? englishAnimeTitle[(i + 1)..].TrimStart() : englishAnimeTitle;
-            }
-        }
 
         var anidbDate = anidbEpisode.GetAirDateAsDate()?.ToDateOnly();
         if (anidbDate is not null && anidbDate > DateTime.UtcNow.AddDays(1).ToDateOnly())
@@ -849,7 +772,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         }
 
         var airdateProbability = tmdbEpisodes
-            .Select(episode => new { episode, probability = CalculateAirDateProbability(anidbDate, episode.AiredAt) })
+            .Select(episode => (episode, probability: CalculateAirDateProbability(anidbDate, episode.AiredAt)))
             .Where(result => result.probability != 0)
             .OrderByDescending(result => result.probability)
             .ThenBy(result => result.episode.SeasonNumber == 0)
@@ -861,44 +784,61 @@ public class TmdbLinkingService : ITmdbLinkingService
             .OrderBy(result => result)
             .ToList() : [];
 
-        // Exact match first.
-        if (titleSearchResults.Count > 0 && titleSearchResults[0] is { } exactTitleMatch && exactTitleMatch.ExactMatch && exactTitleMatch.LengthDifference < 3)
+        var crossRef = SelectBestEpisodeMatch(anidbEpisode, tmdbEpisodes, isSpecial, titleSearchResults, airdateProbability, out confidence);
+        return crossRef;
+    }
+
+    // Resolves the AniDB title to search TMDB with, fixing it up for the first/single episode of a
+    // few anime types. isExcludedTitle is set when the episode is a bare "Complete Movie"/"Music
+    // Video" placeholder that should never be searched for.
+    private string? ResolveAnidbSearchTitle(AniDB_Anime anime, AniDB_Episode anidbEpisode, out bool isExcludedTitle)
+    {
+        isExcludedTitle = false;
+        var anidbTitle = _anidbEpisodeTitles.GetByEpisodeIDAndLanguage(anidbEpisode.EpisodeID, TitleLanguage.English)
+            .FirstOrDefault(title => !IsGenericEpisodeTitle(title.Title, anidbEpisode.EpisodeType, anidbEpisode.EpisodeNumber))?.Title;
+        if (string.IsNullOrEmpty(anidbTitle))
+            return anidbTitle;
+
+        var titlesToNotSearch = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { "Complete Movie", "Music Video" };
+        if (titlesToNotSearch.Any(title => anidbTitle.Contains(title, StringComparison.InvariantCultureIgnoreCase)))
         {
-            var tmdbEpisode = exactTitleMatch.Result;
-            var dateMatches = airdateProbability.Any(result => result.episode == tmdbEpisode);
-            var rating = dateMatches ? MatchRating.DateAndTitleMatches : MatchRating.TitleMatches;
-            confidence = (dateMatches ? 1 : 0) + (1 - exactTitleMatch.Distance);
-            return new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, rating);
+            isExcludedTitle = true;
+            return null;
         }
 
-        // Almost exact match second.
-        if (titleSearchResults.Count > 0 && titleSearchResults[0] is { } kindaTitleMatch && kindaTitleMatch.Distance < 0.2D && kindaTitleMatch.LengthDifference < 6)
+        // Fix up the title for the first/single episode of a few anime types.
+        if (_titlesToSearch.Contains(anidbTitle) && anime.Titles.FirstOrDefault(title => title.TitleType == TitleType.Official && title.Language == TitleLanguage.English)?.Title is { } englishAnimeTitle)
         {
-            var tmdbEpisode = kindaTitleMatch.Result;
-            var dateMatches = airdateProbability.Any(result => result.episode == tmdbEpisode);
-            var rating = dateMatches ? MatchRating.DateAndTitleKindaMatches : MatchRating.TitleKindaMatches;
-            confidence = (dateMatches ? 1 : 0) + (1 - kindaTitleMatch.Distance);
-            return new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, rating);
+            var i = englishAnimeTitle.IndexOf(':');
+            anidbTitle = i > 0 && i < englishAnimeTitle.Length - 1 ? englishAnimeTitle[(i + 1)..].TrimStart() : englishAnimeTitle;
         }
 
-        // Followed by checking the air date.
-        if (airdateProbability.Count > 0)
-        {
-            var matched = airdateProbability.FirstOrDefault(r => titleSearchResults.Any(result => result.Result == r.episode));
-            var tmdbEpisode = matched?.episode;
-            var rating = tmdbEpisode is null ? MatchRating.DateMatches : MatchRating.DateAndTitleKindaMatches;
-            confidence = matched?.probability ?? airdateProbability[0].probability;
-            tmdbEpisode ??= airdateProbability[0].episode;
-            return new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, rating);
-        }
+        return anidbTitle;
+    }
 
-        // Followed by _any_ title match.
-        if (titleSearchResults.Count > 0)
-        {
-            var tmdbEpisode = titleSearchResults[0]!.Result;
-            confidence = 1 - titleSearchResults[0]!.Distance;
-            return new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, MatchRating.TitleKindaMatches);
-        }
+    // Picks the strongest candidate out of the title/air-date evidence gathered by the caller, tiered
+    // from exact title+date corroboration down to a positional fallback.
+    private static CrossRef_AniDB_TMDB_Episode SelectBestEpisodeMatch(
+        AniDB_Episode anidbEpisode,
+        IReadOnlyList<TMDB_Episode> tmdbEpisodes,
+        bool isSpecial,
+        List<SeriesSearch.SearchResult<TMDB_Episode>> titleSearchResults,
+        List<(TMDB_Episode episode, double probability)> airdateProbability,
+        out double confidence)
+    {
+        if (TryExactTitleMatch(anidbEpisode, titleSearchResults, airdateProbability, out var crossRef, out confidence))
+            return crossRef;
+
+        if (TryKindaTitleMatch(anidbEpisode, titleSearchResults, airdateProbability, out crossRef, out confidence))
+            return crossRef;
+
+        if (TryAirDateMatch(anidbEpisode, titleSearchResults, airdateProbability, out crossRef, out confidence))
+            return crossRef;
+
+        if (TryAnyTitleMatch(anidbEpisode, titleSearchResults, out crossRef, out confidence))
+            return crossRef;
+
+        confidence = 0;
 
         // And finally, just pick the first available episode if it's not a special.
         if (!isSpecial && tmdbEpisodes.Count > 0)
@@ -906,6 +846,83 @@ public class TmdbLinkingService : ITmdbLinkingService
 
         // And if all above failed, then return an empty link.
         return new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, 0, 0, MatchRating.None);
+    }
+
+    private static bool TryExactTitleMatch(
+        AniDB_Episode anidbEpisode,
+        List<SeriesSearch.SearchResult<TMDB_Episode>> titleSearchResults,
+        List<(TMDB_Episode episode, double probability)> airdateProbability,
+        out CrossRef_AniDB_TMDB_Episode crossRef,
+        out double confidence)
+    {
+        crossRef = null!;
+        confidence = 0;
+        if (titleSearchResults.Count == 0 || titleSearchResults[0] is not { } exactTitleMatch || !exactTitleMatch.ExactMatch || exactTitleMatch.LengthDifference >= 3)
+            return false;
+
+        var tmdbEpisode = exactTitleMatch.Result;
+        var dateMatches = airdateProbability.Any(result => result.episode == tmdbEpisode);
+        var rating = dateMatches ? MatchRating.DateAndTitleMatches : MatchRating.TitleMatches;
+        confidence = (dateMatches ? 1 : 0) + (1 - exactTitleMatch.Distance);
+        crossRef = new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, rating);
+        return true;
+    }
+
+    private static bool TryKindaTitleMatch(
+        AniDB_Episode anidbEpisode,
+        List<SeriesSearch.SearchResult<TMDB_Episode>> titleSearchResults,
+        List<(TMDB_Episode episode, double probability)> airdateProbability,
+        out CrossRef_AniDB_TMDB_Episode crossRef,
+        out double confidence)
+    {
+        crossRef = null!;
+        confidence = 0;
+        if (titleSearchResults.Count == 0 || titleSearchResults[0] is not { } kindaTitleMatch || kindaTitleMatch.Distance >= 0.2D || kindaTitleMatch.LengthDifference >= 6)
+            return false;
+
+        var tmdbEpisode = kindaTitleMatch.Result;
+        var dateMatches = airdateProbability.Any(result => result.episode == tmdbEpisode);
+        var rating = dateMatches ? MatchRating.DateAndTitleKindaMatches : MatchRating.TitleKindaMatches;
+        confidence = (dateMatches ? 1 : 0) + (1 - kindaTitleMatch.Distance);
+        crossRef = new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, rating);
+        return true;
+    }
+
+    private static bool TryAirDateMatch(
+        AniDB_Episode anidbEpisode,
+        List<SeriesSearch.SearchResult<TMDB_Episode>> titleSearchResults,
+        List<(TMDB_Episode episode, double probability)> airdateProbability,
+        out CrossRef_AniDB_TMDB_Episode crossRef,
+        out double confidence)
+    {
+        crossRef = null!;
+        confidence = 0;
+        if (airdateProbability.Count == 0)
+            return false;
+
+        var matched = airdateProbability.FirstOrDefault(r => titleSearchResults.Any(result => result.Result == r.episode));
+        var tmdbEpisode = matched.episode ?? airdateProbability[0].episode;
+        var rating = matched.episode is null ? MatchRating.DateMatches : MatchRating.DateAndTitleKindaMatches;
+        confidence = matched.episode is null ? airdateProbability[0].probability : matched.probability;
+        crossRef = new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, rating);
+        return true;
+    }
+
+    private static bool TryAnyTitleMatch(
+        AniDB_Episode anidbEpisode,
+        List<SeriesSearch.SearchResult<TMDB_Episode>> titleSearchResults,
+        out CrossRef_AniDB_TMDB_Episode crossRef,
+        out double confidence)
+    {
+        crossRef = null!;
+        confidence = 0;
+        if (titleSearchResults.Count == 0)
+            return false;
+
+        var tmdbEpisode = titleSearchResults[0]!.Result;
+        confidence = 1 - titleSearchResults[0]!.Distance;
+        crossRef = new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, MatchRating.TitleKindaMatches);
+        return true;
     }
 
     private static double CalculateAirDateProbability(DateOnly? firstDate, DateOnly? secondDate, int maxDifferenceInDays = 2)
@@ -961,6 +978,7 @@ public class TmdbLinkingService : ITmdbLinkingService
             // Repeat until a full pass makes no swaps, to fully untangle runs of 3+ reversed weak matches.
             while (BubbleSwapPass(ordered, tmdbEpisodeDict))
             {
+                // Intentionally empty: BubbleSwapPass has already applied this pass's swaps in place.
             }
         }
     }

--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -806,7 +806,7 @@ public class TmdbLinkingService : ITmdbLinkingService
     {
         // Skip matching if we try to match a music video or complete movie.
         var anidbTitle = _anidbEpisodeTitles.GetByEpisodeIDAndLanguage(anidbEpisode.EpisodeID, TitleLanguage.English)
-            .Where(title => !title.Title.Trim().Equals($"Episode {anidbEpisode.EpisodeNumber}", StringComparison.InvariantCultureIgnoreCase))
+            .Where(title => !IsGenericEpisodeTitle(title.Title, anidbEpisode.EpisodeType, anidbEpisode.EpisodeNumber))
             .FirstOrDefault()?.Title;
         var titlesToNotSearch = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { "Complete Movie", "Music Video" };
         if (!string.IsNullOrEmpty(anidbTitle) && titlesToNotSearch.Any(title => anidbTitle.Contains(title, StringComparison.InvariantCultureIgnoreCase)))
@@ -902,6 +902,27 @@ public class TmdbLinkingService : ITmdbLinkingService
 
     private static string ReplaceTitle(string title) =>
         _characterReplacementDict.Aggregate(title, (current, kv) => current.Replace(kv.Key, kv.Value));
+
+    // AniDB emits an auto-generated placeholder title ("Episode 5", "Episode S1", "Episode C2", ...) for
+    // episodes it has no real title for, using the same type-prefix convention as AniDBEpisodeNumber
+    // (Episode="", Special="S", Credits="C", Trailer="T", Parody="P", Other="O" — see
+    // Shoko.Server.Providers.AniDB.Helpers.AniDBEpisodeNumber). Treating a placeholder as real title
+    // content lets it leak into the fuzzy title search and coincidentally "match" an unrelated TMDB
+    // episode purely because both titles are just "Episode <number>" — with no title evidence behind it.
+    // The old check only excluded the normal-episode form ("Episode {N}"), so specials/credits/trailers/
+    // etc. with no real title were never filtered.
+    private static readonly Dictionary<EpisodeType, string> _episodeTypePrefixes = new()
+    {
+        [EpisodeType.Episode] = "",
+        [EpisodeType.Special] = "S",
+        [EpisodeType.Credits] = "C",
+        [EpisodeType.Trailer] = "T",
+        [EpisodeType.Parody] = "P",
+        [EpisodeType.Other] = "O",
+    };
+
+    private static bool IsGenericEpisodeTitle(string title, EpisodeType episodeType, int episodeNumber) =>
+        title.Trim().Equals($"Episode {_episodeTypePrefixes.GetValueOrDefault(episodeType)}{episodeNumber}", StringComparison.InvariantCultureIgnoreCase);
 
     // Ratings assigned without any title evidence — pure air-date coincidence or the last-resort
     // positional fallback. Both are cheap to get backwards when TMDB's own episode dates are shifted

--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -903,49 +903,39 @@ public class TmdbLinkingService : ITmdbLinkingService
     private static string ReplaceTitle(string title) =>
         _characterReplacementDict.Aggregate(title, (current, kv) => current.Replace(kv.Key, kv.Value));
 
-    // AniDB emits an auto-generated placeholder title ("Episode 5", "Episode S1", "Episode C2", ...) for
-    // episodes it has no real title for, using the same type-prefix convention as AniDBEpisodeNumber
-    // (Episode="", Special="S", Credits="C", Trailer="T", Parody="P", Other="O" — see
-    // Shoko.Server.Providers.AniDB.Helpers.AniDBEpisodeNumber). Treating a placeholder as real title
-    // content lets it leak into the fuzzy title search and coincidentally "match" an unrelated TMDB
-    // episode purely because both titles are just "Episode <number>" — with no title evidence behind it.
-    // The old check only excluded the normal-episode form ("Episode {N}"), so specials/credits/trailers/
-    // etc. with no real title were never filtered.
-    private static readonly Dictionary<EpisodeType, string> _episodeTypePrefixes = new()
+    // Mirrors AniDBEpisodeNumber.ToString()'s prefix convention; throws instead of silently defaulting if the two ever drift apart.
+    private static string GenericEpisodeTitlePrefix(EpisodeType episodeType) => episodeType switch
     {
-        [EpisodeType.Episode] = "",
-        [EpisodeType.Special] = "S",
-        [EpisodeType.Credits] = "C",
-        [EpisodeType.Trailer] = "T",
-        [EpisodeType.Parody] = "P",
-        [EpisodeType.Other] = "O",
+        EpisodeType.Episode => "",
+        EpisodeType.Special => "S",
+        EpisodeType.Credits => "C",
+        EpisodeType.Trailer => "T",
+        EpisodeType.Parody => "P",
+        EpisodeType.Other => "O",
+        _ => throw new ArgumentOutOfRangeException(nameof(episodeType), episodeType, null),
     };
 
     private static bool IsGenericEpisodeTitle(string title, EpisodeType episodeType, int episodeNumber) =>
-        title.Trim().Equals($"Episode {_episodeTypePrefixes.GetValueOrDefault(episodeType)}{episodeNumber}", StringComparison.InvariantCultureIgnoreCase);
+        title.Trim().Equals($"Episode {GenericEpisodeTitlePrefix(episodeType)}{episodeNumber}", StringComparison.InvariantCultureIgnoreCase);
 
-    // Ratings assigned without any title evidence — pure air-date coincidence or the last-resort
-    // positional fallback. Both are cheap to get backwards when TMDB's own episode dates are shifted
-    // relative to AniDB's (e.g. an early exclusive-stream premiere AniDB tracked but TMDB never listed),
-    // since a date-only match can grab the wrong TMDB episode before its true AniDB neighbor gets a turn.
+    // Ratings assigned with zero title evidence — the only ones a coincidental air-date mismatch can put out of order.
     private static readonly HashSet<MatchRating> _weakOrderRatings = [MatchRating.DateMatches, MatchRating.FirstAvailable];
 
-    // AniDB's episode order is the point of truth. If two AniDB-adjacent episodes both matched on
-    // weak evidence alone and their TMDB assignments came out in the wrong order, swap them back into
-    // AniDB order instead of trusting TMDB's (possibly mis-dated) episode numbering.
-    internal static void ReconcileEpisodeOrderInversions(IReadOnlyDictionary<int, AniDB_Episode> anidbEpisodes, IReadOnlyDictionary<int, TMDB_Episode> tmdbEpisodeDict, IReadOnlyList<CrossRef_AniDB_TMDB_Episode> toAdd)
+    // Swaps adjacent weak TMDB matches into AniDB order; strong matches stay in the ordering (true adjacency) but are never swapped.
+    internal static void ReconcileEpisodeOrderInversions(
+        IReadOnlyDictionary<int, AniDB_Episode> anidbEpisodes,
+        IReadOnlyDictionary<int, TMDB_Episode> tmdbEpisodeDict,
+        IReadOnlyList<CrossRef_AniDB_TMDB_Episode> toAdd)
     {
         var groups = toAdd
-            .Where(xref => xref.TmdbEpisodeID != 0 && _weakOrderRatings.Contains(xref.MatchRating) && anidbEpisodes.ContainsKey(xref.AnidbEpisodeID))
+            .Where(xref => xref.TmdbEpisodeID != 0 && anidbEpisodes.ContainsKey(xref.AnidbEpisodeID))
             .GroupBy(xref => anidbEpisodes[xref.AnidbEpisodeID].EpisodeType);
 
         foreach (var group in groups)
         {
             var ordered = group.OrderBy(xref => anidbEpisodes[xref.AnidbEpisodeID].EpisodeNumber).ToList();
 
-            // A single left-to-right pass only bubbles one inversion at a time, so a run of 3+
-            // weak matches in reverse order (e.g. T3,T2,T1) needs more than one pass to fully
-            // untangle. Repeat until a full pass makes no swaps.
+            // Repeat until a full pass makes no swaps, to fully untangle runs of 3+ reversed weak matches.
             bool swapped;
             do
             {
@@ -954,6 +944,8 @@ public class TmdbLinkingService : ITmdbLinkingService
                 {
                     var a = ordered[i];
                     var b = ordered[i + 1];
+                    if (!_weakOrderRatings.Contains(a.MatchRating) || !_weakOrderRatings.Contains(b.MatchRating))
+                        continue;
                     if (!tmdbEpisodeDict.TryGetValue(a.TmdbEpisodeID, out var tmdbA) || !tmdbEpisodeDict.TryGetValue(b.TmdbEpisodeID, out var tmdbB))
                         continue;
 

--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -511,8 +511,19 @@ public class TmdbLinkingService : ITmdbLinkingService
             .Where(episode => episode.SeasonNumber == 0)
             .OrderBy(episode => episode.EpisodeNumber)
             .ToList();
+        // Ranks an AniDB episode's best candidate match without consuming it, so passes can process
+        // the strongest matches first and let weaker duplicate claims fall back to their next-best
+        // candidate instead of losing a shared TMDB episode purely by AniDB episode order.
+        double PeekMatchConfidence(AniDB_Episode ep)
+        {
+            var isSpecialEpisode = ep.EpisodeType is EpisodeType.Special || anime.AnimeType is not AnimeType.TVSeries and not AnimeType.Web;
+            var candidates = isSpecialEpisode ? tmdbSpecialEpisodes : tmdbNormalEpisodes;
+            TryFindAnidbAndTmdbMatch(anime, ep, candidates, isSpecialEpisode && !isOVA, out var episodeConfidence);
+            return episodeConfidence;
+        }
+
         var current = 0;
-        foreach (var episode in anidbEpisodes.Values)
+        foreach (var episode in anidbEpisodes.Values.OrderByDescending(PeekMatchConfidence))
         {
             current++;
             _logger.LogTrace("Checking episode {EpisodeType} {EpisodeNumber}. (AniDB ID: {AnidbEpisodeID}, Progress: {Current}/{Total}, Pass: 1/4)", episode.EpisodeType, episode.EpisodeNumber, episode.EpisodeID, current, anidbEpisodes.Count);
@@ -631,7 +642,7 @@ public class TmdbLinkingService : ITmdbLinkingService
             }
 
             current = 0;
-            foreach (var episode in secondPass)
+            foreach (var episode in secondPass.OrderByDescending(PeekMatchConfidence))
             {
                 // Try find a match.
                 current++;
@@ -685,7 +696,7 @@ public class TmdbLinkingService : ITmdbLinkingService
             }
 
             current = 0;
-            foreach (var episode in thirdPass)
+            foreach (var episode in thirdPass.OrderByDescending(PeekMatchConfidence))
             {
                 // Try find a match.
                 current++;
@@ -739,7 +750,7 @@ public class TmdbLinkingService : ITmdbLinkingService
             }
 
             current = 0;
-            foreach (var episode in fourthPass)
+            foreach (var episode in fourthPass.OrderByDescending(PeekMatchConfidence))
             {
                 // Try find a match.
                 current++;
@@ -802,12 +813,19 @@ public class TmdbLinkingService : ITmdbLinkingService
         int NormalEpisodeSeasonNumberSelector(CrossRef_AniDB_TMDB_Episode xref) => xref.TmdbEpisodeID is not 0 && (isOVA || anidbEpisodes[xref.AnidbEpisodeID].EpisodeType is EpisodeType.Episode) && tmdbEpisodeDict.TryGetValue(xref.TmdbEpisodeID, out var tmdbEpisode) ? tmdbEpisode.SeasonNumber : -1;
     }
 
-    private CrossRef_AniDB_TMDB_Episode TryFindAnidbAndTmdbMatch(AniDB_Anime anime, AniDB_Episode anidbEpisode, IReadOnlyList<TMDB_Episode> tmdbEpisodes, bool isSpecial)
+    private CrossRef_AniDB_TMDB_Episode TryFindAnidbAndTmdbMatch(AniDB_Anime anime, AniDB_Episode anidbEpisode, IReadOnlyList<TMDB_Episode> tmdbEpisodes, bool isSpecial) =>
+        TryFindAnidbAndTmdbMatch(anime, anidbEpisode, tmdbEpisodes, isSpecial, out _);
+
+    // The out confidence score lets callers rank multiple AniDB episodes contending for the same
+    // TMDB episode within a pass, so the strongest match claims it instead of whichever AniDB
+    // episode happened to be processed first.
+    private CrossRef_AniDB_TMDB_Episode TryFindAnidbAndTmdbMatch(AniDB_Anime anime, AniDB_Episode anidbEpisode, IReadOnlyList<TMDB_Episode> tmdbEpisodes, bool isSpecial, out double confidence)
     {
+        confidence = 0;
+
         // Skip matching if we try to match a music video or complete movie.
         var anidbTitle = _anidbEpisodeTitles.GetByEpisodeIDAndLanguage(anidbEpisode.EpisodeID, TitleLanguage.English)
-            .Where(title => !IsGenericEpisodeTitle(title.Title, anidbEpisode.EpisodeType, anidbEpisode.EpisodeNumber))
-            .FirstOrDefault()?.Title;
+            .FirstOrDefault(title => !IsGenericEpisodeTitle(title.Title, anidbEpisode.EpisodeType, anidbEpisode.EpisodeNumber))?.Title;
         var titlesToNotSearch = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase) { "Complete Movie", "Music Video" };
         if (!string.IsNullOrEmpty(anidbTitle) && titlesToNotSearch.Any(title => anidbTitle.Contains(title, StringComparison.InvariantCultureIgnoreCase)))
             return new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, 0, 0, MatchRating.None);
@@ -849,6 +867,7 @@ public class TmdbLinkingService : ITmdbLinkingService
             var tmdbEpisode = exactTitleMatch.Result;
             var dateMatches = airdateProbability.Any(result => result.episode == tmdbEpisode);
             var rating = dateMatches ? MatchRating.DateAndTitleMatches : MatchRating.TitleMatches;
+            confidence = (dateMatches ? 1 : 0) + (1 - exactTitleMatch.Distance);
             return new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, rating);
         }
 
@@ -858,14 +877,17 @@ public class TmdbLinkingService : ITmdbLinkingService
             var tmdbEpisode = kindaTitleMatch.Result;
             var dateMatches = airdateProbability.Any(result => result.episode == tmdbEpisode);
             var rating = dateMatches ? MatchRating.DateAndTitleKindaMatches : MatchRating.TitleKindaMatches;
+            confidence = (dateMatches ? 1 : 0) + (1 - kindaTitleMatch.Distance);
             return new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, rating);
         }
 
         // Followed by checking the air date.
         if (airdateProbability.Count > 0)
         {
-            var tmdbEpisode = airdateProbability.FirstOrDefault(r => titleSearchResults.Any(result => result.Result == r.episode))?.episode;
+            var matched = airdateProbability.FirstOrDefault(r => titleSearchResults.Any(result => result.Result == r.episode));
+            var tmdbEpisode = matched?.episode;
             var rating = tmdbEpisode is null ? MatchRating.DateMatches : MatchRating.DateAndTitleKindaMatches;
+            confidence = matched?.probability ?? airdateProbability[0].probability;
             tmdbEpisode ??= airdateProbability[0].episode;
             return new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, rating);
         }
@@ -874,6 +896,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         if (titleSearchResults.Count > 0)
         {
             var tmdbEpisode = titleSearchResults[0]!.Result;
+            confidence = 1 - titleSearchResults[0]!.Distance;
             return new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, MatchRating.TitleKindaMatches);
         }
 
@@ -936,28 +959,39 @@ public class TmdbLinkingService : ITmdbLinkingService
             var ordered = group.OrderBy(xref => anidbEpisodes[xref.AnidbEpisodeID].EpisodeNumber).ToList();
 
             // Repeat until a full pass makes no swaps, to fully untangle runs of 3+ reversed weak matches.
-            bool swapped;
-            do
+            while (BubbleSwapPass(ordered, tmdbEpisodeDict))
             {
-                swapped = false;
-                for (var i = 0; i < ordered.Count - 1; i++)
-                {
-                    var a = ordered[i];
-                    var b = ordered[i + 1];
-                    if (!_weakOrderRatings.Contains(a.MatchRating) || !_weakOrderRatings.Contains(b.MatchRating))
-                        continue;
-                    if (!tmdbEpisodeDict.TryGetValue(a.TmdbEpisodeID, out var tmdbA) || !tmdbEpisodeDict.TryGetValue(b.TmdbEpisodeID, out var tmdbB))
-                        continue;
-
-                    if ((tmdbA.SeasonNumber, tmdbA.EpisodeNumber).CompareTo((tmdbB.SeasonNumber, tmdbB.EpisodeNumber)) <= 0)
-                        continue;
-
-                    (a.TmdbEpisodeID, b.TmdbEpisodeID) = (b.TmdbEpisodeID, a.TmdbEpisodeID);
-                    (a.TmdbShowID, b.TmdbShowID) = (b.TmdbShowID, a.TmdbShowID);
-                    swapped = true;
-                }
-            } while (swapped);
+            }
         }
+    }
+
+    // A single left-to-right adjacent-swap pass over the ordered group; returns true if anything moved.
+    private static bool BubbleSwapPass(List<CrossRef_AniDB_TMDB_Episode> ordered, IReadOnlyDictionary<int, TMDB_Episode> tmdbEpisodeDict)
+    {
+        var swapped = false;
+        for (var i = 0; i < ordered.Count - 1; i++)
+        {
+            var a = ordered[i];
+            var b = ordered[i + 1];
+            if (!ShouldSwap(a, b, tmdbEpisodeDict))
+                continue;
+
+            (a.TmdbEpisodeID, b.TmdbEpisodeID) = (b.TmdbEpisodeID, a.TmdbEpisodeID);
+            (a.TmdbShowID, b.TmdbShowID) = (b.TmdbShowID, a.TmdbShowID);
+            swapped = true;
+        }
+
+        return swapped;
+    }
+
+    private static bool ShouldSwap(CrossRef_AniDB_TMDB_Episode a, CrossRef_AniDB_TMDB_Episode b, IReadOnlyDictionary<int, TMDB_Episode> tmdbEpisodeDict)
+    {
+        if (!_weakOrderRatings.Contains(a.MatchRating) || !_weakOrderRatings.Contains(b.MatchRating))
+            return false;
+        if (!tmdbEpisodeDict.TryGetValue(a.TmdbEpisodeID, out var tmdbA) || !tmdbEpisodeDict.TryGetValue(b.TmdbEpisodeID, out var tmdbB))
+            return false;
+
+        return (tmdbA.SeasonNumber, tmdbA.EpisodeNumber).CompareTo((tmdbB.SeasonNumber, tmdbB.EpisodeNumber)) > 0;
     }
 
     #endregion

--- a/Shoko.Server/Utilities/SeriesSearch.cs
+++ b/Shoko.Server/Utilities/SeriesSearch.cs
@@ -99,8 +99,10 @@ public static class SeriesSearch
         {
             if (CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.NonSpacingMark)
                 continue;
-            // U+301C 〜 (wave dash) survives NFKD unchanged and must be mapped explicitly.
-            sb.Append(c is '-' or '_' or '.' or ':' or ',' or '!' or ';' or '/' or '\\' or '(' or ')' or '[' or ']' or '〜' ? ' ' : c);
+            // U+301C 〜 (wave dash) survives NFKD unchanged and must be mapped explicitly. ASCII '~' is
+            // included alongside it since both are used interchangeably as decorative emphasis brackets
+            // in anime episode titles (e.g. "~Walpurgis~" vs ": Walpurgis"), never as meaningful content.
+            sb.Append(c is '-' or '_' or '.' or ':' or ',' or '!' or ';' or '/' or '\\' or '(' or ')' or '[' or ']' or '〜' or '~' ? ' ' : c);
         }
 
         return sb.ToString().Normalize(NormalizationForm.FormKC).ToLowerInvariant().CompactWhitespaces();

--- a/Shoko.Server/Utilities/SeriesSearch.cs
+++ b/Shoko.Server/Utilities/SeriesSearch.cs
@@ -102,7 +102,9 @@ public static class SeriesSearch
             // U+301C 〜 (wave dash) survives NFKD unchanged and must be mapped explicitly. ASCII '~' is
             // included alongside it since both are used interchangeably as decorative emphasis brackets
             // in anime episode titles (e.g. "~Walpurgis~" vs ": Walpurgis"), never as meaningful content.
-            sb.Append(c is '-' or '_' or '.' or ':' or ',' or '!' or ';' or '/' or '\\' or '(' or ')' or '[' or ']' or '〜' or '~' ? ' ' : c);
+            // '|' joins the same family: some sources join a double-episode title with "A / B", others
+            // with "A | B" (e.g. "Bell Cranel: Adventurer" vs "Bell Cranel | Adventurer").
+            sb.Append(c is '-' or '_' or '.' or ':' or ',' or '!' or ';' or '/' or '\\' or '(' or ')' or '[' or ']' or '〜' or '~' or '|' ? ' ' : c);
         }
 
         return sb.ToString().Normalize(NormalizationForm.FormKC).ToLowerInvariant().CompactWhitespaces();

--- a/Shoko.Server/Utilities/SeriesSearch.cs
+++ b/Shoko.Server/Utilities/SeriesSearch.cs
@@ -99,11 +99,7 @@ public static class SeriesSearch
         {
             if (CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.NonSpacingMark)
                 continue;
-            // U+301C 〜 (wave dash) survives NFKD unchanged and must be mapped explicitly. ASCII '~' is
-            // included alongside it since both are used interchangeably as decorative emphasis brackets
-            // in anime episode titles (e.g. "~Walpurgis~" vs ": Walpurgis"), never as meaningful content.
-            // '|' joins the same family: some sources join a double-episode title with "A / B", others
-            // with "A | B" (e.g. "Bell Cranel: Adventurer" vs "Bell Cranel | Adventurer").
+            // U+301C 〜 survives NFKD unchanged; '~'/'|' join it as decorative separators (e.g. "~X~"/": X", "A | B"/"A / B").
             sb.Append(c is '-' or '_' or '.' or ':' or ',' or '!' or ';' or '/' or '\\' or '(' or ')' or '[' or ']' or '〜' or '~' or '|' ? ' ' : c);
         }
 

--- a/Shoko.Tests/Providers/TMDB/TmdbLinkingServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbLinkingServiceTests.cs
@@ -143,4 +143,26 @@ public class TmdbLinkingServiceTests
         Assert.Equal(101, xrefEpisode.TmdbEpisodeID);
         Assert.Equal(102, xrefSpecial.TmdbEpisodeID);
     }
+
+    // AniDB's auto-generated placeholder title for an untitled episode follows the same type-prefix
+    // convention as AniDBEpisodeNumber (Episode="", Special="S", Credits="C", Trailer="T", Parody="P",
+    // Other="O"). Reproduces a live mismatch: an untitled AniDB special aired 2021-01-06 got matched to
+    // an unrelated TMDB "Episode 10" (aired 2019-08-01, no date corroboration at all) purely because the
+    // old filter only recognized the normal-episode placeholder form ("Episode {N}") and let "Episode S1"
+    // leak through as if it were a real, distinguishing title.
+    [Theory]
+    [InlineData(EpisodeType.Episode, 5, "Episode 5", true)]
+    [InlineData(EpisodeType.Special, 1, "Episode S1", true)]
+    [InlineData(EpisodeType.Credits, 2, "Episode C2", true)]
+    [InlineData(EpisodeType.Trailer, 3, "Episode T3", true)]
+    [InlineData(EpisodeType.Parody, 4, "Episode P4", true)]
+    [InlineData(EpisodeType.Other, 6, "Episode O6", true)]
+    [InlineData(EpisodeType.Special, 1, "Episode 1", false)]
+    [InlineData(EpisodeType.Special, 1, "Demon Lords' Banquet: Walpurgis", false)]
+    public void IsGenericEpisodeTitle_RecognizesPerTypePlaceholderFormat(EpisodeType episodeType, int episodeNumber, string title, bool expected)
+    {
+        var method = typeof(TmdbLinkingService).GetMethod("IsGenericEpisodeTitle", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        var result = (bool)method.Invoke(null, [title, episodeType, episodeNumber])!;
+        Assert.Equal(expected, result);
+    }
 }

--- a/Shoko.Tests/Providers/TMDB/TmdbLinkingServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbLinkingServiceTests.cs
@@ -161,7 +161,8 @@ public class TmdbLinkingServiceTests
     [InlineData(EpisodeType.Special, 1, "Demon Lords' Banquet: Walpurgis", false)]
     public void IsGenericEpisodeTitle_RecognizesPerTypePlaceholderFormat(EpisodeType episodeType, int episodeNumber, string title, bool expected)
     {
-        var method = typeof(TmdbLinkingService).GetMethod("IsGenericEpisodeTitle", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static;
+        var method = typeof(TmdbLinkingService).GetMethod("IsGenericEpisodeTitle", flags)!;
         var result = (bool)method.Invoke(null, [title, episodeType, episodeNumber])!;
         Assert.Equal(expected, result);
     }

--- a/Shoko.Tests/Providers/TMDB/TmdbLinkingServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbLinkingServiceTests.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using Shoko.Abstractions.Metadata.Enums;
+using Shoko.Server.Models.AniDB;
+using Shoko.Server.Models.CrossReference;
+using Shoko.Server.Models.TMDB;
+using Shoko.Server.Providers.TMDB;
+using Xunit;
+
+namespace Shoko.Tests.Providers.TMDB;
+
+public class TmdbLinkingServiceTests
+{
+    // Reproduces "Heroine? Saint? No, I'm an All-Works Maid (And Proud of It)!": AniDB tracks an
+    // early exclusive-stream premiere for episode 1 (2026-06-24) that TMDB never listed. TMDB's S1E1
+    // is dated 2026-07-01, which happens to be AniDB episode 2's air date, so a date-only match grabs
+    // TMDB S1E1 for AniDB episode 2 before episode 1 gets a turn, leaving episode 1 to fall back to
+    // "first available" (TMDB S1E2). Reconciliation should swap them back into AniDB order.
+    [Fact]
+    public void ReconcileEpisodeOrderInversions_SwapsBackToAnidbOrder_WhenBothMatchesAreWeak()
+    {
+        var anidbEp1 = new AniDB_Episode { EpisodeID = 1, EpisodeNumber = 1, EpisodeType = EpisodeType.Episode };
+        var anidbEp2 = new AniDB_Episode { EpisodeID = 2, EpisodeNumber = 2, EpisodeType = EpisodeType.Episode };
+        var anidbEpisodes = new Dictionary<int, AniDB_Episode> { [1] = anidbEp1, [2] = anidbEp2 };
+
+        var tmdbEp1 = new TMDB_Episode { TmdbEpisodeID = 101, SeasonNumber = 1, EpisodeNumber = 1 };
+        var tmdbEp2 = new TMDB_Episode { TmdbEpisodeID = 102, SeasonNumber = 1, EpisodeNumber = 2 };
+        var tmdbEpisodeDict = new Dictionary<int, TMDB_Episode> { [101] = tmdbEp1, [102] = tmdbEp2 };
+
+        // Bug reproduction: episode 1 fell back to "first available" TMDB S1E2, episode 2 grabbed
+        // TMDB S1E1 via a coincidental exact air-date match.
+        var xrefEp1 = new CrossRef_AniDB_TMDB_Episode(anidbEp1.EpisodeID, 0, tmdbEp2.TmdbEpisodeID, 0, MatchRating.FirstAvailable);
+        var xrefEp2 = new CrossRef_AniDB_TMDB_Episode(anidbEp2.EpisodeID, 0, tmdbEp1.TmdbEpisodeID, 0, MatchRating.DateMatches);
+        var toAdd = new List<CrossRef_AniDB_TMDB_Episode> { xrefEp1, xrefEp2 };
+
+        TmdbLinkingService.ReconcileEpisodeOrderInversions(anidbEpisodes, tmdbEpisodeDict, toAdd);
+
+        Assert.Equal(tmdbEp1.TmdbEpisodeID, xrefEp1.TmdbEpisodeID);
+        Assert.Equal(tmdbEp2.TmdbEpisodeID, xrefEp2.TmdbEpisodeID);
+    }
+
+    [Fact]
+    public void ReconcileEpisodeOrderInversions_LeavesOrderAlone_WhenAlreadyCorrect()
+    {
+        var anidbEp1 = new AniDB_Episode { EpisodeID = 1, EpisodeNumber = 1, EpisodeType = EpisodeType.Episode };
+        var anidbEp2 = new AniDB_Episode { EpisodeID = 2, EpisodeNumber = 2, EpisodeType = EpisodeType.Episode };
+        var anidbEpisodes = new Dictionary<int, AniDB_Episode> { [1] = anidbEp1, [2] = anidbEp2 };
+
+        var tmdbEp1 = new TMDB_Episode { TmdbEpisodeID = 101, SeasonNumber = 1, EpisodeNumber = 1 };
+        var tmdbEp2 = new TMDB_Episode { TmdbEpisodeID = 102, SeasonNumber = 1, EpisodeNumber = 2 };
+        var tmdbEpisodeDict = new Dictionary<int, TMDB_Episode> { [101] = tmdbEp1, [102] = tmdbEp2 };
+
+        var xrefEp1 = new CrossRef_AniDB_TMDB_Episode(anidbEp1.EpisodeID, 0, tmdbEp1.TmdbEpisodeID, 0, MatchRating.FirstAvailable);
+        var xrefEp2 = new CrossRef_AniDB_TMDB_Episode(anidbEp2.EpisodeID, 0, tmdbEp2.TmdbEpisodeID, 0, MatchRating.DateMatches);
+        var toAdd = new List<CrossRef_AniDB_TMDB_Episode> { xrefEp1, xrefEp2 };
+
+        TmdbLinkingService.ReconcileEpisodeOrderInversions(anidbEpisodes, tmdbEpisodeDict, toAdd);
+
+        Assert.Equal(tmdbEp1.TmdbEpisodeID, xrefEp1.TmdbEpisodeID);
+        Assert.Equal(tmdbEp2.TmdbEpisodeID, xrefEp2.TmdbEpisodeID);
+    }
+
+    // A strong (title-corroborated) match should never be reshuffled just because its weak neighbor
+    // looks out of order — the title evidence is trusted over positional guessing.
+    [Fact]
+    public void ReconcileEpisodeOrderInversions_DoesNotTouchStrongMatches()
+    {
+        var anidbEp1 = new AniDB_Episode { EpisodeID = 1, EpisodeNumber = 1, EpisodeType = EpisodeType.Episode };
+        var anidbEp2 = new AniDB_Episode { EpisodeID = 2, EpisodeNumber = 2, EpisodeType = EpisodeType.Episode };
+        var anidbEpisodes = new Dictionary<int, AniDB_Episode> { [1] = anidbEp1, [2] = anidbEp2 };
+
+        var tmdbEp1 = new TMDB_Episode { TmdbEpisodeID = 101, SeasonNumber = 1, EpisodeNumber = 1 };
+        var tmdbEp2 = new TMDB_Episode { TmdbEpisodeID = 102, SeasonNumber = 1, EpisodeNumber = 2 };
+        var tmdbEpisodeDict = new Dictionary<int, TMDB_Episode> { [101] = tmdbEp1, [102] = tmdbEp2 };
+
+        // Episode 1 has a confirmed title match pointing at S1E2 (e.g. a legitimately reordered
+        // episode); episode 2 only has a weak positional guess at S1E1. This should not be swapped.
+        var xrefEp1 = new CrossRef_AniDB_TMDB_Episode(anidbEp1.EpisodeID, 0, tmdbEp2.TmdbEpisodeID, 0, MatchRating.TitleMatches);
+        var xrefEp2 = new CrossRef_AniDB_TMDB_Episode(anidbEp2.EpisodeID, 0, tmdbEp1.TmdbEpisodeID, 0, MatchRating.FirstAvailable);
+        var toAdd = new List<CrossRef_AniDB_TMDB_Episode> { xrefEp1, xrefEp2 };
+
+        TmdbLinkingService.ReconcileEpisodeOrderInversions(anidbEpisodes, tmdbEpisodeDict, toAdd);
+
+        Assert.Equal(tmdbEp2.TmdbEpisodeID, xrefEp1.TmdbEpisodeID);
+        Assert.Equal(tmdbEp1.TmdbEpisodeID, xrefEp2.TmdbEpisodeID);
+    }
+
+    // A single left-to-right adjacent-swap pass only bubbles one inversion per pass — a full
+    // 3-episode reversal (AniDB 1,2,3 -> TMDB 3,2,1) needs two passes to fully sort. Confirms the
+    // reconciliation loops until stable rather than stopping after one pass.
+    [Fact]
+    public void ReconcileEpisodeOrderInversions_FullyUntangles_ThreeEpisodeReversal()
+    {
+        var anidbEpisodes = new Dictionary<int, AniDB_Episode>
+        {
+            [1] = new() { EpisodeID = 1, EpisodeNumber = 1, EpisodeType = EpisodeType.Episode },
+            [2] = new() { EpisodeID = 2, EpisodeNumber = 2, EpisodeType = EpisodeType.Episode },
+            [3] = new() { EpisodeID = 3, EpisodeNumber = 3, EpisodeType = EpisodeType.Episode },
+        };
+
+        var tmdbEpisodeDict = new Dictionary<int, TMDB_Episode>
+        {
+            [101] = new() { TmdbEpisodeID = 101, SeasonNumber = 1, EpisodeNumber = 1 },
+            [102] = new() { TmdbEpisodeID = 102, SeasonNumber = 1, EpisodeNumber = 2 },
+            [103] = new() { TmdbEpisodeID = 103, SeasonNumber = 1, EpisodeNumber = 3 },
+        };
+
+        var xrefEp1 = new CrossRef_AniDB_TMDB_Episode(1, 0, 103, 0, MatchRating.FirstAvailable);
+        var xrefEp2 = new CrossRef_AniDB_TMDB_Episode(2, 0, 102, 0, MatchRating.DateMatches);
+        var xrefEp3 = new CrossRef_AniDB_TMDB_Episode(3, 0, 101, 0, MatchRating.FirstAvailable);
+        var toAdd = new List<CrossRef_AniDB_TMDB_Episode> { xrefEp1, xrefEp2, xrefEp3 };
+
+        TmdbLinkingService.ReconcileEpisodeOrderInversions(anidbEpisodes, tmdbEpisodeDict, toAdd);
+
+        Assert.Equal(101, xrefEp1.TmdbEpisodeID);
+        Assert.Equal(102, xrefEp2.TmdbEpisodeID);
+        Assert.Equal(103, xrefEp3.TmdbEpisodeID);
+    }
+
+    // Specials and normal episodes are matched independently and should never be reconciled
+    // against each other even if their AniDB episode numbers happen to collide (e.g. Special 1
+    // and Episode 1).
+    [Fact]
+    public void ReconcileEpisodeOrderInversions_DoesNotCrossEpisodeTypeBoundary()
+    {
+        var anidbEpisodes = new Dictionary<int, AniDB_Episode>
+        {
+            [1] = new() { EpisodeID = 1, EpisodeNumber = 1, EpisodeType = EpisodeType.Episode },
+            [2] = new() { EpisodeID = 2, EpisodeNumber = 1, EpisodeType = EpisodeType.Special },
+        };
+
+        var tmdbEpisodeDict = new Dictionary<int, TMDB_Episode>
+        {
+            [101] = new() { TmdbEpisodeID = 101, SeasonNumber = 1, EpisodeNumber = 2 },
+            [102] = new() { TmdbEpisodeID = 102, SeasonNumber = 0, EpisodeNumber = 1 },
+        };
+
+        var xrefEpisode = new CrossRef_AniDB_TMDB_Episode(1, 0, 101, 0, MatchRating.FirstAvailable);
+        var xrefSpecial = new CrossRef_AniDB_TMDB_Episode(2, 0, 102, 0, MatchRating.FirstAvailable);
+        var toAdd = new List<CrossRef_AniDB_TMDB_Episode> { xrefEpisode, xrefSpecial };
+
+        TmdbLinkingService.ReconcileEpisodeOrderInversions(anidbEpisodes, tmdbEpisodeDict, toAdd);
+
+        Assert.Equal(101, xrefEpisode.TmdbEpisodeID);
+        Assert.Equal(102, xrefSpecial.TmdbEpisodeID);
+    }
+}

--- a/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbSearchServiceTests.cs
@@ -105,16 +105,15 @@ public class TmdbSearchServiceTests
     public void NormalizeForIndex_WaveDash_MapsToSpace(string input, string expected)
         => Assert.Equal(expected, SeriesSearch.NormalizeForIndex(input).Trim());
 
-    // ── NormalizeForIndex: fullwidth tilde U+FF5E (known gap) ───────────────
+    // ── NormalizeForIndex: fullwidth tilde U+FF5E ────────────────────────────
 
     [Fact]
-    public void NormalizeForIndex_FullwidthTilde_NotMappedToSpace()
+    public void NormalizeForIndex_FullwidthTilde_MappedToSpace()
     {
-        // U+FF5E ～ is converted by NFKC to ASCII tilde ~ (not a space).
-        // This is a known gap — it does not get the same treatment as U+301C 〜.
-        // This test documents the current behavior so any future change is intentional.
+        // U+FF5E ～ is decomposed by NFKD to ASCII tilde ~ before the separator mapping runs,
+        // so it now gets the same space treatment as ASCII '~' and U+301C 〜.
         var result = SeriesSearch.NormalizeForIndex("Foo～Bar");
-        Assert.NotEqual("foo bar", result);  // tilde survives, space not inserted
+        Assert.Equal("foo bar", result);
     }
 
     // ── NormalizeForIndex: superscript decomposition ─────────────────────────

--- a/Shoko.Tests/SeriesSearchNormalizationTest.cs
+++ b/Shoko.Tests/SeriesSearchNormalizationTest.cs
@@ -70,6 +70,9 @@ public class SeriesSearchNormalizationTest
         new object[] { "Demon Lords' Banquet: Walpurgis", "Demon Lords' Banquet ~Walpurgis~", true },
         // Unrelated titles should not match just because both use tildes.
         new object[] { "~Naruto~", "~Fullmetal Alchemist~", false },
+        // Same normalization applies to show titles, not just episode titles (e.g. TMDB show
+        // "Naruto ~Shippuden~" vs AniDB show "Naruto: Shippuden").
+        new object[] { "Naruto ~Shippuden~", "Naruto: Shippuden", true },
     };
 
     // Via NormalizeForIndex (what .Search() uses), not FuzzyMatch — its ForceASCII pipeline already deletes '~'/'|', so it'd pass regardless of this fix.
@@ -87,6 +90,9 @@ public class SeriesSearchNormalizationTest
         new object[] { "Berlint Panic | The Informant", "Berlint Panic / The Informant", true },
         // Unrelated titles should not match just because both use pipes.
         new object[] { "Naruto | Shippuden", "Fullmetal Alchemist | Brotherhood", false },
+        // Same normalization applies to show titles, not just episode titles (e.g. TMDB show
+        // "Naruto | Shippuden" vs AniDB show "Naruto: Shippuden").
+        new object[] { "Naruto | Shippuden", "Naruto: Shippuden", true },
     };
 
     [Theory, MemberData(nameof(PipeData))]

--- a/Shoko.Tests/SeriesSearchNormalizationTest.cs
+++ b/Shoko.Tests/SeriesSearchNormalizationTest.cs
@@ -60,4 +60,19 @@ public class SeriesSearchNormalizationTest
     [Theory, MemberData(nameof(EllipsisData))]
     public void EllipsisNormalization(string title, string query, bool expectMatch)
         => Assert.Equal(expectMatch, title.FuzzyMatch(query));
+
+    public static IEnumerable<object[]> TildeData => new List<object[]>
+    {
+        // TMDB-style "~Emphasis~" title matched by an AniDB-style ": Emphasis" query, and vice versa
+        // (e.g. Slime (2021 Part 2) episode 10, "Demon Lords' Banquet ~Walpurgis~" vs "Demon Lords'
+        // Banquet: Walpurgis").
+        new object[] { "Demon Lords' Banquet ~Walpurgis~", "Demon Lords' Banquet: Walpurgis", true },
+        new object[] { "Demon Lords' Banquet: Walpurgis", "Demon Lords' Banquet ~Walpurgis~", true },
+        // Unrelated titles should not match just because both use tildes.
+        new object[] { "~Naruto~", "~Fullmetal Alchemist~", false },
+    };
+
+    [Theory, MemberData(nameof(TildeData))]
+    public void TildeNormalization(string title, string query, bool expectMatch)
+        => Assert.Equal(expectMatch, title.FuzzyMatch(query));
 }

--- a/Shoko.Tests/SeriesSearchNormalizationTest.cs
+++ b/Shoko.Tests/SeriesSearchNormalizationTest.cs
@@ -75,4 +75,20 @@ public class SeriesSearchNormalizationTest
     [Theory, MemberData(nameof(TildeData))]
     public void TildeNormalization(string title, string query, bool expectMatch)
         => Assert.Equal(expectMatch, title.FuzzyMatch(query));
+
+    public static IEnumerable<object[]> PipeData => new List<object[]>
+    {
+        // AniDB-style "A: B" title matched by a TMDB-style "A | B" query, and vice versa (e.g. DanMachi
+        // episode 1, AniDB "Bell Cranel: Adventurer" vs TMDB "Bell Cranel | Adventurer").
+        new object[] { "Bell Cranel | Adventurer", "Bell Cranel: Adventurer", true },
+        new object[] { "Bell Cranel: Adventurer", "Bell Cranel | Adventurer", true },
+        // "/" (already normalized) and "|" should be interchangeable too.
+        new object[] { "Berlint Panic | The Informant", "Berlint Panic / The Informant", true },
+        // Unrelated titles should not match just because both use pipes.
+        new object[] { "Naruto | Shippuden", "Fullmetal Alchemist | Brotherhood", false },
+    };
+
+    [Theory, MemberData(nameof(PipeData))]
+    public void PipeNormalization(string title, string query, bool expectMatch)
+        => Assert.Equal(expectMatch, title.FuzzyMatch(query));
 }

--- a/Shoko.Tests/SeriesSearchNormalizationTest.cs
+++ b/Shoko.Tests/SeriesSearchNormalizationTest.cs
@@ -72,9 +72,10 @@ public class SeriesSearchNormalizationTest
         new object[] { "~Naruto~", "~Fullmetal Alchemist~", false },
     };
 
+    // Via NormalizeForIndex (what .Search() uses), not FuzzyMatch — its ForceASCII pipeline already deletes '~'/'|', so it'd pass regardless of this fix.
     [Theory, MemberData(nameof(TildeData))]
     public void TildeNormalization(string title, string query, bool expectMatch)
-        => Assert.Equal(expectMatch, title.FuzzyMatch(query));
+        => Assert.Equal(expectMatch, SeriesSearch.NormalizeForIndex(title) == SeriesSearch.NormalizeForIndex(query));
 
     public static IEnumerable<object[]> PipeData => new List<object[]>
     {
@@ -90,5 +91,5 @@ public class SeriesSearchNormalizationTest
 
     [Theory, MemberData(nameof(PipeData))]
     public void PipeNormalization(string title, string query, bool expectMatch)
-        => Assert.Equal(expectMatch, title.FuzzyMatch(query));
+        => Assert.Equal(expectMatch, SeriesSearch.NormalizeForIndex(title) == SeriesSearch.NormalizeForIndex(query));
 }


### PR DESCRIPTION
## Summary
Fixes several root causes behind low-confidence (`*KindaMatches`) and outright-wrong AniDB↔TMDB episode cross-references, found via a library-wide audit of existing matches:

- **Episode order reconciliation**: when two AniDB-adjacent episodes both matched on weak evidence alone (date-only or last-resort positional), a coincidental TMDB air-date mismatch could swap them. `ReconcileEpisodeOrderInversions` now detects and corrects these after matching, iterating to convergence for runs of 3+ reversed episodes. A follow-up commit fixes a false-adjacency bug in that same method: it originally treated two weak matches as neighbors even when a trusted (title-corroborated) match sat between them in true AniDB order, which could produce an incorrect swap.
- **Generic placeholder titles**: AniDB's auto-generated placeholder titles ("Episode 5", "Episode S1", "Episode C2", ...) were only excluded from title search for normal episodes; specials/credits/trailers/etc. with no real title could leak through and coincidentally match an unrelated TMDB episode with zero real evidence.
- **Punctuation normalization**: `~` and `|` are common decorative/joining characters in episode titles (e.g. TMDB's `~Walpurgis~` vs AniDB's `: Walpurgis`, or TMDB's `A | B` vs AniDB's `A / B`) that weren't normalized the same as the wave dash and `/`, silently downgrading otherwise-identical titles to a lower match confidence tier.
- **Greedy candidate starvation**: each matching pass processed AniDB episodes in episode-number order and removed a TMDB episode from the shared candidate pool as soon as any episode claimed it, so when two AniDB episodes both matched the same TMDB episode within a pass, whichever came first won regardless of match strength. `TryFindAnidbAndTmdbMatch` now also reports a confidence score (title distance plus air-date corroboration), and each pass orders its episodes by that score before matching so the strongest match gets first pick.

## Test plan
- [x] `dotnet build Shoko.Server.sln` — 0 errors
- [x] Full relevant unit test suite passes in `SeriesSearchNormalizationTest` + `TmdbLinkingServiceTests`, including new regression tests for the false-adjacency fix and show-title normalization coverage
- [x] Traced call sites and mutation safety for `ReconcileEpisodeOrderInversions` and the `NormalizeForIndex` blast radius (whole-show auto-linking) by hand
- [x] Confirmed no external callers reference any of the extracted/renamed private helper methods