### PR TITLE
fix: ProcessReleaseProvider job key collision and VideoReleaseService ignoring releaseInfo provided data

### DIFF
--- a/Shoko.Server/Scheduling/Jobs/Shoko/ProcessReleaseProviderJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Shoko/ProcessReleaseProviderJob.cs
@@ -48,7 +48,6 @@ public class ProcessReleaseProviderJob : BaseJob
 
     public int MatchAttemptID { get; set; }
 
-    [JobKeyMember]
     public Guid ProviderID { get; set; }
 
     public override string TypeName => "Get Release Information for Video From Provider";

--- a/Shoko.Server/Services/VideoReleaseService.cs
+++ b/Shoko.Server/Services/VideoReleaseService.cs
@@ -1066,6 +1066,17 @@ public class VideoReleaseService(
             return null;
         }
 
+        // If releaseInfo is defined and hasn't short circuited, use the provided information.
+        if (releaseInfo.GroupID is not null && releaseInfo.GroupName is not null)
+        {
+            // Handle the one group on AniDB which has GroupShortName = ''
+            if (string.IsNullOrWhiteSpace(releaseInfo.GroupShortName))
+            {
+                releaseInfo.GroupShortName = releaseInfo.GroupName;
+            }
+            return null;
+        }
+
         // If we have an existing release from the group with valid names, use that.
         var existingReleasesForGroup = releaseInfoRepository.GetByGroupAndProviderIDs(releaseInfo.GroupID, releaseInfo.GroupSource)
             .Where(rI => !string.IsNullOrEmpty(rI.GroupName) && !string.IsNullOrEmpty(rI.GroupShortName))


### PR DESCRIPTION
This pull request introduces a small fix to how group information is handled in the `VideoReleaseService`, and a minor cleanup in the `ProcessReleaseProviderJob` class. The most important changes are:

**Release group information handling:**

* Added logic to use `releaseInfo` when `GroupID` and `GroupName` are not null, preventing additional AniDB calls.

* Added logic to assign `GroupShortName` to `GroupName` if `GroupShortName` is empty, ensuring that `GroupShortName` is always populated, even when not set. E.g. [Bara-Tsuki](https://anidb.net/group/13019)

**Code cleanup:**

* Removed the `[JobKeyMember]` attribute from the `ProviderID` property in `ProcessReleaseProviderJob`, switching from manual to automatic JobKeyMember definition, resolving JobKey collisions between `ProcessReleaseProviderJob`.