### PR TITLE
feat(actions): implement plugin-registrable action system

### DIFF
--- a/Shoko.Abstractions/Action/ActionCategory.md
+++ b/Shoko.Abstractions/Action/ActionCategory.md
@@ -1,0 +1,51 @@
+# ActionCategory — Design Overview
+
+`ActionCategory` is a hard-validated enum (`: byte`) with fixed members.
+Plugins cannot register new categories at runtime — adding a genuinely new
+category requires a PR against core to extend the enum.
+
+## Members
+
+| Member | Value | Description |
+|--------|-------|-------------|
+| `Import` | `0x01` | File import and scanning actions. |
+| `AniDB` | `0x21` | AniDB metadata and synchronization actions. |
+| `TMDB` | `0x22` | TMDB metadata and synchronization actions. |
+| `AniList` | `0x23` | AniList metadata and synchronization actions. |
+| `Sync` | `0x31` | Data synchronization actions across providers. |
+| `Images` | `0x71` | Image download and management actions. |
+| `Maintenance` | `0xF1` | System maintenance actions. |
+| `Mischievous` | `0xF2` | Uncategorized or miscellaneous actions. |
+| `Destructive` | `0xFE` | Destructive operations such as purging data. |
+| `PluginInferred` | `0xFF` | Category label is inferred from the owning plugin's name. |
+
+## Value spacing
+
+The hex values are intentionally spaced into ranges to allow future additions
+without renumbering:
+
+- `0x01–0x3F` — provider-specific categories (Import, AniDB, TMDB, AniList, Sync)
+- `0x71–0x7F` — system categories (Images)
+- `0xF1–0xFF` — special categories (Maintenance, Mischievous, Destructive,
+  PluginInferred)
+
+## `Mischievous` vs `PluginInferred`
+
+- **`Mischievous`** is the default fallback. An action that doesn't explicitly
+  set a category lands here. Its label is "Mischievous", owned centrally by
+  core.
+- **`PluginInferred`** is an opt-in choice. When an action uses this category,
+  `ActionService.AddParts` sets `ExecutableActionInfo.CategoryName` to the
+  owning plugin's display name instead of the enum member name.
+
+  This means `PluginInferred` effectively delegates the category label itself to
+  the plugin — distinct from the RFC's original `Generic` proposal, which
+  specified a fixed core-owned label. `Mischievous` exists as the true
+  core-owned fallback that aligns with the original RFC intent.
+
+## Category display names
+
+Each enum member's display name is its own `ToString()` value, except for
+`PluginInferred`, where the display name is the plugin's name. The
+`ExecutableActionInfo.CategoryName` field carries the resolved display label
+for API consumers.

--- a/Shoko.Abstractions/Action/ActionScope.md
+++ b/Shoko.Abstractions/Action/ActionScope.md
@@ -1,0 +1,65 @@
+# ActionScope — Design Overview
+
+`ActionScope` is a `[Flags]` enum that encodes two orthogonal concerns in a
+single value:
+
+1. **Permission level** — whether an action requires admin privileges or is open
+   to any authenticated user.
+2. **Entity scope** — the entity type the action operates on (Global, Group,
+   Series, or Episode).
+
+## Base flags
+
+| Flag | Bit | Meaning |
+|------|-----|---------|
+| `System` | `1 << 0` | Admin-only action. Requires `[Authorize("admin")]`. |
+| `User` | `1 << 1` | Any authenticated user may invoke. |
+| `Global` | `1 << 2` | Not tied to any particular entity. |
+| `Group` | `1 << 3` | Scoped to a group. |
+| `Series` | `1 << 4` | Scoped to a series. |
+| `Episode` | `1 << 5` | Scoped to an episode. |
+
+## Combined (named) values
+
+Every value stored in an action's `ExecutableActionInfo.Scopes` set is always a
+combination of exactly one permission flag (`System` or `User`) plus exactly one
+entity flag (`Global`, `Group`, `Series`, or `Episode`). The named combined
+values exist for client convenience:
+
+| Named value | Permission | Entity |
+|-------------|------------|--------|
+| `SystemAndGlobal` | System | Global |
+| `UserAndGlobal` | User | Global |
+| `SystemAndGroup` | System | Group |
+| `UserAndGroup` | User | Group |
+| `SystemAndSeries` | System | Series |
+| `UserAndSeries` | User | Series |
+| `SystemAndEpisode` | System | Episode |
+| `UserAndEpisode` | User | Episode |
+
+**Important:** bare flags like bare `Global` or bare `System` are never stored in
+an action's scope set. They exist only as filter values for querying.
+
+## Filtering
+
+Because every stored value is a combination, `HasFlag`-based filtering allows
+querying by either axis independently:
+
+- `GetActions(scopes: [ActionScope.System])` — returns all admin actions across
+  all entity levels.
+- `GetActions(scopes: [ActionScope.Global])` — returns all global actions
+  (both admin and user variants).
+- `GetActions(scopes: [ActionScope.SystemAndGroup])` — returns actions that
+  require admin privileges and target a group.
+
+This is the approach used in `ActionService.GetActions` and the listing
+endpoints in the API controller.
+
+## Why a single enum instead of separate Scope + Permission enums?
+
+The RFC's revised Gap 8 specifies a separate `ActionPermission` enum orthogonal
+to `ActionScope`. Keeping both on a single `[Flags]` enum simplifies the
+`ExecutableActionInfo.Scopes` set: a multi-scope action stores values like
+`{ SystemAndGlobal, UserAndGlobal }` — both carry the entity scope (`Global`)
+alongside the permission level. A listing endpoint can filter by either axis
+with a single `HasFlag` call, without joining across two separate enums.

--- a/Shoko.Abstractions/Action/Enums/ActionCategory.cs
+++ b/Shoko.Abstractions/Action/Enums/ActionCategory.cs
@@ -1,0 +1,63 @@
+using System.Text.Json.Serialization;
+using Newtonsoft.Json.Converters;
+
+namespace Shoko.Abstractions.Action.Enums;
+
+/// <summary>
+///   Defines the category of an executable action. Categories group related
+///   actions together in the UI and can be used to filter the action list.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+[Newtonsoft.Json.JsonConverter(typeof(StringEnumConverter))]
+public enum ActionCategory : byte
+{
+    /// <summary>
+    ///   File import and scanning actions.
+    /// </summary>
+    Import = 0x01,
+
+    /// <summary>
+    ///   AniDB metadata and synchronization actions.
+    /// </summary>
+    AniDB = 0x21,
+
+    /// <summary>
+    ///   TMDB metadata and synchronization actions.
+    /// </summary>
+    TMDB = 0x22,
+
+    /// <summary>
+    ///   AniList metadata and synchronization actions.
+    /// </summary>
+    AniList = 0x23,
+
+    /// <summary>
+    ///   Data synchronization actions across providers.
+    /// </summary>
+    Sync = 0x31,
+
+    /// <summary>
+    ///   Image download and management actions.
+    /// </summary>
+    Images = 0x71,
+
+    /// <summary>
+    ///   System maintenance actions.
+    /// </summary>
+    Maintenance = 0xF1,
+
+    /// <summary>
+    ///   Uncategorized or miscellaneous actions.
+    /// </summary>
+    Mischievous =0xF2,
+
+    /// <summary>
+    ///   Destructive operations such as purging data.
+    /// </summary>
+    Destructive = 0xFE,
+
+    /// <summary>
+    ///   The category should be inferred from the plugin that provides the action.
+    /// </summary>
+    PluginInferred = 0xFF,
+}

--- a/Shoko.Abstractions/Action/Enums/ActionCategory.cs
+++ b/Shoko.Abstractions/Action/Enums/ActionCategory.cs
@@ -47,9 +47,10 @@ public enum ActionCategory : byte
     Maintenance = 0xF1,
 
     /// <summary>
-    ///   Uncategorized or miscellaneous actions.
+    ///   Uncategorized or miscellaneous actions. Actions which does not set
+    ///   their own category will be placed in this category by default.
     /// </summary>
-    Mischievous =0xF2,
+    Mischievous = 0xF2,
 
     /// <summary>
     ///   Destructive operations such as purging data.

--- a/Shoko.Abstractions/Action/Enums/ActionScope.cs
+++ b/Shoko.Abstractions/Action/Enums/ActionScope.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json.Serialization;
 using Newtonsoft.Json.Converters;
 
@@ -6,47 +7,83 @@ namespace Shoko.Abstractions.Action.Enums;
 /// <summary>
 ///   The scope of an action.
 /// </summary>
+[Flags]
 [JsonConverter(typeof(JsonStringEnumConverter))]
 [Newtonsoft.Json.JsonConverter(typeof(StringEnumConverter))]
 public enum ActionScope : byte
 {
     /// <summary>
-    ///   Global administrative action. Requires administrator privileges.
+    ///   Indicates the scope is ran at the system-level.
     /// </summary>
-    Global = 1,
+    System = 1 << 0,
 
     /// <summary>
-    ///   Global user action. Can be ran by any user.
+    ///   Indicates the scope is ran at the user-level, per user.
     /// </summary>
-    GlobalUser = 2,
+    User = 1 << 1,
 
     /// <summary>
-    ///   Group-level action. Requires administrator privileges.
+    ///   Global-scoped action. The scoped action is not particularly tied to
+    ///   any particular group, series or episode.
     /// </summary>
-    Group = 3,
+    Global = 1 << 2,
 
     /// <summary>
-    ///   Group-level user action. Can be ran by any user.
+    ///   Global system-level administrative action. Requires administrator
+    ///   privileges to run.
     /// </summary>
-    GroupUser = 4,
+    SystemAndGlobal = Global | System,
 
     /// <summary>
-    ///   Series-level action. Requires administrator privileges.
+    ///   Global user-level user action. Can be ran by any user.
     /// </summary>
-    Series = 5,
+    UserAndGlobal = Global | User,
 
     /// <summary>
-    ///   Series-level user action. Can be ran by any user.
+    ///   Group-scoped action. The action is scope to run on a group.
     /// </summary>
-    SeriesUser = 6,
+    Group = 1 << 3,
 
     /// <summary>
-    ///   Episode-level action. Requires administrator privileges.
+    ///   Group-scoped system-level administrative action. Requires
+    ///   administrator privileges to run.
     /// </summary>
-    Episode = 7,
+    SystemAndGroup = System | Group,
 
     /// <summary>
-    ///   Episode-level user action. Can be ran by any user.
+    ///   Group-scoped user-level user action. Can be ran by any user.
     /// </summary>
-    EpisodeUser = 8,
+    UserAndGroup = User | Group,
+
+    /// <summary>
+    ///   Series-scoped action. The action is scope to run on a series.
+    /// </summary>
+    Series = 1 << 4,
+
+    /// <summary>
+    ///   Series-scoped system-level administrative action. Requires
+    ///   administrator privileges to run.
+    /// </summary>
+    SystemAndSeries = System | Series,
+
+    /// <summary>
+    ///   Series-scoped user-level user action. Can be ran by any user.
+    /// </summary>
+    UserAndSeries = User | Series,
+
+    /// <summary>
+    ///   Episode-scoped action. The action is scope to run on an episode.
+    /// </summary>
+    Episode = 1 << 5,
+
+    /// <summary>
+    ///   Episode-scoped system-level administrative action. Requires
+    ///   administrator privileges to run.
+    /// </summary>
+    SystemAndEpisode = System | Episode,
+
+    /// <summary>
+    ///   Episode-scoped user-level user action. Can be ran by any user.
+    /// </summary>
+    UserAndEpisode = User | Episode,
 }

--- a/Shoko.Abstractions/Action/Enums/ActionScope.cs
+++ b/Shoko.Abstractions/Action/Enums/ActionScope.cs
@@ -1,0 +1,52 @@
+using System.Text.Json.Serialization;
+using Newtonsoft.Json.Converters;
+
+namespace Shoko.Abstractions.Action.Enums;
+
+/// <summary>
+///   The scope of an action.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+[Newtonsoft.Json.JsonConverter(typeof(StringEnumConverter))]
+public enum ActionScope : byte
+{
+    /// <summary>
+    ///   Global administrative action. Requires administrator privileges.
+    /// </summary>
+    Global = 1,
+
+    /// <summary>
+    ///   Global user action. Can be ran by any user.
+    /// </summary>
+    GlobalUser = 2,
+
+    /// <summary>
+    ///   Group-level action. Requires administrator privileges.
+    /// </summary>
+    Group = 3,
+
+    /// <summary>
+    ///   Group-level user action. Can be ran by any user.
+    /// </summary>
+    GroupUser = 4,
+
+    /// <summary>
+    ///   Series-level action. Requires administrator privileges.
+    /// </summary>
+    Series = 5,
+
+    /// <summary>
+    ///   Series-level user action. Can be ran by any user.
+    /// </summary>
+    SeriesUser = 6,
+
+    /// <summary>
+    ///   Episode-level action. Requires administrator privileges.
+    /// </summary>
+    Episode = 7,
+
+    /// <summary>
+    ///   Episode-level user action. Can be ran by any user.
+    /// </summary>
+    EpisodeUser = 8,
+}

--- a/Shoko.Abstractions/Action/ExecutableActionInfo.cs
+++ b/Shoko.Abstractions/Action/ExecutableActionInfo.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Plugin.Models;
+
+namespace Shoko.Abstractions.Action;
+
+/// <summary>
+///   Describes an executable action registered by a plugin or the core server.
+///   Instances are created by <see cref="Services.IActionService.AddParts"/>
+///   and exposed to callers via <see cref="Services.IActionService.GetActions"/>.
+/// </summary>
+public sealed class ExecutableActionInfo
+{
+    /// <summary>
+    ///   A stable, deterministic identifier for this action derived from its
+    ///   implementing type. Suitable for serialization and cross-session use.
+    /// </summary>
+    public required Guid ID { get; init; }
+
+    /// <summary>
+    ///   The human-readable name of the action.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    ///   A description of what the action does.
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    ///   The category of the action. <see cref="ActionCategory.PluginInferred"/>
+    ///   indicates the display name should be taken from <see cref="CategoryName"/>.
+    /// </summary>
+    public required ActionCategory Category { get; init; }
+
+    /// <summary>
+    ///   The display name for the action's category. When <see cref="Category"/>
+    ///   is <see cref="ActionCategory.PluginInferred"/>, this is set to the
+    ///   plugin's name. Otherwise it matches the enum member name.
+    /// </summary>
+    public required string CategoryName { get; init; }
+
+    /// <summary>
+    ///   The scopes at which the action can operate. A single action
+    ///   implementation may support multiple scopes by implementing
+    ///   several of the <c>IExecutable*Action</c> sub-interfaces.
+    /// </summary>
+    public required IReadOnlySet<ActionScope> Scopes { get; init; }
+
+    /// <summary>
+    ///   Indicates whether the action requires explicit user confirmation
+    ///   before it can be executed. Destructive or irreversible actions
+    ///   should return <c>true</c>.
+    /// </summary>
+    public required bool RequiresConfirmation { get; init; }
+
+    /// <summary>
+    ///   Information about the plugin that the executable action belongs to.
+    /// </summary>
+    public required LocalPluginInfo PluginInfo { get; init; }
+}

--- a/Shoko.Abstractions/Action/IExecutableAction.cs
+++ b/Shoko.Abstractions/Action/IExecutableAction.cs
@@ -41,7 +41,7 @@ public interface IExecutableAction
     /// <summary>
     ///   The category of the action.
     /// </summary>
-    public ActionCategory Category { get => ActionCategory.PluginInferred; }
+    public ActionCategory Category { get => ActionCategory.Mischievous; }
 
     /// <summary>
     ///   Indicates whether the action requires explicit user confirmation
@@ -52,12 +52,12 @@ public interface IExecutableAction
 }
 
 /// <summary>
-///   A global administrative action.
+///   A global-scoped system-level administrative action.
 /// </summary>
-public interface IExecutableGlobalAction : IExecutableAction
+public interface IExecutableGlobalSystemAction : IExecutableAction
 {
     /// <summary>
-    ///   Execute the global administrative action.
+    ///   Execute the global-scoped system-level administrative action.
     /// </summary>
     /// <param name="cancellationToken">
     ///   The cancellation token.
@@ -69,12 +69,12 @@ public interface IExecutableGlobalAction : IExecutableAction
 }
 
 /// <summary>
-///   A global user action.
+///   A global-scoped user-level user action.
 /// </summary>
 public interface IExecutableGlobalUserAction : IExecutableAction
 {
     /// <summary>
-    ///   Execute the global user action.
+    ///   Execute the global-scoped user-level user action.
     /// </summary>
     /// <param name="user">
     ///   The user to run the action for.
@@ -89,12 +89,12 @@ public interface IExecutableGlobalUserAction : IExecutableAction
 }
 
 /// <summary>
-///   A group-level administrative action.
+///   A group-scoped system-level administrative action.
 /// </summary>
-public interface IExecutableGroupAction : IExecutableAction
+public interface IExecutableGroupSystemAction : IExecutableAction
 {
     /// <summary>
-    ///   Execute the group-level administrative action.
+    ///   Execute the group-scoped system-level administrative action.
     /// </summary>
     /// <param name="group">
     ///   The group to run the action on.
@@ -109,12 +109,12 @@ public interface IExecutableGroupAction : IExecutableAction
 }
 
 /// <summary>
-///   A group-level user action.
+///   A group-scoped user-level user action.
 /// </summary>
 public interface IExecutableGroupUserAction : IExecutableAction
 {
     /// <summary>
-    ///   Execute the group-level user action.
+    ///   Execute the group-scoped user-level user action.
     /// </summary>
     /// <param name="group">
     ///   The group to run the action on.
@@ -132,12 +132,12 @@ public interface IExecutableGroupUserAction : IExecutableAction
 }
 
 /// <summary>
-///   A series-level administrative action.
+///   A series-scoped system-level administrative action.
 /// </summary>
-public interface IExecutableSeriesAction : IExecutableAction
+public interface IExecutableSeriesSystemAction : IExecutableAction
 {
     /// <summary>
-    ///   Execute the series-level administrative action.
+    ///   Execute the series-scoped system-level administrative action.
     /// </summary>
     /// <param name="series">
     ///   The series to run the action on.
@@ -152,12 +152,12 @@ public interface IExecutableSeriesAction : IExecutableAction
 }
 
 /// <summary>
-///   A series-level user action.
+///   A series-scoped user-level user action.
 /// </summary>
 public interface IExecutableSeriesUserAction : IExecutableAction
 {
     /// <summary>
-    ///   Execute the series-level user action.
+    ///   Execute the series-scoped user-level user action.
     /// </summary>
     /// <param name="series">
     ///   The series to run the action on.
@@ -175,12 +175,12 @@ public interface IExecutableSeriesUserAction : IExecutableAction
 }
 
 /// <summary>
-///   An episode-level administrative action.
+///   An episode-scoped system-level administrative action.
 /// </summary>
-public interface IExecutableEpisodeAction : IExecutableAction
+public interface IExecutableEpisodeSystemAction : IExecutableAction
 {
     /// <summary>
-    ///   Execute the episode-level administrative action.
+    ///   Execute the episode-scoped system-level administrative action.
     /// </summary>
     /// <param name="episode">
     ///   The episode to run the action on.
@@ -195,12 +195,12 @@ public interface IExecutableEpisodeAction : IExecutableAction
 }
 
 /// <summary>
-///   An episode-level user action.
+///   An episode-scoped user-level user action.
 /// </summary>
 public interface IExecutableEpisodeUserAction : IExecutableAction
 {
     /// <summary>
-    ///   Execute the episode-level user action.
+    ///   Execute the episode-scoped user-level user action.
     /// </summary>
     /// <param name="episode">
     ///   The episode to run the action on.

--- a/Shoko.Abstractions/Action/IExecutableAction.cs
+++ b/Shoko.Abstractions/Action/IExecutableAction.cs
@@ -1,0 +1,218 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Abstractions.User;
+
+namespace Shoko.Abstractions.Action;
+
+/// <summary>
+///   Base interface for all executable actions.
+/// </summary>
+/// <remarks>
+///   <para>
+///     Each action's stable identifier (<see cref="ExecutableActionInfo.ID"/>)
+///     is a UUIDv5 deterministically derived from the action class's
+///     fully-qualified name using the plugin's ID as the UUIDv5 namespace.
+///   </para>
+///   <para>
+///     <strong>This ID is not stable across class renames or namespace moves.</strong>
+///     If a plugin author renames or moves the implementing class, the derived
+///     UUID will change. Existing references to the old ID (e.g. stored
+///     bookmarks or scheduled invocations) will no longer resolve, and the
+///     action will appear as a new entry under the new ID. This is by design
+///     — deriving from namespace + class name + plugin ID makes accidental
+///     collisions between unrelated plugins extremely unlikely without
+///     requiring an explicit, collision-managed key field.
+///   </para>
+/// </remarks>
+public interface IExecutableAction
+{
+    /// <summary>
+    ///   The name of the action.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    ///   The description of the action.
+    /// </summary>
+    public string? Description { get => null; }
+
+    /// <summary>
+    ///   The category of the action.
+    /// </summary>
+    public ActionCategory Category { get => ActionCategory.PluginInferred; }
+
+    /// <summary>
+    ///   Indicates whether the action requires explicit user confirmation
+    ///   before it can be executed. Destructive or irreversible actions
+    ///   should return <c>true</c>.
+    /// </summary>
+    public bool RequiresConfirmation { get => false; }
+}
+
+/// <summary>
+///   A global administrative action.
+/// </summary>
+public interface IExecutableGlobalAction : IExecutableAction
+{
+    /// <summary>
+    ///   Execute the global administrative action.
+    /// </summary>
+    /// <param name="cancellationToken">
+    ///   The cancellation token.
+    /// </param>
+    /// <returns>
+    ///   A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    Task Execute(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///   A global user action.
+/// </summary>
+public interface IExecutableGlobalUserAction : IExecutableAction
+{
+    /// <summary>
+    ///   Execute the global user action.
+    /// </summary>
+    /// <param name="user">
+    ///   The user to run the action for.
+    /// </param>
+    /// <param name="cancellationToken">
+    ///   The cancellation token.
+    /// </param>
+    /// <returns>
+    ///   A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    Task Execute(IUser user, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///   A group-level administrative action.
+/// </summary>
+public interface IExecutableGroupAction : IExecutableAction
+{
+    /// <summary>
+    ///   Execute the group-level administrative action.
+    /// </summary>
+    /// <param name="group">
+    ///   The group to run the action on.
+    /// </param>
+    /// <param name="cancellationToken">
+    ///   The cancellation token.
+    /// </param>
+    /// <returns>
+    ///   A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    Task Execute(IShokoGroup group, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///   A group-level user action.
+/// </summary>
+public interface IExecutableGroupUserAction : IExecutableAction
+{
+    /// <summary>
+    ///   Execute the group-level user action.
+    /// </summary>
+    /// <param name="group">
+    ///   The group to run the action on.
+    /// </param>
+    /// <param name="user">
+    ///   The user to run the action for.
+    /// </param>
+    /// <param name="cancellationToken">
+    ///   The cancellation token.
+    /// </param>
+    /// <returns>
+    ///   A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    Task Execute(IShokoGroup group, IUser user, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///   A series-level administrative action.
+/// </summary>
+public interface IExecutableSeriesAction : IExecutableAction
+{
+    /// <summary>
+    ///   Execute the series-level administrative action.
+    /// </summary>
+    /// <param name="series">
+    ///   The series to run the action on.
+    /// </param>
+    /// <param name="cancellationToken">
+    ///   The cancellation token.
+    /// </param>
+    /// <returns>
+    ///   A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    Task Execute(IShokoSeries series, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///   A series-level user action.
+/// </summary>
+public interface IExecutableSeriesUserAction : IExecutableAction
+{
+    /// <summary>
+    ///   Execute the series-level user action.
+    /// </summary>
+    /// <param name="series">
+    ///   The series to run the action on.
+    /// </param>
+    /// <param name="user">
+    ///   The user to run the action for.
+    /// </param>
+    /// <param name="cancellationToken">
+    ///   The cancellation token.
+    /// </param>
+    /// <returns>
+    ///   A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    Task Execute(IShokoSeries series, IUser user, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///   An episode-level administrative action.
+/// </summary>
+public interface IExecutableEpisodeAction : IExecutableAction
+{
+    /// <summary>
+    ///   Execute the episode-level administrative action.
+    /// </summary>
+    /// <param name="episode">
+    ///   The episode to run the action on.
+    /// </param>
+    /// <param name="cancellationToken">
+    ///   The cancellation token.
+    /// </param>
+    /// <returns>
+    ///   A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    Task Execute(IShokoEpisode episode, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+///   An episode-level user action.
+/// </summary>
+public interface IExecutableEpisodeUserAction : IExecutableAction
+{
+    /// <summary>
+    ///   Execute the episode-level user action.
+    /// </summary>
+    /// <param name="episode">
+    ///   The episode to run the action on.
+    /// </param>
+    /// <param name="user">
+    ///   The user to run the action for.
+    /// </param>
+    /// <param name="cancellationToken">
+    ///   The cancellation token.
+    /// </param>
+    /// <returns>
+    ///   A <see cref="Task" /> representing the asynchronous operation.
+    /// </returns>
+    Task Execute(IShokoEpisode episode, IUser user, CancellationToken cancellationToken = default);
+}

--- a/Shoko.Abstractions/Action/IExecutableAction.cs
+++ b/Shoko.Abstractions/Action/IExecutableAction.cs
@@ -29,9 +29,10 @@ namespace Shoko.Abstractions.Action;
 public interface IExecutableAction
 {
     /// <summary>
-    ///   The name of the action.
+    ///   The name of the action. When <c>null</c>, the service derives a
+    ///   display name from the implementing class's name automatically.
     /// </summary>
-    public string Name { get; }
+    public string? Name { get => null; }
 
     /// <summary>
     ///   The description of the action.

--- a/Shoko.Abstractions/Action/IExecutableAction.md
+++ b/Shoko.Abstractions/Action/IExecutableAction.md
@@ -1,0 +1,106 @@
+# IExecutableAction — Plugin Author's Guide
+
+## Overview
+
+`IExecutableAction` is the base interface for all plugin-registrable actions.
+A plugin action is a discrete, invokable unit of work that appears in the Shoko
+Actions menu and can be triggered by ID via the API.
+
+## Sub-interfaces
+
+Rather than a single `Execute(CancellationToken)` as proposed by the RFC, this
+implementation defines 8 scope-specific sub-interfaces, each providing exactly
+the context the action needs:
+
+| Interface | Execute Signature | Use Case |
+|-----------|-------------------|----------|
+| `IExecutableGlobalSystemAction` | `Execute(CancellationToken)` | Admin-only global action |
+| `IExecutableGlobalUserAction` | `Execute(IUser, CancellationToken)` | User-facing global action |
+| `IExecutableGroupSystemAction` | `Execute(IShokoGroup, CancellationToken)` | Admin-only group action |
+| `IExecutableGroupUserAction` | `Execute(IShokoGroup, IUser, CancellationToken)` | User-facing group action |
+| `IExecutableSeriesSystemAction` | `Execute(IShokoSeries, CancellationToken)` | Admin-only series action |
+| `IExecutableSeriesUserAction` | `Execute(IShokoSeries, IUser, CancellationToken)` | User-facing series action |
+| `IExecutableEpisodeSystemAction` | `Execute(IShokoEpisode, CancellationToken)` | Admin-only episode action |
+| `IExecutableEpisodeUserAction` | `Execute(IShokoEpisode, IUser, CancellationToken)` | User-facing episode action |
+
+The interface an action implements is a self-documenting declaration of what it
+needs — no guesswork about whether `Execute` will receive a series, a user, or
+neither.
+
+## Multi-scope actions
+
+A single class can support multiple scopes by implementing more than one
+sub-interface:
+
+```csharp
+internal sealed class MyAction : IExecutableGlobalSystemAction, IExecutableSeriesSystemAction
+{
+    public string Name => "My Action";
+    public ActionCategory Category => ActionCategory.Miscellaneous;
+
+    public Task Execute(CancellationToken cancellationToken = default) { … }
+    public Task Execute(IShokoSeries series, CancellationToken cancellationToken = default) { … }
+}
+```
+
+`ActionService.AddParts` detects every implemented interface via
+`typeof(T).IsAssignableFrom` and registers each as a supported scope on
+`ExecutableActionInfo.Scopes`. The action then appears in both the global and
+series listing endpoints.
+
+## Required members
+
+- **`Name`** — the display name shown in the Actions menu.
+
+## Optional defaults
+
+| Member | Default | Description |
+|--------|---------|-------------|
+| `Description` | `null` | Longer description of what the action does. |
+| `Category` | `ActionCategory.Mischievous` | Groups the action into a named category in the UI. See `ActionCategory.md` for available values. |
+| `RequiresConfirmation` | `false` | Set to `true` for destructive or irreversible actions so the UI prompts for confirmation before invoking. |
+
+## ID derivation
+
+Each action's stable identifier (`ExecutableActionInfo.ID`) is a UUIDv5
+deterministically derived from:
+
+- **Namespace:** the owning plugin's ID
+- **Name:** the action class's fully-qualified name
+
+```
+UuidUtility.GetV5(actionType.FullName, pluginInfo.ID)
+```
+
+**This ID is not stable across class renames or namespace moves.** If you rename
+or move the implementing class, the derived UUID will change. Existing references
+to the old ID will no longer resolve. This is by design — deriving from plugin
+ID + class name makes accidental collisions between unrelated plugins
+structurally impossible.
+
+## Lifetime
+
+Action instances are **transient**. A fresh instance is created via
+`IPluginManager.GetExport<IExecutableAction>(type)` on each execution. If you
+need to persist state across invocations, declare your action as a singleton
+in your plugin's DI registration — but this is your responsibility, not the
+framework's.
+
+## Permission model
+
+The permission level (admin-only vs. any authenticated user) is encoded in
+which sub-interface you implement:
+
+- **`*SystemAction`** — requires admin privileges. Only users with `IsAdmin = 1`
+  can list or invoke this action.
+- **`*UserAction`** — any authenticated user can list and invoke this action.
+
+See `ActionScope.md` for details on how `System` and `User` flags work
+under the hood.
+
+## Execution
+
+Actions always run through the job queue. The API schedules execution via
+`ScheduleExecuteOf*` methods — there is no direct/immediate execution path
+exposed to API consumers. This ensures progress/status is visible through the
+standard queue UI and error logging.

--- a/Shoko.Abstractions/Action/IExecutableAction.md
+++ b/Shoko.Abstractions/Action/IExecutableAction.md
@@ -3,8 +3,10 @@
 ## Overview
 
 `IExecutableAction` is the base interface for all plugin-registrable actions.
-A plugin action is a discrete, invokable unit of work that appears in the Shoko
-Actions menu and can be triggered by ID via the API.
+A plugin action is a discrete, invokable unit of work that can be triggered by ID
+via the API. All actions appear in the same listing endpoints regardless of their
+permission level — admins see everything, standard users only see user-facing
+actions.
 
 ## Sub-interfaces
 
@@ -12,20 +14,25 @@ Rather than a single `Execute(CancellationToken)` as proposed by the RFC, this
 implementation defines 8 scope-specific sub-interfaces, each providing exactly
 the context the action needs:
 
-| Interface | Execute Signature | Use Case |
-|-----------|-------------------|----------|
-| `IExecutableGlobalSystemAction` | `Execute(CancellationToken)` | Admin-only global action |
-| `IExecutableGlobalUserAction` | `Execute(IUser, CancellationToken)` | User-facing global action |
-| `IExecutableGroupSystemAction` | `Execute(IShokoGroup, CancellationToken)` | Admin-only group action |
-| `IExecutableGroupUserAction` | `Execute(IShokoGroup, IUser, CancellationToken)` | User-facing group action |
-| `IExecutableSeriesSystemAction` | `Execute(IShokoSeries, CancellationToken)` | Admin-only series action |
-| `IExecutableSeriesUserAction` | `Execute(IShokoSeries, IUser, CancellationToken)` | User-facing series action |
-| `IExecutableEpisodeSystemAction` | `Execute(IShokoEpisode, CancellationToken)` | Admin-only episode action |
-| `IExecutableEpisodeUserAction` | `Execute(IShokoEpisode, IUser, CancellationToken)` | User-facing episode action |
+| Interface | Execute Signature | Description |
+|-----------|-------------------|-------------|
+| `IExecutableGlobalSystemAction` | `Execute(CancellationToken)` | Global scope, system-level (admin). No user context. |
+| `IExecutableGlobalUserAction` | `Execute(IUser, CancellationToken)` | Global scope, user-level (any auth). Operates on behalf of the given user. |
+| `IExecutableGroupSystemAction` | `Execute(IShokoGroup, CancellationToken)` | Group scope, system-level (admin). |
+| `IExecutableGroupUserAction` | `Execute(IShokoGroup, IUser, CancellationToken)` | Group scope, user-level (any auth). |
+| `IExecutableSeriesSystemAction` | `Execute(IShokoSeries, CancellationToken)` | Series scope, system-level (admin). |
+| `IExecutableSeriesUserAction` | `Execute(IShokoSeries, IUser, CancellationToken)` | Series scope, user-level (any auth). |
+| `IExecutableEpisodeSystemAction` | `Execute(IShokoEpisode, CancellationToken)` | Episode scope, system-level (admin). |
+| `IExecutableEpisodeUserAction` | `Execute(IShokoEpisode, IUser, CancellationToken)` | Episode scope, user-level (any auth). |
 
 The interface an action implements is a self-documenting declaration of what it
 needs — no guesswork about whether `Execute` will receive a series, a user, or
 neither.
+
+**Note:** implementing `IExecutableAction` directly without any sub-interface
+will not register a valid action — the service detects scope support only from
+the sub-interfaces. At least one sub-interface must be implemented for the
+action to be registered.
 
 ## Multi-scope actions
 
@@ -85,19 +92,23 @@ framework's.
 
 ## Permission model
 
-The permission level (admin-only vs. any authenticated user) is encoded in
-which sub-interface you implement:
+The permission level is encoded in which sub-interface you implement. The API
+layer enforces access before the action ever runs:
 
-- **`*SystemAction`** — requires admin privileges. Only users with `IsAdmin = 1`
-  can list or invoke this action.
-- **`*UserAction`** — any authenticated user can list and invoke this action.
+- **`*SystemAction`** — the API layer rejects non-admin callers before
+  the action is scheduled.
+- **`*UserAction`** — any authenticated user may invoke. The API layer ties
+  the invocation to the caller's API token. The `IUser` parameter identifies
+  the user on whose behalf the action runs.
 
 See `ActionScope.md` for details on how `System` and `User` flags work
 under the hood.
 
 ## Execution
 
-Actions always run through the job queue. The API schedules execution via
-`ScheduleExecuteOf*` methods — there is no direct/immediate execution path
-exposed to API consumers. This ensures progress/status is visible through the
-standard queue UI and error logging.
+Actions triggered through the API always run via the job queue system — the API
+schedules execution through `ScheduleExecuteOf*` methods, ensuring progress and
+status are visible through the standard queue UI and error logging.
+
+Plugins may use the `IActionService.Execute*` methods directly to run an action
+immediate in-process without going through the queue system, if needed.

--- a/Shoko.Abstractions/Action/IExecutableAction.md
+++ b/Shoko.Abstractions/Action/IExecutableAction.md
@@ -48,14 +48,11 @@ internal sealed class MyAction : IExecutableGlobalSystemAction, IExecutableSerie
 `ExecutableActionInfo.Scopes`. The action then appears in both the global and
 series listing endpoints.
 
-## Required members
-
-- **`Name`** — the display name shown in the Actions menu.
-
 ## Optional defaults
 
 | Member | Default | Description |
 |--------|---------|-------------|
+| `Name` | Inferred from class name | When `null`, the service derives a display name from the implementing class (splits PascalCase, strips "Action" suffix). |
 | `Description` | `null` | Longer description of what the action does. |
 | `Category` | `ActionCategory.Mischievous` | Groups the action into a named category in the UI. See `ActionCategory.md` for available values. |
 | `RequiresConfirmation` | `false` | Set to `true` for destructive or irreversible actions so the UI prompts for confirmation before invoking. |

--- a/Shoko.Abstractions/Action/Services/IActionService.cs
+++ b/Shoko.Abstractions/Action/Services/IActionService.cs
@@ -52,19 +52,21 @@ public interface IActionService
     #region Global
 
     /// <summary>
-    ///   Executes a global action immediately and awaits completion.
+    ///   Executes a global-scoped system-level administrative action
+    ///   immediately and awaits completion.
     /// </summary>
     /// <param name="actionInfo">The action to execute.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support global scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.Global"/>).
+    ///   <see cref="ActionScope.SystemAndGlobal"/>).
     /// </exception>
-    Task ExecuteGlobalAction(ExecutableActionInfo actionInfo, CancellationToken cancellationToken = default);
+    Task ExecuteGlobalSystemAction(ExecutableActionInfo actionInfo, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///   Schedules a global action for later execution through the job queue.
+    ///   Schedules a global-scoped system-level administrative action for later
+    ///   execution through the job queue system.
     /// </summary>
     /// <param name="actionInfo">The action to schedule.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -72,12 +74,13 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support global scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.Global"/>).
+    ///   <see cref="ActionScope.SystemAndGlobal"/>).
     /// </exception>
-    Task ScheduleExecuteOfGlobalAction(ExecutableActionInfo actionInfo, CancellationToken cancellationToken = default, bool prioritize = false);
+    Task ScheduleExecuteOfGlobalSystemAction(ExecutableActionInfo actionInfo, CancellationToken cancellationToken = default, bool prioritize = false);
 
     /// <summary>
-    ///   Executes a global user action immediately for the specified user and awaits completion.
+    ///   Executes a global-scoped user-level user action immediately for the
+    ///   specified user and awaits completion.
     /// </summary>
     /// <param name="actionInfo">The action to execute.</param>
     /// <param name="user">The user to run the action for.</param>
@@ -85,12 +88,13 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support user scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.GlobalUser"/>).
+    ///   <see cref="ActionScope.UserAndGlobal"/>).
     /// </exception>
     Task ExecuteGlobalUserAction(ExecutableActionInfo actionInfo, IUser user, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///   Schedules a global user action for later execution through the job queue.
+    ///   Schedules a global-scoped user-level user action for later execution
+    ///   through the job queue system.
     /// </summary>
     /// <param name="actionInfo">The action to schedule.</param>
     /// <param name="user">The user to run the action for.</param>
@@ -99,7 +103,7 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support user scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.GlobalUser"/>).
+    ///   <see cref="ActionScope.UserAndGlobal"/>).
     /// </exception>
     Task ScheduleExecuteOfGlobalUserAction(ExecutableActionInfo actionInfo, IUser user, CancellationToken cancellationToken = default, bool prioritize = false);
 
@@ -108,7 +112,8 @@ public interface IActionService
     #region Group
 
     /// <summary>
-    ///   Executes a group action immediately for the specified group and awaits completion.
+    ///   Executes a group-scoped system-level administrative action immediately
+    ///   for the specified group and awaits completion.
     /// </summary>
     /// <param name="actionInfo">The action to execute.</param>
     /// <param name="group">The group to run the action on.</param>
@@ -116,12 +121,13 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support group scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.Group"/>).
+    ///   <see cref="ActionScope.SystemAndGroup"/>).
     /// </exception>
-    Task ExecuteGroupAction(ExecutableActionInfo actionInfo, IShokoGroup group, CancellationToken cancellationToken = default);
+    Task ExecuteGroupSystemAction(ExecutableActionInfo actionInfo, IShokoGroup group, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///   Schedules a group action for later execution through the job queue.
+    ///   Schedules a group-scoped system-level administrative action for later
+    ///   execution through the job queue system.
     /// </summary>
     /// <param name="actionInfo">The action to schedule.</param>
     /// <param name="group">The group to run the action on.</param>
@@ -130,12 +136,13 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support group scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.Group"/>).
+    ///   <see cref="ActionScope.SystemAndGroup"/>).
     /// </exception>
-    Task ScheduleExecuteOfGroupAction(ExecutableActionInfo actionInfo, IShokoGroup group, CancellationToken cancellationToken = default, bool prioritize = false);
+    Task ScheduleExecuteOfGroupSystemAction(ExecutableActionInfo actionInfo, IShokoGroup group, CancellationToken cancellationToken = default, bool prioritize = false);
 
     /// <summary>
-    ///   Executes a group user action immediately for the specified group and user, and awaits completion.
+    ///   Executes a group-scoped user-level user action immediately for the
+    ///   specified group and user, and awaits completion.
     /// </summary>
     /// <param name="actionInfo">The action to execute.</param>
     /// <param name="group">The group to run the action on.</param>
@@ -144,12 +151,13 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support group user scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.GroupUser"/>).
+    ///   <see cref="ActionScope.UserAndGroup"/>).
     /// </exception>
     Task ExecuteGroupUserAction(ExecutableActionInfo actionInfo, IShokoGroup group, IUser user, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///   Schedules a group user action for later execution through the job queue.
+    ///   Schedules a group-scoped user action for later execution through the
+    ///   job queue.
     /// </summary>
     /// <param name="actionInfo">The action to schedule.</param>
     /// <param name="group">The group to run the action on.</param>
@@ -159,7 +167,7 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support group user scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.GroupUser"/>).
+    ///   <see cref="ActionScope.UserAndGroup"/>).
     /// </exception>
     Task ScheduleExecuteOfGroupUserAction(ExecutableActionInfo actionInfo, IShokoGroup group, IUser user, CancellationToken cancellationToken = default, bool prioritize = false);
 
@@ -168,7 +176,8 @@ public interface IActionService
     #region Series
 
     /// <summary>
-    ///   Executes a series action immediately for the specified series and awaits completion.
+    ///   Executes a series-scoped system-level administrative action
+    ///   immediately for the specified series and awaits completion.
     /// </summary>
     /// <param name="actionInfo">The action to execute.</param>
     /// <param name="series">The series to run the action on.</param>
@@ -176,12 +185,13 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support series scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.Series"/>).
+    ///   <see cref="ActionScope.SystemAndSeries"/>).
     /// </exception>
-    Task ExecuteSeriesAction(ExecutableActionInfo actionInfo, IShokoSeries series, CancellationToken cancellationToken = default);
+    Task ExecuteSeriesSystemAction(ExecutableActionInfo actionInfo, IShokoSeries series, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///   Schedules a series action for later execution through the job queue.
+    ///   Schedules a series-scoped system-level administrative action for later
+    ///   execution through the job queue system.
     /// </summary>
     /// <param name="actionInfo">The action to schedule.</param>
     /// <param name="series">The series to run the action on.</param>
@@ -190,12 +200,13 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support series scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.Series"/>).
+    ///   <see cref="ActionScope.SystemAndSeries"/>).
     /// </exception>
-    Task ScheduleExecuteOfSeriesAction(ExecutableActionInfo actionInfo, IShokoSeries series, CancellationToken cancellationToken = default, bool prioritize = false);
+    Task ScheduleExecuteOfSeriesSystemAction(ExecutableActionInfo actionInfo, IShokoSeries series, CancellationToken cancellationToken = default, bool prioritize = false);
 
     /// <summary>
-    ///   Executes a series user action immediately for the specified series and user, and awaits completion.
+    ///   Executes a series-scoped user-level user action immediately for the
+    ///   specified series and user, and awaits completion.
     /// </summary>
     /// <param name="actionInfo">The action to execute.</param>
     /// <param name="series">The series to run the action on.</param>
@@ -204,12 +215,13 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support series user scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.SeriesUser"/>).
+    ///   <see cref="ActionScope.UserAndSeries"/>).
     /// </exception>
     Task ExecuteSeriesUserAction(ExecutableActionInfo actionInfo, IShokoSeries series, IUser user, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///   Schedules a series user action for later execution through the job queue.
+    ///   Schedules a series-scoped user-level user action for later execution
+    ///   through the job queue system.
     /// </summary>
     /// <param name="actionInfo">The action to schedule.</param>
     /// <param name="series">The series to run the action on.</param>
@@ -219,7 +231,7 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support series user scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.SeriesUser"/>).
+    ///   <see cref="ActionScope.UserAndSeries"/>).
     /// </exception>
     Task ScheduleExecuteOfSeriesUserAction(ExecutableActionInfo actionInfo, IShokoSeries series, IUser user, CancellationToken cancellationToken = default, bool prioritize = false);
 
@@ -228,7 +240,8 @@ public interface IActionService
     #region Episode
 
     /// <summary>
-    ///   Executes an episode action immediately for the specified episode and awaits completion.
+    ///   Executes an episode-scoped system-level administrative action
+    ///   immediately for the specified episode and awaits completion.
     /// </summary>
     /// <param name="actionInfo">The action to execute.</param>
     /// <param name="episode">The episode to run the action on.</param>
@@ -238,10 +251,11 @@ public interface IActionService
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
     ///   <see cref="ActionScope.Episode"/>).
     /// </exception>
-    Task ExecuteEpisodeAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, CancellationToken cancellationToken = default);
+    Task ExecuteEpisodeSystemAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///   Schedules an episode action for later execution through the job queue.
+    ///   Schedules an episode-scoped system-level administrative action for
+    ///   later execution through the job queue.
     /// </summary>
     /// <param name="actionInfo">The action to schedule.</param>
     /// <param name="episode">The episode to run the action on.</param>
@@ -252,10 +266,11 @@ public interface IActionService
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
     ///   <see cref="ActionScope.Episode"/>).
     /// </exception>
-    Task ScheduleExecuteOfEpisodeAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, CancellationToken cancellationToken = default, bool prioritize = false);
+    Task ScheduleExecuteOfEpisodeSystemAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, CancellationToken cancellationToken = default, bool prioritize = false);
 
     /// <summary>
-    ///   Executes an episode user action immediately for the specified episode and user, and awaits completion.
+    ///   Executes an episode-scoped user-level user action immediately for the
+    ///   specified episode and user, and awaits completion.
     /// </summary>
     /// <param name="actionInfo">The action to execute.</param>
     /// <param name="episode">The episode to run the action on.</param>
@@ -264,12 +279,13 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support episode user scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.EpisodeUser"/>).
+    ///   <see cref="ActionScope.UserAndEpisode"/>).
     /// </exception>
     Task ExecuteEpisodeUserAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, IUser user, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///   Schedules an episode user action for later execution through the job queue.
+    ///   Schedules an episode-scoped user-level user action for later execution
+    ///   through the job queue system.
     /// </summary>
     /// <param name="actionInfo">The action to schedule.</param>
     /// <param name="episode">The episode to run the action on.</param>
@@ -279,7 +295,7 @@ public interface IActionService
     /// <exception cref="InvalidOperationException">
     ///   Thrown when <paramref name="actionInfo"/> does not support episode user scope
     ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
-    ///   <see cref="ActionScope.EpisodeUser"/>).
+    ///   <see cref="ActionScope.UserAndEpisode"/>).
     /// </exception>
     Task ScheduleExecuteOfEpisodeUserAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, IUser user, CancellationToken cancellationToken = default, bool prioritize = false);
 

--- a/Shoko.Abstractions/Action/Services/IActionService.cs
+++ b/Shoko.Abstractions/Action/Services/IActionService.cs
@@ -1,0 +1,287 @@
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Abstractions.User;
+
+namespace Shoko.Abstractions.Action.Services;
+
+/// <summary>
+///   Service for registering, discovering, and executing plugin-provided actions.
+///   Actions are registered during plugin initialization via <see cref="AddParts"/>
+///   and can be executed immediately or scheduled through the job queue.
+/// </summary>
+public interface IActionService
+{
+    /// <summary>
+    ///   Registers a collection of executable actions. Called once during plugin
+    ///   initialization. Subsequent calls are no-ops.
+    /// </summary>
+    /// <param name="actions">The executable actions to register.</param>
+    void AddParts(IEnumerable<IExecutableAction> actions);
+
+    /// <summary>
+    ///   Gets the list of all registered actions, optionally filtered by scopes,
+    ///   categories, or category names. Each enumerable is converted to a set
+    ///   internally; actions matching at least one value in each non-null set
+    ///   are returned.
+    /// </summary>
+    /// <param name="scopes">
+    ///   Optional scope filter. Returns actions whose <see cref="ExecutableActionInfo.Scopes"/>
+    ///   set overlaps with any value in the provided sequence.
+    /// </param>
+    /// <param name="categories">Optional category enum filter.</param>
+    /// <param name="categoryNames">
+    ///   Optional category name filter. Matches <see cref="ExecutableActionInfo.CategoryName"/>
+    ///   case-insensitively. Useful for filtering by plugin name when
+    ///   <see cref="ExecutableActionInfo.Category"/> is <see cref="ActionCategory.PluginInferred"/>.
+    /// </param>
+    /// <returns>A read-only list of matching <see cref="ExecutableActionInfo"/>.</returns>
+    IReadOnlyList<ExecutableActionInfo> GetActions(IEnumerable<ActionScope>? scopes = null, IEnumerable<ActionCategory>? categories = null, IEnumerable<string>? categoryNames = null);
+
+    /// <summary>
+    ///   Gets information about a registered action by its ID.
+    /// </summary>
+    /// <param name="actionId">The action's stable identifier.</param>
+    /// <returns>The action info, or <c>null</c> if no action with the given ID is registered.</returns>
+    ExecutableActionInfo? GetActionById(Guid actionId);
+
+    #region Global
+
+    /// <summary>
+    ///   Executes a global action immediately and awaits completion.
+    /// </summary>
+    /// <param name="actionInfo">The action to execute.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support global scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.Global"/>).
+    /// </exception>
+    Task ExecuteGlobalAction(ExecutableActionInfo actionInfo, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///   Schedules a global action for later execution through the job queue.
+    /// </summary>
+    /// <param name="actionInfo">The action to schedule.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="prioritize">If <c>true</c>, the job is enqueued at maximum priority.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support global scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.Global"/>).
+    /// </exception>
+    Task ScheduleExecuteOfGlobalAction(ExecutableActionInfo actionInfo, CancellationToken cancellationToken = default, bool prioritize = false);
+
+    /// <summary>
+    ///   Executes a global user action immediately for the specified user and awaits completion.
+    /// </summary>
+    /// <param name="actionInfo">The action to execute.</param>
+    /// <param name="user">The user to run the action for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support user scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.GlobalUser"/>).
+    /// </exception>
+    Task ExecuteGlobalUserAction(ExecutableActionInfo actionInfo, IUser user, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///   Schedules a global user action for later execution through the job queue.
+    /// </summary>
+    /// <param name="actionInfo">The action to schedule.</param>
+    /// <param name="user">The user to run the action for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="prioritize">If <c>true</c>, the job is enqueued at maximum priority.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support user scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.GlobalUser"/>).
+    /// </exception>
+    Task ScheduleExecuteOfGlobalUserAction(ExecutableActionInfo actionInfo, IUser user, CancellationToken cancellationToken = default, bool prioritize = false);
+
+    #endregion
+
+    #region Group
+
+    /// <summary>
+    ///   Executes a group action immediately for the specified group and awaits completion.
+    /// </summary>
+    /// <param name="actionInfo">The action to execute.</param>
+    /// <param name="group">The group to run the action on.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support group scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.Group"/>).
+    /// </exception>
+    Task ExecuteGroupAction(ExecutableActionInfo actionInfo, IShokoGroup group, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///   Schedules a group action for later execution through the job queue.
+    /// </summary>
+    /// <param name="actionInfo">The action to schedule.</param>
+    /// <param name="group">The group to run the action on.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="prioritize">If <c>true</c>, the job is enqueued at maximum priority.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support group scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.Group"/>).
+    /// </exception>
+    Task ScheduleExecuteOfGroupAction(ExecutableActionInfo actionInfo, IShokoGroup group, CancellationToken cancellationToken = default, bool prioritize = false);
+
+    /// <summary>
+    ///   Executes a group user action immediately for the specified group and user, and awaits completion.
+    /// </summary>
+    /// <param name="actionInfo">The action to execute.</param>
+    /// <param name="group">The group to run the action on.</param>
+    /// <param name="user">The user to run the action for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support group user scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.GroupUser"/>).
+    /// </exception>
+    Task ExecuteGroupUserAction(ExecutableActionInfo actionInfo, IShokoGroup group, IUser user, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///   Schedules a group user action for later execution through the job queue.
+    /// </summary>
+    /// <param name="actionInfo">The action to schedule.</param>
+    /// <param name="group">The group to run the action on.</param>
+    /// <param name="user">The user to run the action for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="prioritize">If <c>true</c>, the job is enqueued at maximum priority.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support group user scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.GroupUser"/>).
+    /// </exception>
+    Task ScheduleExecuteOfGroupUserAction(ExecutableActionInfo actionInfo, IShokoGroup group, IUser user, CancellationToken cancellationToken = default, bool prioritize = false);
+
+    #endregion
+
+    #region Series
+
+    /// <summary>
+    ///   Executes a series action immediately for the specified series and awaits completion.
+    /// </summary>
+    /// <param name="actionInfo">The action to execute.</param>
+    /// <param name="series">The series to run the action on.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support series scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.Series"/>).
+    /// </exception>
+    Task ExecuteSeriesAction(ExecutableActionInfo actionInfo, IShokoSeries series, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///   Schedules a series action for later execution through the job queue.
+    /// </summary>
+    /// <param name="actionInfo">The action to schedule.</param>
+    /// <param name="series">The series to run the action on.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="prioritize">If <c>true</c>, the job is enqueued at maximum priority.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support series scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.Series"/>).
+    /// </exception>
+    Task ScheduleExecuteOfSeriesAction(ExecutableActionInfo actionInfo, IShokoSeries series, CancellationToken cancellationToken = default, bool prioritize = false);
+
+    /// <summary>
+    ///   Executes a series user action immediately for the specified series and user, and awaits completion.
+    /// </summary>
+    /// <param name="actionInfo">The action to execute.</param>
+    /// <param name="series">The series to run the action on.</param>
+    /// <param name="user">The user to run the action for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support series user scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.SeriesUser"/>).
+    /// </exception>
+    Task ExecuteSeriesUserAction(ExecutableActionInfo actionInfo, IShokoSeries series, IUser user, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///   Schedules a series user action for later execution through the job queue.
+    /// </summary>
+    /// <param name="actionInfo">The action to schedule.</param>
+    /// <param name="series">The series to run the action on.</param>
+    /// <param name="user">The user to run the action for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="prioritize">If <c>true</c>, the job is enqueued at maximum priority.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support series user scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.SeriesUser"/>).
+    /// </exception>
+    Task ScheduleExecuteOfSeriesUserAction(ExecutableActionInfo actionInfo, IShokoSeries series, IUser user, CancellationToken cancellationToken = default, bool prioritize = false);
+
+    #endregion
+
+    #region Episode
+
+    /// <summary>
+    ///   Executes an episode action immediately for the specified episode and awaits completion.
+    /// </summary>
+    /// <param name="actionInfo">The action to execute.</param>
+    /// <param name="episode">The episode to run the action on.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support episode scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.Episode"/>).
+    /// </exception>
+    Task ExecuteEpisodeAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///   Schedules an episode action for later execution through the job queue.
+    /// </summary>
+    /// <param name="actionInfo">The action to schedule.</param>
+    /// <param name="episode">The episode to run the action on.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="prioritize">If <c>true</c>, the job is enqueued at maximum priority.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support episode scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.Episode"/>).
+    /// </exception>
+    Task ScheduleExecuteOfEpisodeAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, CancellationToken cancellationToken = default, bool prioritize = false);
+
+    /// <summary>
+    ///   Executes an episode user action immediately for the specified episode and user, and awaits completion.
+    /// </summary>
+    /// <param name="actionInfo">The action to execute.</param>
+    /// <param name="episode">The episode to run the action on.</param>
+    /// <param name="user">The user to run the action for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support episode user scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.EpisodeUser"/>).
+    /// </exception>
+    Task ExecuteEpisodeUserAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, IUser user, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///   Schedules an episode user action for later execution through the job queue.
+    /// </summary>
+    /// <param name="actionInfo">The action to schedule.</param>
+    /// <param name="episode">The episode to run the action on.</param>
+    /// <param name="user">The user to run the action for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="prioritize">If <c>true</c>, the job is enqueued at maximum priority.</param>
+    /// <exception cref="InvalidOperationException">
+    ///   Thrown when <paramref name="actionInfo"/> does not support episode user scope
+    ///   (its <see cref="ExecutableActionInfo.Scopes"/> set does not contain
+    ///   <see cref="ActionScope.EpisodeUser"/>).
+    /// </exception>
+    Task ScheduleExecuteOfEpisodeUserAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, IUser user, CancellationToken cancellationToken = default, bool prioritize = false);
+
+    #endregion
+}

--- a/Shoko.Server/API/v3/Controllers/ActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/ActionController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -7,10 +8,9 @@ using Microsoft.AspNetCore.Mvc;
 using Shoko.Abstractions.Action.Enums;
 using Shoko.Abstractions.Action.Services;
 using Shoko.Abstractions.Metadata.Enums;
-using Shoko.Abstractions.Web.Attributes;
 using Shoko.Abstractions.Metadata.Services;
-using Shoko.Abstractions.User;
 using Shoko.Abstractions.Video.Services;
+using Shoko.Abstractions.Web.Attributes;
 using Shoko.QueueProcessor.Abstractions;
 using Shoko.QueueProcessor.Scheduling;
 using Shoko.Server.API.Annotations;
@@ -98,24 +98,28 @@ public class ActionController : BaseController
     /// <summary>
     ///   Execute a global or user-scoped action by its ID.
     /// </summary>
-    /// <param name="id">The action ID.</param>
+    /// <param name="actionID">The action ID.</param>
     /// <param name="scope">
-    ///   Optional scope override. When omitted, the server picks the highest
-    ///   priority scope available to the user (Global for admins, User for
-    ///   standard users).
+    ///   Optional scope override. Only <see cref="ActionScope.System"/> or
+    ///   <see cref="ActionScope.User"/> are valid. When omitted, the server
+    ///   picks the highest priority scope available to the user (System for
+    ///   admins, User for standard users).
     /// </param>
-    [HttpPost("{id}/Execute")]
-    public async Task<ActionResult> ExecuteGlobalAction(Guid id, [FromQuery] ActionScope? scope = null)
+    [HttpPost("{actionId}/Execute")]
+    public async Task<ActionResult> ExecuteGlobalAction(
+        [FromRoute] Guid actionID,
+        [FromQuery, AllowedValues(ActionScope.System, ActionScope.User, ErrorMessage = "Execution scope must be 'System' or 'User' when specified.")] ActionScope? scope = null
+    )
     {
-        var actionInfo = _actionServiceInterface.GetActionById(id);
+        var actionInfo = _actionServiceInterface.GetActionById(actionID);
         if (actionInfo is null)
             return NotFound();
 
-        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes, ActionScope.Global);
-        if (!actionInfo.Scopes.Contains(resolvedScope))
+        var resolvedScope = ResolveDefaultScope(actionInfo.Scopes, ActionScope.Global, scope);
+        if (!resolvedScope.HasValue || !actionInfo.Scopes.Contains(resolvedScope.Value))
             return BadRequest(string.Format(UnsupportedScope, resolvedScope));
 
-        if (resolvedScope.HasFlag(ActionScope.System) && User.IsAdmin != 1)
+        if (resolvedScope.Value.HasFlag(ActionScope.System) && User.IsAdmin != 1)
             return Forbid(RequiresAdmin);
 
         switch (resolvedScope)
@@ -148,24 +152,29 @@ public class ActionController : BaseController
     ///   Execute a group-scoped action by its ID for the specified group.
     /// </summary>
     /// <param name="groupID">The group ID.</param>
-    /// <param name="id">The action ID.</param>
+    /// <param name="actionID">The action ID.</param>
     /// <param name="scope">
-    ///   Optional scope override. When omitted, the server picks the highest
-    ///   priority scope available to the user (Group for admins, GroupUser
-    ///   for standard users).
+    ///   Optional scope override. Only <see cref="ActionScope.System"/> or
+    ///   <see cref="ActionScope.User"/> are valid. When omitted, the server
+    ///   picks the highest priority scope available to the user (System for
+    ///   admins, User for standard users).
     /// </param>
-    [HttpPost("Group/{groupID}/Action/{id}/Execute")]
-    public async Task<ActionResult> ExecuteGroupAction([FromRoute] int groupID, [FromRoute] Guid id, [FromQuery] ActionScope? scope = null)
+    [HttpPost("Group/{groupID}/Action/{actionID}/Execute")]
+    public async Task<ActionResult> ExecuteGroupAction(
+        [FromRoute] int groupID,
+        [FromRoute] Guid actionID,
+        [FromQuery, AllowedValues(ActionScope.System, ActionScope.User, ErrorMessage = "Execution scope must be 'System' or 'User' when specified.")] ActionScope? scope = null
+    )
     {
-        var actionInfo = _actionServiceInterface.GetActionById(id);
+        var actionInfo = _actionServiceInterface.GetActionById(actionID);
         if (actionInfo is null)
             return NotFound();
 
-        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes, ActionScope.Group);
-        if (!actionInfo.Scopes.Contains(resolvedScope))
+        var resolvedScope = ResolveDefaultScope(actionInfo.Scopes, ActionScope.Group, scope);
+        if (!resolvedScope.HasValue || !actionInfo.Scopes.Contains(resolvedScope.Value))
             return BadRequest(string.Format(UnsupportedScope, resolvedScope));
 
-        if (resolvedScope.HasFlag(ActionScope.System) && User.IsAdmin != 1)
+        if (resolvedScope.Value.HasFlag(ActionScope.System) && User.IsAdmin != 1)
             return Forbid(RequiresAdmin);
 
         var group = _animeGroups.GetByID(groupID);
@@ -202,24 +211,29 @@ public class ActionController : BaseController
     ///   Execute a series-scoped action by its ID for the specified series.
     /// </summary>
     /// <param name="seriesID">The AniDB anime ID of the series.</param>
-    /// <param name="id">The action ID.</param>
+    /// <param name="actionID">The action ID.</param>
     /// <param name="scope">
-    ///   Optional scope override. When omitted, the server picks the highest
-    ///   priority scope available to the user (Series for admins, SeriesUser
-    ///   for standard users).
+    ///   Optional scope override. Only <see cref="ActionScope.System"/> or
+    ///   <see cref="ActionScope.User"/> are valid. When omitted, the server
+    ///   picks the highest priority scope available to the user (System for
+    ///   admins, User for standard users).
     /// </param>
-    [HttpPost("Series/{seriesID}/Action/{id}/Execute")]
-    public async Task<ActionResult> ExecuteSeriesAction([FromRoute] int seriesID, [FromRoute] Guid id, [FromQuery] ActionScope? scope = null)
+    [HttpPost("Series/{seriesID}/Action/{actionID}/Execute")]
+    public async Task<ActionResult> ExecuteSeriesAction(
+        [FromRoute] int seriesID,
+        [FromRoute] Guid actionID,
+        [FromQuery, AllowedValues(ActionScope.System, ActionScope.User, ErrorMessage = "Execution scope must be 'System' or 'User' when specified.")] ActionScope? scope = null
+    )
     {
-        var actionInfo = _actionServiceInterface.GetActionById(id);
+        var actionInfo = _actionServiceInterface.GetActionById(actionID);
         if (actionInfo is null)
             return NotFound();
 
-        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes, ActionScope.Series);
-        if (!actionInfo.Scopes.Contains(resolvedScope))
+        var resolvedScope = ResolveDefaultScope(actionInfo.Scopes, ActionScope.Series, scope);
+        if (!resolvedScope.HasValue || !actionInfo.Scopes.Contains(resolvedScope.Value))
             return BadRequest(string.Format(UnsupportedScope, resolvedScope));
 
-        if (resolvedScope.HasFlag(ActionScope.System) && User.IsAdmin != 1)
+        if (resolvedScope.Value.HasFlag(ActionScope.System) && User.IsAdmin != 1)
             return Forbid(RequiresAdmin);
 
         var series = _animeSeries.GetByAnimeID(seriesID);
@@ -256,24 +270,29 @@ public class ActionController : BaseController
     ///   Execute an episode-scoped action by its ID for the specified episode.
     /// </summary>
     /// <param name="episodeID">The episode ID.</param>
-    /// <param name="id">The action ID.</param>
+    /// <param name="actionID">The action ID.</param>
     /// <param name="scope">
-    ///   Optional scope override. When omitted, the server picks the highest
-    ///   priority scope available to the user (Episode for admins, EpisodeUser
-    ///   for standard users).
+    ///   Optional scope override. Only <see cref="ActionScope.System"/> or
+    ///   <see cref="ActionScope.User"/> are valid. When omitted, the server
+    ///   picks the highest priority scope available to the user (System for
+    ///   admins, User for standard users).
     /// </param>
-    [HttpPost("Episode/{episodeID}/Action/{id}/Execute")]
-    public async Task<ActionResult> ExecuteEpisodeAction([FromRoute] int episodeID, [FromRoute] Guid id, [FromQuery] ActionScope? scope = null)
+    [HttpPost("Episode/{episodeID}/Action/{actionID}/Execute")]
+    public async Task<ActionResult> ExecuteEpisodeAction(
+        [FromRoute] int episodeID,
+        [FromRoute] Guid actionID,
+        [FromQuery, AllowedValues(ActionScope.System, ActionScope.User, ErrorMessage = "Execution scope must be 'System' or 'User' when specified.")] ActionScope? scope = null
+    )
     {
-        var actionInfo = _actionServiceInterface.GetActionById(id);
+        var actionInfo = _actionServiceInterface.GetActionById(actionID);
         if (actionInfo is null)
             return NotFound();
 
-        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes, ActionScope.Episode);
-        if (!actionInfo.Scopes.Contains(resolvedScope))
+        var resolvedScope = ResolveDefaultScope(actionInfo.Scopes, ActionScope.Episode, scope);
+        if (!resolvedScope.HasValue || !actionInfo.Scopes.Contains(resolvedScope.Value))
             return BadRequest(string.Format(UnsupportedScope, resolvedScope));
 
-        if (resolvedScope.HasFlag(ActionScope.System) && User.IsAdmin != 1)
+        if (resolvedScope.Value.HasFlag(ActionScope.System) && User.IsAdmin != 1)
             return Forbid(RequiresAdmin);
 
         var episode = _animeEpisodes.GetByID(episodeID);
@@ -327,12 +346,12 @@ public class ActionController : BaseController
     ///   Resolves the default scope from a set of available scopes based on
     ///   user role priority.
     /// </summary>
-    private ActionScope ResolveDefaultScope(IReadOnlySet<ActionScope> available, ActionScope scope)
+    private ActionScope? ResolveDefaultScope(IReadOnlySet<ActionScope> available, ActionScope scope, ActionScope? baseScope)
     {
-        if (User.IsAdmin == 1 && available.Contains(ActionScope.System | scope))
+        if (((baseScope is null && User.IsAdmin == 1) || baseScope is ActionScope.System) && available.Contains(ActionScope.System | scope))
             return ActionScope.System | scope;
 
-        if (available.Contains(ActionScope.User | scope))
+        if (baseScope is null or ActionScope.User && available.Contains(ActionScope.User | scope))
             return ActionScope.User | scope;
 
         return 0;

--- a/Shoko.Server/API/v3/Controllers/ActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/ActionController.cs
@@ -34,6 +34,11 @@ namespace Shoko.Server.API.v3.Controllers;
 [Authorize]
 public class ActionController : BaseController
 {
+    private const string ObsoleteMessage = "Use the new action system instead.";
+    private const string UnsupportedScope = "The action does not support the '{0}' scope.";
+    private const string UnexpectedScope = "Unexpected scope '{0}' on this endpoint.";
+    private const string RequiresAdmin = "Administrator privileges are required for this action scope.";
+
     private readonly AnimeGroupCreator _groupCreator;
     private readonly ActionService _actionService;
     private readonly IActionService _actionServiceInterface;
@@ -47,12 +52,6 @@ public class ActionController : BaseController
     private readonly AnimeSeriesRepository _animeSeries;
     private readonly AnimeGroupRepository _animeGroups;
     private readonly AnimeEpisodeRepository _animeEpisodes;
-
-    /// <summary>Priority-ordered scopes for admins when no scope is specified.</summary>
-    private static readonly ActionScope[] _adminScopePriority = [ActionScope.Global, ActionScope.GlobalUser, ActionScope.Series, ActionScope.SeriesUser, ActionScope.Group, ActionScope.GroupUser, ActionScope.Episode, ActionScope.EpisodeUser];
-
-    /// <summary>Priority-ordered scopes for standard users when no scope is specified.</summary>
-    private static readonly ActionScope[] _userScopePriority = [ActionScope.GlobalUser, ActionScope.SeriesUser, ActionScope.GroupUser, ActionScope.EpisodeUser];
 
     public ActionController(
         TmdbMetadataService tmdbMetadataService,
@@ -91,39 +90,10 @@ public class ActionController : BaseController
     ///   List all registered global/user-scoped actions, grouped by category,
     ///   filtered to scopes the current user can execute.
     /// </summary>
-    [HttpGet]
+    [HttpGet("Actions")]
     [InitFriendly]
-    public ActionResult<IReadOnlyList<ActionCategoryGroup>> GetActions()
-    {
-        var actions = _actionServiceInterface.GetActions(scopes: [ActionScope.Global, ActionScope.GlobalUser]);
-        var isAdmin = User.IsAdmin == 1;
-        var result = actions
-            .Select(info =>
-            {
-                var permittedScopes = isAdmin
-                    ? info.Scopes.Where(s => s is ActionScope.Global or ActionScope.GlobalUser).ToHashSet()
-                    : info.Scopes.Where(s => s is ActionScope.GlobalUser).ToHashSet();
-                return (Info: info, PermittedScopes: permittedScopes);
-            })
-            .Where(t => t.PermittedScopes.Count > 0)
-            .GroupBy(t => t.Info.CategoryName)
-            .Select(g => new ActionCategoryGroup
-            {
-                Name = g.Key,
-                Actions = g.Select(t => new ActionInfo
-                {
-                    ID = t.Info.ID,
-                    Name = t.Info.Name,
-                    Description = t.Info.Description,
-                    RequiresConfirmation = t.Info.RequiresConfirmation,
-                    Scopes = t.PermittedScopes,
-                    Plugin = new PluginInfo(t.Info.PluginInfo),
-                }).ToList(),
-            })
-            .ToList();
-
-        return Ok(result);
-    }
+    public IReadOnlyList<ActionCategoryGroup> GetActions()
+         => GetActionCategories(ActionScope.Global, User.IsAdmin == 1);
 
     /// <summary>
     ///   Execute a global or user-scoped action by its ID.
@@ -141,23 +111,25 @@ public class ActionController : BaseController
         if (actionInfo is null)
             return NotFound();
 
-        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes);
+        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes, ActionScope.Global);
         if (!actionInfo.Scopes.Contains(resolvedScope))
-            return BadRequest($"The action does not support the '{resolvedScope}' scope.");
+            return BadRequest(string.Format(UnsupportedScope, resolvedScope));
 
-        if (resolvedScope is ActionScope.Global or ActionScope.Series && User.IsAdmin != 1)
-            return Forbid("Admin privileges are required for this action scope.");
+        if (resolvedScope.HasFlag(ActionScope.System) && User.IsAdmin != 1)
+            return Forbid(RequiresAdmin);
 
         switch (resolvedScope)
         {
-            case ActionScope.Global:
-                await _actionServiceInterface.ScheduleExecuteOfGlobalAction(actionInfo);
+            case ActionScope.SystemAndGlobal:
+                await _actionServiceInterface.ScheduleExecuteOfGlobalSystemAction(actionInfo);
                 break;
-            case ActionScope.GlobalUser:
-                await _actionServiceInterface.ScheduleExecuteOfGlobalUserAction(actionInfo, (IUser)User);
+
+            case ActionScope.UserAndGlobal:
+                await _actionServiceInterface.ScheduleExecuteOfGlobalUserAction(actionInfo, User);
                 break;
+
             default:
-                return BadRequest($"Unexpected scope '{resolvedScope}' on this endpoint.");
+                return BadRequest(string.Format(UnexpectedScope, resolvedScope));
         }
 
         return Ok();
@@ -167,40 +139,10 @@ public class ActionController : BaseController
     ///   List all registered group-scoped actions, grouped by category,
     ///   filtered to scopes the current user can execute.
     /// </summary>
-    [HttpGet("Group/{groupID}/Action")]
+    [HttpGet("Group/Actions")]
     [InitFriendly]
-    public ActionResult<IReadOnlyList<ActionCategoryGroup>> GetGroupActions([FromRoute] int groupID)
-    {
-        var actions = _actionServiceInterface.GetActions(scopes: [ActionScope.Group, ActionScope.GroupUser]);
-        var isAdmin = User.IsAdmin == 1;
-
-        var result = actions
-            .Select(info =>
-            {
-                var permittedScopes = isAdmin
-                    ? info.Scopes
-                    : info.Scopes.Where(s => s is ActionScope.GroupUser).ToHashSet();
-                return (Info: info, PermittedScopes: permittedScopes);
-            })
-            .Where(t => t.PermittedScopes.Count > 0)
-            .GroupBy(t => t.Info.CategoryName)
-            .Select(g => new ActionCategoryGroup
-            {
-                Name = g.Key,
-                Actions = g.Select(t => new ActionInfo
-                {
-                    ID = t.Info.ID,
-                    Name = t.Info.Name,
-                    Description = t.Info.Description,
-                    RequiresConfirmation = t.Info.RequiresConfirmation,
-                    Scopes = t.PermittedScopes,
-                    Plugin = new PluginInfo(t.Info.PluginInfo),
-                }).ToList(),
-            })
-            .ToList();
-
-        return Ok(result);
-    }
+    public IReadOnlyList<ActionCategoryGroup> GetGroupActions()
+         => GetActionCategories(ActionScope.Group, User.IsAdmin == 1);
 
     /// <summary>
     ///   Execute a group-scoped action by its ID for the specified group.
@@ -219,12 +161,12 @@ public class ActionController : BaseController
         if (actionInfo is null)
             return NotFound();
 
-        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes);
+        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes, ActionScope.Group);
         if (!actionInfo.Scopes.Contains(resolvedScope))
-            return BadRequest($"The action does not support the '{resolvedScope}' scope.");
+            return BadRequest(string.Format(UnsupportedScope, resolvedScope));
 
-        if (resolvedScope is ActionScope.Group && User.IsAdmin != 1)
-            return Forbid("Admin privileges are required for this action scope.");
+        if (resolvedScope.HasFlag(ActionScope.System) && User.IsAdmin != 1)
+            return Forbid(RequiresAdmin);
 
         var group = _animeGroups.GetByID(groupID);
         if (group is null)
@@ -233,13 +175,15 @@ public class ActionController : BaseController
         switch (resolvedScope)
         {
             case ActionScope.Group:
-                await _actionServiceInterface.ScheduleExecuteOfGroupAction(actionInfo, group);
+                await _actionServiceInterface.ScheduleExecuteOfGroupSystemAction(actionInfo, group);
                 break;
-            case ActionScope.GroupUser:
-                await _actionServiceInterface.ScheduleExecuteOfGroupUserAction(actionInfo, group, (IUser)User);
+
+            case ActionScope.UserAndGroup:
+                await _actionServiceInterface.ScheduleExecuteOfGroupUserAction(actionInfo, group, User);
                 break;
+
             default:
-                return BadRequest($"Unexpected scope '{resolvedScope}' on this endpoint.");
+                return BadRequest(string.Format(UnexpectedScope, resolvedScope));
         }
 
         return Ok();
@@ -249,40 +193,10 @@ public class ActionController : BaseController
     ///   List all registered series-scoped actions, grouped by category,
     ///   filtered to scopes the current user can execute.
     /// </summary>
-    [HttpGet("Series/{seriesID}/Action")]
+    [HttpGet("Series/Actions")]
     [InitFriendly]
-    public ActionResult<IReadOnlyList<ActionCategoryGroup>> GetSeriesActions([FromRoute] int seriesID)
-    {
-        var actions = _actionServiceInterface.GetActions(scopes: [ActionScope.Series, ActionScope.SeriesUser]);
-        var isAdmin = User.IsAdmin == 1;
-
-        var result = actions
-            .Select(info =>
-            {
-                var permittedScopes = isAdmin
-                    ? info.Scopes.Where(s => s is ActionScope.Series or ActionScope.SeriesUser).ToHashSet()
-                    : info.Scopes.Where(s => s is ActionScope.SeriesUser).ToHashSet();
-                return (Info: info, PermittedScopes: permittedScopes);
-            })
-            .Where(t => t.PermittedScopes.Count > 0)
-            .GroupBy(t => t.Info.CategoryName)
-            .Select(g => new ActionCategoryGroup
-            {
-                Name = g.Key,
-                Actions = g.Select(t => new ActionInfo
-                {
-                    ID = t.Info.ID,
-                    Name = t.Info.Name,
-                    Description = t.Info.Description,
-                    RequiresConfirmation = t.Info.RequiresConfirmation,
-                    Scopes = t.PermittedScopes,
-                    Plugin = new PluginInfo(t.Info.PluginInfo),
-                }).ToList(),
-            })
-            .ToList();
-
-        return Ok(result);
-    }
+    public IReadOnlyList<ActionCategoryGroup> GetSeriesActions()
+         => GetActionCategories(ActionScope.Series, User.IsAdmin == 1);
 
     /// <summary>
     ///   Execute a series-scoped action by its ID for the specified series.
@@ -301,12 +215,12 @@ public class ActionController : BaseController
         if (actionInfo is null)
             return NotFound();
 
-        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes);
+        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes, ActionScope.Series);
         if (!actionInfo.Scopes.Contains(resolvedScope))
-            return BadRequest($"The action does not support the '{resolvedScope}' scope.");
+            return BadRequest(string.Format(UnsupportedScope, resolvedScope));
 
-        if (resolvedScope is ActionScope.Series && User.IsAdmin != 1)
-            return Forbid("Admin privileges are required for this action scope.");
+        if (resolvedScope.HasFlag(ActionScope.System) && User.IsAdmin != 1)
+            return Forbid(RequiresAdmin);
 
         var series = _animeSeries.GetByAnimeID(seriesID);
         if (series is null)
@@ -315,13 +229,15 @@ public class ActionController : BaseController
         switch (resolvedScope)
         {
             case ActionScope.Series:
-                await _actionServiceInterface.ScheduleExecuteOfSeriesAction(actionInfo, series);
+                await _actionServiceInterface.ScheduleExecuteOfSeriesSystemAction(actionInfo, series);
                 break;
-            case ActionScope.SeriesUser:
-                await _actionServiceInterface.ScheduleExecuteOfSeriesUserAction(actionInfo, series, (IUser)User);
+
+            case ActionScope.UserAndSeries:
+                await _actionServiceInterface.ScheduleExecuteOfSeriesUserAction(actionInfo, series, User);
                 break;
+
             default:
-                return BadRequest($"Unexpected scope '{resolvedScope}' on this endpoint.");
+                return BadRequest(string.Format(UnexpectedScope, resolvedScope));
         }
 
         return Ok();
@@ -331,19 +247,63 @@ public class ActionController : BaseController
     ///   List all registered episode-scoped actions, grouped by category,
     ///   filtered to scopes the current user can execute.
     /// </summary>
-    [HttpGet("Episode/{episodeID}/Action")]
+    [HttpGet("Episode/Actions")]
     [InitFriendly]
-    public ActionResult<IReadOnlyList<ActionCategoryGroup>> GetEpisodeActions([FromRoute] int episodeID)
-    {
-        var actions = _actionServiceInterface.GetActions(scopes: [ActionScope.Episode, ActionScope.EpisodeUser]);
-        var isAdmin = User.IsAdmin == 1;
+    public IReadOnlyList<ActionCategoryGroup> GetEpisodeActions()
+        => GetActionCategories(ActionScope.Episode, User.IsAdmin == 1);
 
-        var result = actions
+    /// <summary>
+    ///   Execute an episode-scoped action by its ID for the specified episode.
+    /// </summary>
+    /// <param name="episodeID">The episode ID.</param>
+    /// <param name="id">The action ID.</param>
+    /// <param name="scope">
+    ///   Optional scope override. When omitted, the server picks the highest
+    ///   priority scope available to the user (Episode for admins, EpisodeUser
+    ///   for standard users).
+    /// </param>
+    [HttpPost("Episode/{episodeID}/Action/{id}/Execute")]
+    public async Task<ActionResult> ExecuteEpisodeAction([FromRoute] int episodeID, [FromRoute] Guid id, [FromQuery] ActionScope? scope = null)
+    {
+        var actionInfo = _actionServiceInterface.GetActionById(id);
+        if (actionInfo is null)
+            return NotFound();
+
+        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes, ActionScope.Episode);
+        if (!actionInfo.Scopes.Contains(resolvedScope))
+            return BadRequest(string.Format(UnsupportedScope, resolvedScope));
+
+        if (resolvedScope.HasFlag(ActionScope.System) && User.IsAdmin != 1)
+            return Forbid(RequiresAdmin);
+
+        var episode = _animeEpisodes.GetByID(episodeID);
+        if (episode is null)
+            return NotFound("Episode not found.");
+
+        switch (resolvedScope)
+        {
+            case ActionScope.Episode:
+                await _actionServiceInterface.ScheduleExecuteOfEpisodeSystemAction(actionInfo, episode);
+                break;
+
+            case ActionScope.UserAndEpisode:
+                await _actionServiceInterface.ScheduleExecuteOfEpisodeUserAction(actionInfo, episode, User);
+                break;
+
+            default:
+                return BadRequest(string.Format(UnexpectedScope, resolvedScope));
+        }
+
+        return Ok();
+    }
+
+    private IReadOnlyList<ActionCategoryGroup> GetActionCategories(ActionScope scope, bool isAdmin)
+        => _actionServiceInterface.GetActions(scopes: [ActionScope.System | scope, ActionScope.User | scope])
             .Select(info =>
             {
                 var permittedScopes = isAdmin
-                    ? info.Scopes
-                    : info.Scopes.Where(s => s is ActionScope.EpisodeUser).ToHashSet();
+                    ? info.Scopes.Where(s => s.HasFlag(scope)).ToHashSet()
+                    : info.Scopes.Where(s => s.HasFlag(ActionScope.User | scope)).ToHashSet();
                 return (Info: info, PermittedScopes: permittedScopes);
             })
             .Where(t => t.PermittedScopes.Count > 0)
@@ -363,63 +323,19 @@ public class ActionController : BaseController
             })
             .ToList();
 
-        return Ok(result);
-    }
-
-    /// <summary>
-    ///   Execute an episode-scoped action by its ID for the specified episode.
-    /// </summary>
-    /// <param name="episodeID">The episode ID.</param>
-    /// <param name="id">The action ID.</param>
-    /// <param name="scope">
-    ///   Optional scope override. When omitted, the server picks the highest
-    ///   priority scope available to the user (Episode for admins, EpisodeUser
-    ///   for standard users).
-    /// </param>
-    [HttpPost("Episode/{episodeID}/Action/{id}/Execute")]
-    public async Task<ActionResult> ExecuteEpisodeAction([FromRoute] int episodeID, [FromRoute] Guid id, [FromQuery] ActionScope? scope = null)
-    {
-        var actionInfo = _actionServiceInterface.GetActionById(id);
-        if (actionInfo is null)
-            return NotFound();
-
-        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes);
-        if (!actionInfo.Scopes.Contains(resolvedScope))
-            return BadRequest($"The action does not support the '{resolvedScope}' scope.");
-
-        if (resolvedScope is ActionScope.Episode && User.IsAdmin != 1)
-            return Forbid("Admin privileges are required for this action scope.");
-
-        var episode = _animeEpisodes.GetByID(episodeID);
-        if (episode is null)
-            return NotFound("Episode not found.");
-
-        switch (resolvedScope)
-        {
-            case ActionScope.Episode:
-                await _actionServiceInterface.ScheduleExecuteOfEpisodeAction(actionInfo, episode);
-                break;
-            case ActionScope.EpisodeUser:
-                await _actionServiceInterface.ScheduleExecuteOfEpisodeUserAction(actionInfo, episode, (IUser)User);
-                break;
-            default:
-                return BadRequest($"Unexpected scope '{resolvedScope}' on this endpoint.");
-        }
-
-        return Ok();
-    }
-
     /// <summary>
     ///   Resolves the default scope from a set of available scopes based on
     ///   user role priority.
     /// </summary>
-    private ActionScope ResolveDefaultScope(IReadOnlySet<ActionScope> available)
+    private ActionScope ResolveDefaultScope(IReadOnlySet<ActionScope> available, ActionScope scope)
     {
-        var priority = User.IsAdmin == 1 ? _adminScopePriority : _userScopePriority;
-        foreach (var s in priority)
-            if (available.Contains(s))
-                return s;
-        return available.First();
+        if (User.IsAdmin == 1 && available.Contains(ActionScope.System | scope))
+            return ActionScope.System | scope;
+
+        if (available.Contains(ActionScope.User | scope))
+            return ActionScope.User | scope;
+
+        return 0;
     }
 
     #endregion
@@ -430,7 +346,7 @@ public class ActionController : BaseController
     /// Run Import. This checks for new files, hashes them etc, scans Drop Folders, checks and scans for community site links (tmdb, etc), and downloads missing images.
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("RunImport")]
     public async Task<ActionResult> RunImport()
     {
@@ -442,7 +358,7 @@ public class ActionController : BaseController
     /// Queues a task to import only new files found in the managed folders
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("ImportNewFiles")]
     public async Task<ActionResult> ImportNewFiles()
     {
@@ -454,7 +370,7 @@ public class ActionController : BaseController
     /// This was for web cache hash syncing, and will be for perceptual hashing maybe eventually.
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("SyncHashes")]
     public ActionResult SyncHashes()
     {
@@ -465,7 +381,7 @@ public class ActionController : BaseController
     /// Sync the votes from Shoko to AniDB.
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("SyncVotes")]
     public async Task<ActionResult> SyncVotes([FromQuery] bool export = false, [FromQuery] bool import = false)
     {
@@ -482,7 +398,7 @@ public class ActionController : BaseController
     /// Remove Entries in the Shoko Database for Files that are no longer accessible
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("RemoveMissingFiles/{removeFromMyList:bool?}")]
     public async Task<ActionResult> RemoveMissingFiles(bool removeFromMyList = true)
     {
@@ -494,7 +410,7 @@ public class ActionController : BaseController
     /// Updates and Downloads Missing Images
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateAllImages")]
     public ActionResult UpdateAllImages()
     {
@@ -511,7 +427,7 @@ public class ActionController : BaseController
     /// <param name="xrefSource">Optional. Filter to a specific cross-reference source.</param>
     /// <param name="force">Optional. Re-download even if images already exist locally.</param>
     /// <returns></returns>
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("DownloadAllImages")]
     public ActionResult DownloadAllImages(
         [FromQuery] DataSource? imageSource = null,
@@ -528,7 +444,7 @@ public class ActionController : BaseController
     /// Scan for TMDB matches for all unlinked AniDB anime.
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("SearchForTmdbMatches")]
     public ActionResult SearchForTmdbMatches()
     {
@@ -540,7 +456,7 @@ public class ActionController : BaseController
     /// Updates all TMDB Movies in the local database.
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateAllTmdbMovies")]
     public ActionResult UpdateAllTmdbMovies()
     {
@@ -553,7 +469,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllUnusedTmdbMovies")]
     public ActionResult PurgeAllUnusedTmdbMovies()
     {
@@ -566,7 +482,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllTmdbMovieCollections")]
     public ActionResult PurgeAllTmdbMovieCollections()
     {
@@ -578,7 +494,7 @@ public class ActionController : BaseController
     /// Update all TMDB Shows in the local database.
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateAllTmdbShows")]
     public ActionResult UpdateAllTmdbShows()
     {
@@ -589,7 +505,7 @@ public class ActionController : BaseController
     /// <summary>
     /// Download any missing TMDB People.
     /// </summary>
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("DownloadMissingTmdbPeople")]
     public ActionResult DownloadMissingTmdbPeople()
     {
@@ -602,7 +518,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllUnusedTmdbImages")]
     public ActionResult PurgeAllUnusedTmdbImages()
     {
@@ -615,7 +531,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllUnusedTmdbShows")]
     public ActionResult PurgeAllUnusedTmdbShows()
     {
@@ -628,7 +544,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllTmdbShowAlternateOrderings")]
     public ActionResult PurgeAllTmdbShowAlternateOrderings()
     {
@@ -644,7 +560,7 @@ public class ActionController : BaseController
     /// <param name="resetAutoLinkingState">Whether to reset the auto-linking state.</param>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllTmdbLinks")]
     public ActionResult PurgeAllTmdbLinks([FromQuery] bool removeShowLinks = true, [FromQuery] bool removeMovieLinks = true, [FromQuery] bool? resetAutoLinkingState = null)
     {
@@ -669,7 +585,7 @@ public class ActionController : BaseController
     /// </param>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllUsedReleases")]
     public ActionResult PurgeAllUsedReleases(
         [FromQuery] bool skipEvents = false,
@@ -691,7 +607,7 @@ public class ActionController : BaseController
     /// </param>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllUnusedReleases")]
     public ActionResult PurgeAllUnusedReleases(
         [FromQuery] bool skipEvents = false,
@@ -706,7 +622,7 @@ public class ActionController : BaseController
     /// Validates invalid images and re-downloads them
     /// </summary>
     /// <returns></returns>
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("ValidateAllImages")]
     public async Task<ActionResult> ValidateAllImages()
     {
@@ -723,7 +639,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("AVDumpMismatchedFiles")]
     public async Task<ActionResult> AVDumpMismatchedFiles()
     {
@@ -739,7 +655,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("DownloadMissingAniDBAnimeData")]
     public ActionResult UpdateMissingAnidbXml()
     {
@@ -756,7 +672,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("DownloadMissingAniDBCreators")]
     public ActionResult ScheduleMissingAniDBCreators()
     {
@@ -771,7 +687,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("SyncMyList")]
     public async Task<ActionResult> SyncMyList()
     {
@@ -784,7 +700,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateAllAniDBInfo")]
     public async Task<ActionResult> UpdateAllAniDBInfo()
     {
@@ -797,7 +713,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateAllMediaInfo")]
     public async Task<ActionResult> UpdateAllMediaInfo()
     {
@@ -810,7 +726,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateSeriesStats")]
     public async Task<ActionResult> UpdateSeriesStats()
     {
@@ -824,7 +740,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateMissingAniDBFileInfo")]
     public async Task<ActionResult> UpdateMissingAniDBFileInfo()
     {
@@ -837,7 +753,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateAniDBCalendar")]
     public async Task<ActionResult> UpdateAniDBCalendarData()
     {
@@ -853,7 +769,7 @@ public class ActionController : BaseController
     /// </remarks>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("RecreateAllGroups")]
     public ActionResult RecreateAllGroups()
     {
@@ -870,7 +786,7 @@ public class ActionController : BaseController
     /// This action requires an admin account because it affects all groups.
     /// </remarks>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("RenameAllGroups")]
     public ActionResult RenameAllGroups()
     {
@@ -885,7 +801,7 @@ public class ActionController : BaseController
     /// This action requires an admin account because it affects the collection.
     /// </remarks>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("CreateMissingSeries")]
     public async Task<ActionResult> CreateMissingSeries()
     {
@@ -898,7 +814,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PlexSyncAll")]
     public async Task<ActionResult> PlexSyncAll()
     {
@@ -911,7 +827,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("AddAllManualLinksToMyList")]
     public async Task<ActionResult> AddAllManualLinksToMyList()
     {
@@ -924,7 +840,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("GetAniDBNotifications")]
     public async Task<ActionResult> GetAniDBNotifications()
     {
@@ -937,7 +853,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("RefreshAniDBMovedFiles")]
     public async Task<ActionResult> RefreshAniDBMovedFiles()
     {
@@ -950,7 +866,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
-    [Obsolete("Use the new action system instead.")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("VerifyAllRelations")]
     public async Task<ActionResult> VerifyAllRelations()
     {

--- a/Shoko.Server/API/v3/Controllers/ActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/ActionController.cs
@@ -317,7 +317,7 @@ public class ActionController : BaseController
     }
 
     private IReadOnlyList<ActionCategoryGroup> GetActionCategories(ActionScope scope, bool isAdmin)
-        => _actionServiceInterface.GetActions(scopes: [ActionScope.System | scope, ActionScope.User | scope])
+        => _actionServiceInterface.GetActions(scopes: [scope])
             .Select(info =>
             {
                 var permittedScopes = isAdmin

--- a/Shoko.Server/API/v3/Controllers/ActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/ActionController.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Shoko.Abstractions.Action.Enums;
 using Shoko.Abstractions.Action.Services;
 using Shoko.Abstractions.Metadata.Enums;
@@ -35,7 +34,6 @@ namespace Shoko.Server.API.v3.Controllers;
 [Authorize]
 public class ActionController : BaseController
 {
-    private readonly ILogger<ActionController> _logger;
     private readonly AnimeGroupCreator _groupCreator;
     private readonly ActionService _actionService;
     private readonly IActionService _actionServiceInterface;
@@ -57,7 +55,6 @@ public class ActionController : BaseController
     private static readonly ActionScope[] _userScopePriority = [ActionScope.GlobalUser, ActionScope.SeriesUser, ActionScope.GroupUser, ActionScope.EpisodeUser];
 
     public ActionController(
-        ILogger<ActionController> logger,
         TmdbMetadataService tmdbMetadataService,
         TmdbLinkingService tmdbLinkingService,
         IQueueScheduler scheduler,
@@ -73,7 +70,6 @@ public class ActionController : BaseController
         AnimeEpisodeRepository animeEpisodes
     ) : base(settingsProvider)
     {
-        _logger = logger;
         _tmdbMetadataService = tmdbMetadataService;
         _tmdbLinkingService = tmdbLinkingService;
         _videoService = videoService;

--- a/Shoko.Server/API/v3/Controllers/ActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/ActionController.cs
@@ -1,22 +1,28 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Action.Services;
 using Shoko.Abstractions.Metadata.Enums;
+using Shoko.Abstractions.Web.Attributes;
 using Shoko.Abstractions.Metadata.Services;
+using Shoko.Abstractions.User;
 using Shoko.Abstractions.Video.Services;
 using Shoko.QueueProcessor.Abstractions;
 using Shoko.QueueProcessor.Scheduling;
 using Shoko.Server.API.Annotations;
 using Shoko.Server.API.ModelBinders;
+using Shoko.Server.API.v3.Models.Action;
+using Shoko.Server.API.v3.Models.Plugin;
 using Shoko.Server.API.v3.Models.Shoko;
 using Shoko.Server.Providers.TMDB;
 using Shoko.Server.Repositories.Cached;
 using Shoko.Server.Scheduling.Jobs.Actions;
 using Shoko.Server.Scheduling.Jobs.AniDB;
-using Shoko.Server.Scheduling.Jobs.Plex;
 using Shoko.Server.Services;
 using Shoko.Server.Settings;
 using Shoko.Server.Tasks;
@@ -32,6 +38,7 @@ public class ActionController : BaseController
     private readonly ILogger<ActionController> _logger;
     private readonly AnimeGroupCreator _groupCreator;
     private readonly ActionService _actionService;
+    private readonly IActionService _actionServiceInterface;
     private readonly IShokoGroupManager _groupService;
     private readonly TmdbMetadataService _tmdbMetadataService;
     private readonly TmdbLinkingService _tmdbLinkingService;
@@ -39,8 +46,15 @@ public class ActionController : BaseController
     private readonly IVideoReleaseService _videoReleaseService;
     private readonly IQueueScheduler _scheduler;
     private readonly IImageManager _imageManager;
-    private readonly VideoLocalRepository _videoLocals;
-    private readonly JMMUserRepository _jmmUsers;
+    private readonly AnimeSeriesRepository _animeSeries;
+    private readonly AnimeGroupRepository _animeGroups;
+    private readonly AnimeEpisodeRepository _animeEpisodes;
+
+    /// <summary>Priority-ordered scopes for admins when no scope is specified.</summary>
+    private static readonly ActionScope[] _adminScopePriority = [ActionScope.Global, ActionScope.GlobalUser, ActionScope.Series, ActionScope.SeriesUser, ActionScope.Group, ActionScope.GroupUser, ActionScope.Episode, ActionScope.EpisodeUser];
+
+    /// <summary>Priority-ordered scopes for standard users when no scope is specified.</summary>
+    private static readonly ActionScope[] _userScopePriority = [ActionScope.GlobalUser, ActionScope.SeriesUser, ActionScope.GroupUser, ActionScope.EpisodeUser];
 
     public ActionController(
         ILogger<ActionController> logger,
@@ -54,8 +68,9 @@ public class ActionController : BaseController
         AnimeGroupCreator groupCreator,
         IShokoGroupManager groupService,
         IImageManager imageManager,
-        VideoLocalRepository videoLocals,
-        JMMUserRepository jmmUsers
+        AnimeSeriesRepository animeSeries,
+        AnimeGroupRepository animeGroups,
+        AnimeEpisodeRepository animeEpisodes
     ) : base(settingsProvider)
     {
         _logger = logger;
@@ -65,12 +80,353 @@ public class ActionController : BaseController
         _videoReleaseService = videoReleaseService;
         _scheduler = scheduler;
         _actionService = actionService;
+        _actionServiceInterface = actionService;
         _groupCreator = groupCreator;
         _groupService = groupService;
         _imageManager = imageManager;
-        _videoLocals = videoLocals;
-        _jmmUsers = jmmUsers;
+        _animeSeries = animeSeries;
+        _animeGroups = animeGroups;
+        _animeEpisodes = animeEpisodes;
     }
+
+    #region New Action System
+
+    /// <summary>
+    ///   List all registered global/user-scoped actions, grouped by category,
+    ///   filtered to scopes the current user can execute.
+    /// </summary>
+    [HttpGet]
+    [InitFriendly]
+    public ActionResult<IReadOnlyList<ActionCategoryGroup>> GetActions()
+    {
+        var actions = _actionServiceInterface.GetActions(scopes: [ActionScope.Global, ActionScope.GlobalUser]);
+        var isAdmin = User.IsAdmin == 1;
+        var result = actions
+            .Select(info =>
+            {
+                var permittedScopes = isAdmin
+                    ? info.Scopes.Where(s => s is ActionScope.Global or ActionScope.GlobalUser).ToHashSet()
+                    : info.Scopes.Where(s => s is ActionScope.GlobalUser).ToHashSet();
+                return (Info: info, PermittedScopes: permittedScopes);
+            })
+            .Where(t => t.PermittedScopes.Count > 0)
+            .GroupBy(t => t.Info.CategoryName)
+            .Select(g => new ActionCategoryGroup
+            {
+                Name = g.Key,
+                Actions = g.Select(t => new ActionInfo
+                {
+                    ID = t.Info.ID,
+                    Name = t.Info.Name,
+                    Description = t.Info.Description,
+                    RequiresConfirmation = t.Info.RequiresConfirmation,
+                    Scopes = t.PermittedScopes,
+                    Plugin = new PluginInfo(t.Info.PluginInfo),
+                }).ToList(),
+            })
+            .ToList();
+
+        return Ok(result);
+    }
+
+    /// <summary>
+    ///   Execute a global or user-scoped action by its ID.
+    /// </summary>
+    /// <param name="id">The action ID.</param>
+    /// <param name="scope">
+    ///   Optional scope override. When omitted, the server picks the highest
+    ///   priority scope available to the user (Global for admins, User for
+    ///   standard users).
+    /// </param>
+    [HttpPost("{id}/Execute")]
+    public async Task<ActionResult> ExecuteGlobalAction(Guid id, [FromQuery] ActionScope? scope = null)
+    {
+        var actionInfo = _actionServiceInterface.GetActionById(id);
+        if (actionInfo is null)
+            return NotFound();
+
+        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes);
+        if (!actionInfo.Scopes.Contains(resolvedScope))
+            return BadRequest($"The action does not support the '{resolvedScope}' scope.");
+
+        if (resolvedScope is ActionScope.Global or ActionScope.Series && User.IsAdmin != 1)
+            return Forbid("Admin privileges are required for this action scope.");
+
+        switch (resolvedScope)
+        {
+            case ActionScope.Global:
+                await _actionServiceInterface.ScheduleExecuteOfGlobalAction(actionInfo);
+                break;
+            case ActionScope.GlobalUser:
+                await _actionServiceInterface.ScheduleExecuteOfGlobalUserAction(actionInfo, (IUser)User);
+                break;
+            default:
+                return BadRequest($"Unexpected scope '{resolvedScope}' on this endpoint.");
+        }
+
+        return Ok();
+    }
+
+    /// <summary>
+    ///   List all registered group-scoped actions, grouped by category,
+    ///   filtered to scopes the current user can execute.
+    /// </summary>
+    [HttpGet("Group/{groupID}/Action")]
+    [InitFriendly]
+    public ActionResult<IReadOnlyList<ActionCategoryGroup>> GetGroupActions([FromRoute] int groupID)
+    {
+        var actions = _actionServiceInterface.GetActions(scopes: [ActionScope.Group, ActionScope.GroupUser]);
+        var isAdmin = User.IsAdmin == 1;
+
+        var result = actions
+            .Select(info =>
+            {
+                var permittedScopes = isAdmin
+                    ? info.Scopes
+                    : info.Scopes.Where(s => s is ActionScope.GroupUser).ToHashSet();
+                return (Info: info, PermittedScopes: permittedScopes);
+            })
+            .Where(t => t.PermittedScopes.Count > 0)
+            .GroupBy(t => t.Info.CategoryName)
+            .Select(g => new ActionCategoryGroup
+            {
+                Name = g.Key,
+                Actions = g.Select(t => new ActionInfo
+                {
+                    ID = t.Info.ID,
+                    Name = t.Info.Name,
+                    Description = t.Info.Description,
+                    RequiresConfirmation = t.Info.RequiresConfirmation,
+                    Scopes = t.PermittedScopes,
+                    Plugin = new PluginInfo(t.Info.PluginInfo),
+                }).ToList(),
+            })
+            .ToList();
+
+        return Ok(result);
+    }
+
+    /// <summary>
+    ///   Execute a group-scoped action by its ID for the specified group.
+    /// </summary>
+    /// <param name="groupID">The group ID.</param>
+    /// <param name="id">The action ID.</param>
+    /// <param name="scope">
+    ///   Optional scope override. When omitted, the server picks the highest
+    ///   priority scope available to the user (Group for admins, GroupUser
+    ///   for standard users).
+    /// </param>
+    [HttpPost("Group/{groupID}/Action/{id}/Execute")]
+    public async Task<ActionResult> ExecuteGroupAction([FromRoute] int groupID, [FromRoute] Guid id, [FromQuery] ActionScope? scope = null)
+    {
+        var actionInfo = _actionServiceInterface.GetActionById(id);
+        if (actionInfo is null)
+            return NotFound();
+
+        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes);
+        if (!actionInfo.Scopes.Contains(resolvedScope))
+            return BadRequest($"The action does not support the '{resolvedScope}' scope.");
+
+        if (resolvedScope is ActionScope.Group && User.IsAdmin != 1)
+            return Forbid("Admin privileges are required for this action scope.");
+
+        var group = _animeGroups.GetByID(groupID);
+        if (group is null)
+            return NotFound("Group not found.");
+
+        switch (resolvedScope)
+        {
+            case ActionScope.Group:
+                await _actionServiceInterface.ScheduleExecuteOfGroupAction(actionInfo, group);
+                break;
+            case ActionScope.GroupUser:
+                await _actionServiceInterface.ScheduleExecuteOfGroupUserAction(actionInfo, group, (IUser)User);
+                break;
+            default:
+                return BadRequest($"Unexpected scope '{resolvedScope}' on this endpoint.");
+        }
+
+        return Ok();
+    }
+
+    /// <summary>
+    ///   List all registered series-scoped actions, grouped by category,
+    ///   filtered to scopes the current user can execute.
+    /// </summary>
+    [HttpGet("Series/{seriesID}/Action")]
+    [InitFriendly]
+    public ActionResult<IReadOnlyList<ActionCategoryGroup>> GetSeriesActions([FromRoute] int seriesID)
+    {
+        var actions = _actionServiceInterface.GetActions(scopes: [ActionScope.Series, ActionScope.SeriesUser]);
+        var isAdmin = User.IsAdmin == 1;
+
+        var result = actions
+            .Select(info =>
+            {
+                var permittedScopes = isAdmin
+                    ? info.Scopes.Where(s => s is ActionScope.Series or ActionScope.SeriesUser).ToHashSet()
+                    : info.Scopes.Where(s => s is ActionScope.SeriesUser).ToHashSet();
+                return (Info: info, PermittedScopes: permittedScopes);
+            })
+            .Where(t => t.PermittedScopes.Count > 0)
+            .GroupBy(t => t.Info.CategoryName)
+            .Select(g => new ActionCategoryGroup
+            {
+                Name = g.Key,
+                Actions = g.Select(t => new ActionInfo
+                {
+                    ID = t.Info.ID,
+                    Name = t.Info.Name,
+                    Description = t.Info.Description,
+                    RequiresConfirmation = t.Info.RequiresConfirmation,
+                    Scopes = t.PermittedScopes,
+                    Plugin = new PluginInfo(t.Info.PluginInfo),
+                }).ToList(),
+            })
+            .ToList();
+
+        return Ok(result);
+    }
+
+    /// <summary>
+    ///   Execute a series-scoped action by its ID for the specified series.
+    /// </summary>
+    /// <param name="seriesID">The AniDB anime ID of the series.</param>
+    /// <param name="id">The action ID.</param>
+    /// <param name="scope">
+    ///   Optional scope override. When omitted, the server picks the highest
+    ///   priority scope available to the user (Series for admins, SeriesUser
+    ///   for standard users).
+    /// </param>
+    [HttpPost("Series/{seriesID}/Action/{id}/Execute")]
+    public async Task<ActionResult> ExecuteSeriesAction([FromRoute] int seriesID, [FromRoute] Guid id, [FromQuery] ActionScope? scope = null)
+    {
+        var actionInfo = _actionServiceInterface.GetActionById(id);
+        if (actionInfo is null)
+            return NotFound();
+
+        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes);
+        if (!actionInfo.Scopes.Contains(resolvedScope))
+            return BadRequest($"The action does not support the '{resolvedScope}' scope.");
+
+        if (resolvedScope is ActionScope.Series && User.IsAdmin != 1)
+            return Forbid("Admin privileges are required for this action scope.");
+
+        var series = _animeSeries.GetByAnimeID(seriesID);
+        if (series is null)
+            return NotFound("Series not found.");
+
+        switch (resolvedScope)
+        {
+            case ActionScope.Series:
+                await _actionServiceInterface.ScheduleExecuteOfSeriesAction(actionInfo, series);
+                break;
+            case ActionScope.SeriesUser:
+                await _actionServiceInterface.ScheduleExecuteOfSeriesUserAction(actionInfo, series, (IUser)User);
+                break;
+            default:
+                return BadRequest($"Unexpected scope '{resolvedScope}' on this endpoint.");
+        }
+
+        return Ok();
+    }
+
+    /// <summary>
+    ///   List all registered episode-scoped actions, grouped by category,
+    ///   filtered to scopes the current user can execute.
+    /// </summary>
+    [HttpGet("Episode/{episodeID}/Action")]
+    [InitFriendly]
+    public ActionResult<IReadOnlyList<ActionCategoryGroup>> GetEpisodeActions([FromRoute] int episodeID)
+    {
+        var actions = _actionServiceInterface.GetActions(scopes: [ActionScope.Episode, ActionScope.EpisodeUser]);
+        var isAdmin = User.IsAdmin == 1;
+
+        var result = actions
+            .Select(info =>
+            {
+                var permittedScopes = isAdmin
+                    ? info.Scopes
+                    : info.Scopes.Where(s => s is ActionScope.EpisodeUser).ToHashSet();
+                return (Info: info, PermittedScopes: permittedScopes);
+            })
+            .Where(t => t.PermittedScopes.Count > 0)
+            .GroupBy(t => t.Info.CategoryName)
+            .Select(g => new ActionCategoryGroup
+            {
+                Name = g.Key,
+                Actions = g.Select(t => new ActionInfo
+                {
+                    ID = t.Info.ID,
+                    Name = t.Info.Name,
+                    Description = t.Info.Description,
+                    RequiresConfirmation = t.Info.RequiresConfirmation,
+                    Scopes = t.PermittedScopes,
+                    Plugin = new PluginInfo(t.Info.PluginInfo),
+                }).ToList(),
+            })
+            .ToList();
+
+        return Ok(result);
+    }
+
+    /// <summary>
+    ///   Execute an episode-scoped action by its ID for the specified episode.
+    /// </summary>
+    /// <param name="episodeID">The episode ID.</param>
+    /// <param name="id">The action ID.</param>
+    /// <param name="scope">
+    ///   Optional scope override. When omitted, the server picks the highest
+    ///   priority scope available to the user (Episode for admins, EpisodeUser
+    ///   for standard users).
+    /// </param>
+    [HttpPost("Episode/{episodeID}/Action/{id}/Execute")]
+    public async Task<ActionResult> ExecuteEpisodeAction([FromRoute] int episodeID, [FromRoute] Guid id, [FromQuery] ActionScope? scope = null)
+    {
+        var actionInfo = _actionServiceInterface.GetActionById(id);
+        if (actionInfo is null)
+            return NotFound();
+
+        var resolvedScope = scope ?? ResolveDefaultScope(actionInfo.Scopes);
+        if (!actionInfo.Scopes.Contains(resolvedScope))
+            return BadRequest($"The action does not support the '{resolvedScope}' scope.");
+
+        if (resolvedScope is ActionScope.Episode && User.IsAdmin != 1)
+            return Forbid("Admin privileges are required for this action scope.");
+
+        var episode = _animeEpisodes.GetByID(episodeID);
+        if (episode is null)
+            return NotFound("Episode not found.");
+
+        switch (resolvedScope)
+        {
+            case ActionScope.Episode:
+                await _actionServiceInterface.ScheduleExecuteOfEpisodeAction(actionInfo, episode);
+                break;
+            case ActionScope.EpisodeUser:
+                await _actionServiceInterface.ScheduleExecuteOfEpisodeUserAction(actionInfo, episode, (IUser)User);
+                break;
+            default:
+                return BadRequest($"Unexpected scope '{resolvedScope}' on this endpoint.");
+        }
+
+        return Ok();
+    }
+
+    /// <summary>
+    ///   Resolves the default scope from a set of available scopes based on
+    ///   user role priority.
+    /// </summary>
+    private ActionScope ResolveDefaultScope(IReadOnlySet<ActionScope> available)
+    {
+        var priority = User.IsAdmin == 1 ? _adminScopePriority : _userScopePriority;
+        foreach (var s in priority)
+            if (available.Contains(s))
+                return s;
+        return available.First();
+    }
+
+    #endregion
 
     #region Common Actions
 
@@ -78,6 +434,7 @@ public class ActionController : BaseController
     /// Run Import. This checks for new files, hashes them etc, scans Drop Folders, checks and scans for community site links (tmdb, etc), and downloads missing images.
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("RunImport")]
     public async Task<ActionResult> RunImport()
     {
@@ -89,6 +446,7 @@ public class ActionController : BaseController
     /// Queues a task to import only new files found in the managed folders
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("ImportNewFiles")]
     public async Task<ActionResult> ImportNewFiles()
     {
@@ -100,6 +458,7 @@ public class ActionController : BaseController
     /// This was for web cache hash syncing, and will be for perceptual hashing maybe eventually.
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("SyncHashes")]
     public ActionResult SyncHashes()
     {
@@ -110,6 +469,7 @@ public class ActionController : BaseController
     /// Sync the votes from Shoko to AniDB.
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("SyncVotes")]
     public async Task<ActionResult> SyncVotes([FromQuery] bool export = false, [FromQuery] bool import = false)
     {
@@ -126,6 +486,7 @@ public class ActionController : BaseController
     /// Remove Entries in the Shoko Database for Files that are no longer accessible
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("RemoveMissingFiles/{removeFromMyList:bool?}")]
     public async Task<ActionResult> RemoveMissingFiles(bool removeFromMyList = true)
     {
@@ -137,6 +498,7 @@ public class ActionController : BaseController
     /// Updates and Downloads Missing Images
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("UpdateAllImages")]
     public ActionResult UpdateAllImages()
     {
@@ -153,6 +515,7 @@ public class ActionController : BaseController
     /// <param name="xrefSource">Optional. Filter to a specific cross-reference source.</param>
     /// <param name="force">Optional. Re-download even if images already exist locally.</param>
     /// <returns></returns>
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("DownloadAllImages")]
     public ActionResult DownloadAllImages(
         [FromQuery] DataSource? imageSource = null,
@@ -169,6 +532,7 @@ public class ActionController : BaseController
     /// Scan for TMDB matches for all unlinked AniDB anime.
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("SearchForTmdbMatches")]
     public ActionResult SearchForTmdbMatches()
     {
@@ -180,6 +544,7 @@ public class ActionController : BaseController
     /// Updates all TMDB Movies in the local database.
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("UpdateAllTmdbMovies")]
     public ActionResult UpdateAllTmdbMovies()
     {
@@ -192,6 +557,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("PurgeAllUnusedTmdbMovies")]
     public ActionResult PurgeAllUnusedTmdbMovies()
     {
@@ -204,6 +570,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("PurgeAllTmdbMovieCollections")]
     public ActionResult PurgeAllTmdbMovieCollections()
     {
@@ -215,6 +582,7 @@ public class ActionController : BaseController
     /// Update all TMDB Shows in the local database.
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("UpdateAllTmdbShows")]
     public ActionResult UpdateAllTmdbShows()
     {
@@ -225,6 +593,7 @@ public class ActionController : BaseController
     /// <summary>
     /// Download any missing TMDB People.
     /// </summary>
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("DownloadMissingTmdbPeople")]
     public ActionResult DownloadMissingTmdbPeople()
     {
@@ -237,6 +606,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("PurgeAllUnusedTmdbImages")]
     public ActionResult PurgeAllUnusedTmdbImages()
     {
@@ -249,6 +619,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("PurgeAllUnusedTmdbShows")]
     public ActionResult PurgeAllUnusedTmdbShows()
     {
@@ -261,6 +632,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("PurgeAllTmdbShowAlternateOrderings")]
     public ActionResult PurgeAllTmdbShowAlternateOrderings()
     {
@@ -276,6 +648,7 @@ public class ActionController : BaseController
     /// <param name="resetAutoLinkingState">Whether to reset the auto-linking state.</param>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("PurgeAllTmdbLinks")]
     public ActionResult PurgeAllTmdbLinks([FromQuery] bool removeShowLinks = true, [FromQuery] bool removeMovieLinks = true, [FromQuery] bool? resetAutoLinkingState = null)
     {
@@ -300,6 +673,7 @@ public class ActionController : BaseController
     /// </param>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("PurgeAllUsedReleases")]
     public ActionResult PurgeAllUsedReleases(
         [FromQuery] bool skipEvents = false,
@@ -321,6 +695,7 @@ public class ActionController : BaseController
     /// </param>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("PurgeAllUnusedReleases")]
     public ActionResult PurgeAllUnusedReleases(
         [FromQuery] bool skipEvents = false,
@@ -335,6 +710,7 @@ public class ActionController : BaseController
     /// Validates invalid images and re-downloads them
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("ValidateAllImages")]
     public async Task<ActionResult> ValidateAllImages()
     {
@@ -351,25 +727,11 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("AVDumpMismatchedFiles")]
     public async Task<ActionResult> AVDumpMismatchedFiles()
     {
-        var settings = SettingsProvider.GetSettings();
-        if (string.IsNullOrWhiteSpace(settings.AniDb.AVDumpKey))
-            return ValidationProblem("Missing AVDump API key.", "Settings");
-
-        var mismatchedFiles = _videoLocals.GetAll()
-            .Where(file => !file.IsEmpty() && file.MediaInfo != null)
-            .Select(file => (Video: file, AniDB: file.ReleaseInfo))
-            .Where(tuple => tuple.AniDB is { ProviderName: "AniDB", IsCorrupted: false } && tuple.Video.MediaInfo?.MenuStreams.Count != 0 != tuple.AniDB.IsChaptered)
-            .Select(tuple => (Path: tuple.Video.FirstResolvedPlace?.Path, tuple.Video))
-            .Where(tuple => !string.IsNullOrEmpty(tuple.Path))
-            .ToDictionary(tuple => tuple.Video.VideoLocalID, tuple => tuple.Path);
-        foreach (var (fileId, filePath) in mismatchedFiles)
-            await _scheduler.StartJob<AVDumpFilesJob>(a => a.Videos = new() { { fileId, filePath } });
-
-        _logger.LogInformation("Queued {QueuedAnimeCount} files for avdumping", mismatchedFiles.Count);
-
+        await _actionService.AVDumpMismatchedFiles();
         return Ok();
     }
 
@@ -381,6 +743,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("DownloadMissingAniDBAnimeData")]
     public ActionResult UpdateMissingAnidbXml()
     {
@@ -397,6 +760,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("DownloadMissingAniDBCreators")]
     public ActionResult ScheduleMissingAniDBCreators()
     {
@@ -411,6 +775,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("SyncMyList")]
     public async Task<ActionResult> SyncMyList()
     {
@@ -423,6 +788,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("UpdateAllAniDBInfo")]
     public async Task<ActionResult> UpdateAllAniDBInfo()
     {
@@ -435,6 +801,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("UpdateAllMediaInfo")]
     public async Task<ActionResult> UpdateAllMediaInfo()
     {
@@ -447,6 +814,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("UpdateSeriesStats")]
     public async Task<ActionResult> UpdateSeriesStats()
     {
@@ -460,6 +828,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("UpdateMissingAniDBFileInfo")]
     public async Task<ActionResult> UpdateMissingAniDBFileInfo()
     {
@@ -472,10 +841,11 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("UpdateAniDBCalendar")]
     public async Task<ActionResult> UpdateAniDBCalendarData()
     {
-        await _scheduler.StartJob<GetAniDBCalendarJob>(c => c.ForceRefresh = true);
+        await _actionService.UpdateAniDBCalendar();
         return Ok();
     }
 
@@ -487,6 +857,7 @@ public class ActionController : BaseController
     /// </remarks>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("RecreateAllGroups")]
     public ActionResult RecreateAllGroups()
     {
@@ -503,6 +874,7 @@ public class ActionController : BaseController
     /// This action requires an admin account because it affects all groups.
     /// </remarks>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("RenameAllGroups")]
     public ActionResult RenameAllGroups()
     {
@@ -517,6 +889,7 @@ public class ActionController : BaseController
     /// This action requires an admin account because it affects the collection.
     /// </remarks>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("CreateMissingSeries")]
     public async Task<ActionResult> CreateMissingSeries()
     {
@@ -529,14 +902,11 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("PlexSyncAll")]
     public async Task<ActionResult> PlexSyncAll()
     {
-        foreach (var user in _jmmUsers.GetAll())
-        {
-            if (string.IsNullOrEmpty(user.PlexToken)) continue;
-            await _scheduler.StartJob<SyncPlexWatchedStatesJob>(c => c.User = user);
-        }
+        await _actionService.PlexSyncAll();
         return Ok();
     }
 
@@ -545,16 +915,12 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("AddAllManualLinksToMyList")]
     public async Task<ActionResult> AddAllManualLinksToMyList()
     {
-        var files = _videoLocals.GetManuallyLinkedVideos();
-        foreach (var vl in files)
-        {
-            await _scheduler.StartJob<AddFileToMyListJob>(c => c.Hash = vl.Hash);
-        }
-
-        return Ok($"Saved {files.Count} AddToMyList Commands");
+        await _actionService.AddAllManualLinksToMyList();
+        return Ok();
     }
 
     /// <summary>
@@ -562,10 +928,11 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("GetAniDBNotifications")]
     public async Task<ActionResult> GetAniDBNotifications()
     {
-        await _scheduler.StartJob<CheckAniDBNotificationsJob>(c => c.ForceRefresh = true);
+        await _actionService.GetAniDBNotifications();
         return Ok();
     }
 
@@ -574,6 +941,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("RefreshAniDBMovedFiles")]
     public async Task<ActionResult> RefreshAniDBMovedFiles()
     {
@@ -586,6 +954,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete("Use the new action system instead.")]
     [HttpGet("VerifyAllRelations")]
     public async Task<ActionResult> VerifyAllRelations()
     {

--- a/Shoko.Server/API/v3/Models/Action/ActionCategoryGroup.cs
+++ b/Shoko.Server/API/v3/Models/Action/ActionCategoryGroup.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Shoko.Server.API.v3.Models.Action;
+
+/// <summary>
+///   A group of actions sharing the same category name.
+/// </summary>
+public sealed class ActionCategoryGroup
+{
+    /// <summary>
+    ///   The display name for the category.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    ///   The actions in this category.
+    /// </summary>
+    public required IReadOnlyList<ActionInfo> Actions { get; init; }
+}

--- a/Shoko.Server/API/v3/Models/Action/ActionInfo.cs
+++ b/Shoko.Server/API/v3/Models/Action/ActionInfo.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Server.API.v3.Models.Plugin;
+
+namespace Shoko.Server.API.v3.Models.Action;
+
+/// <summary>
+///   Describes a registered executable action for API consumers.
+/// </summary>
+public sealed class ActionInfo
+{
+    /// <summary>
+    ///   The stable identifier for this action.
+    /// </summary>
+    public required Guid ID { get; init; }
+
+    /// <summary>
+    ///   The human-readable name of the action.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    ///   A description of what the action does.
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    ///   Whether the action requires explicit user confirmation before execution.
+    /// </summary>
+    public required bool RequiresConfirmation { get; init; }
+
+    /// <summary>
+    ///   The scopes at which this action can operate, filtered to the ones the
+    ///   current user is permitted to execute.
+    /// </summary>
+    public required IReadOnlySet<ActionScope> Scopes { get; init; }
+
+    /// <summary>
+    ///   Information about the plugin that registered this action.
+    /// </summary>
+    public required PluginInfo Plugin { get; init; }
+}

--- a/Shoko.Server/Plugin/PluginManager.cs
+++ b/Shoko.Server/Plugin/PluginManager.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 using ImageMagick;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Services;
 using Shoko.Abstractions.Config;
 using Shoko.Abstractions.Config.Services;
 using Shoko.Abstractions.Core;
@@ -452,6 +454,9 @@ public partial class PluginManager(ILogger<PluginManager> logger, ISystemService
 
         var supplementaryMetadataService = ISystemService.StaticServices.GetRequiredService<SupplementaryMetadataService>();
         supplementaryMetadataService.AddParts(GetExports<ISupplementaryMetadataProvider>());
+
+        var actionService = ISystemService.StaticServices.GetRequiredService<IActionService>();
+        actionService.AddParts(GetExports<IExecutableAction>());
     }
 
     private IEnumerable<(string?, string[], bool)> GetPluginDirectories()

--- a/Shoko.Server/Plugin/TypeReflectionExtensions.cs
+++ b/Shoko.Server/Plugin/TypeReflectionExtensions.cs
@@ -13,8 +13,9 @@ public static partial class TypeReflectionExtensions
     /// Gets the display name for a type.
     /// </summary>
     /// <param name="type">The type.</param>
-    public static string GetDisplayName(this Type type)
-        => GetDisplayName(type.ToContextualType());
+    /// <param name="transform">The transform function.</param>
+    public static string GetDisplayName(this Type type, Func<string, string>? transform = null)
+        => GetDisplayName(type.ToContextualType(), transform);
 
     /// <summary>
     /// Gets the display name for a member.

--- a/Shoko.Server/Scheduling/Jobs/Actions/ExecuteActionJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Actions/ExecuteActionJob.cs
@@ -101,15 +101,13 @@ internal class ExecuteActionJob(
                 if (_userName is not null) details.Add("User", _userName);
                 else details.Add("User ID", UserID);
             if (GroupID.HasValue)
-                if (_entityName is not null && !AnimeID.HasValue) details.Add("Group", _entityName);
-                else if (_entityName is not null) details.Add("Group", _entityName);
+                if (_entityName is not null) details.Add("Group", _entityName);
                 else details.Add("Group ID", GroupID);
             else if (AnimeID.HasValue)
                 if (_entityName is not null) details.Add("Series", _entityName);
                 else details.Add("Anime ID", AnimeID);
             else if (EpisodeID.HasValue)
-                if (_entityName is not null && !AnimeID.HasValue && !GroupID.HasValue) details.Add("Episode", _entityName);
-                else if (_entityName is not null) details.Add("Episode", _entityName);
+                if (_entityName is not null) details.Add("Episode", _entityName);
                 else details.Add("Episode ID", EpisodeID);
             return details;
         }

--- a/Shoko.Server/Scheduling/Jobs/Actions/ExecuteActionJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Actions/ExecuteActionJob.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Action.Services;
+using Shoko.Abstractions.Metadata.Services;
+using Shoko.Abstractions.User.Services;
+using Shoko.QueueProcessor.Acquisition.Attributes;
+using Shoko.QueueProcessor.Concurrency;
+
+namespace Shoko.Server.Scheduling.Jobs.Actions;
+
+/// <summary>
+///   Job that executes a registered plugin action by its identifier,
+///   optionally scoped to a specific user and/or entity (series, group,
+///   episode).
+///   Enqueued by <see cref="IActionService.ScheduleExecuteOfGlobalAction"/>
+///   and its overloads.
+/// </summary>
+[DatabaseRequired]
+[DisallowConcurrentExecution]
+internal class ExecuteActionJob(
+    IActionService actionService,
+    IUserService userService,
+    IMetadataService metadataService
+) : BaseJob
+{
+    /// <summary>
+    ///   The stable identifier of the action to execute.
+    /// </summary>
+    public Guid ActionID { get; set; }
+
+    /// <summary>
+    ///   The user ID to scope the action to, if applicable.
+    /// </summary>
+    public int? UserID { get; set; }
+
+    /// <summary>
+    ///   The group ID to scope the action to, if applicable.
+    /// </summary>
+    public int? GroupID { get; set; }
+
+    /// <summary>
+    ///   The AniDB anime ID of the series to scope the action to, if applicable.
+    /// </summary>
+    public int? AnimeID { get; set; }
+
+    /// <summary>
+    ///   The episode ID to scope the action to, if applicable.
+    /// </summary>
+    public int? EpisodeID { get; set; }
+
+    private string? _actionName;
+
+    private string? _userName;
+
+    private string? _entityName;
+
+    public override string TypeName => "Execute Action";
+
+    public override string Title => "Executing Action";
+
+    public override void PostInit()
+    {
+        var actionInfo = actionService.GetActionById(ActionID);
+        _actionName = actionInfo?.Name;
+
+        if (UserID.HasValue)
+        {
+            var user = userService.GetUserByID(UserID.Value);
+            _userName = user?.Username;
+        }
+
+        if (GroupID.HasValue)
+        {
+            var group = metadataService.GetShokoGroupByID(GroupID.Value);
+            _entityName = group?.Title;
+        }
+        else if (AnimeID.HasValue)
+        {
+            var series = metadataService.GetShokoSeriesByAnidbID(AnimeID.Value);
+            _entityName = series?.Title;
+        }
+        else if (EpisodeID.HasValue)
+        {
+            var episode = metadataService.GetShokoEpisodeByID(EpisodeID.Value);
+            _entityName = episode?.Title;
+        }
+    }
+
+    public override Dictionary<string, object> Details
+    {
+        get
+        {
+            var details = new Dictionary<string, object>();
+            if (_actionName is not null) details.Add("Action", _actionName);
+            else details.Add("Action ID", ActionID);
+            details.Add("Scope", ScopeToName());
+            if (UserID.HasValue)
+                if (_userName is not null) details.Add("User", _userName);
+                else details.Add("User ID", UserID);
+            if (GroupID.HasValue)
+                if (_entityName is not null && !AnimeID.HasValue) details.Add("Group", _entityName);
+                else if (_entityName is not null) details.Add("Group", _entityName);
+                else details.Add("Group ID", GroupID);
+            else if (AnimeID.HasValue)
+                if (_entityName is not null) details.Add("Series", _entityName);
+                else details.Add("Anime ID", AnimeID);
+            else if (EpisodeID.HasValue)
+                if (_entityName is not null && !AnimeID.HasValue && !GroupID.HasValue) details.Add("Episode", _entityName);
+                else if (_entityName is not null) details.Add("Episode", _entityName);
+                else details.Add("Episode ID", EpisodeID);
+            return details;
+        }
+    }
+
+    public override async Task Execute()
+    {
+        var action = actionService.GetActionById(ActionID);
+        if (action is null)
+        {
+            _logger.LogWarning("ExecuteActionJob: Action not found: {ActionID}", ActionID);
+            return;
+        }
+
+        _logger.LogInformation("Executing action \"{Action}\"", _actionName ?? ActionID.ToString());
+
+        var user = UserID.HasValue ? userService.GetUserByID(UserID.Value) : null;
+
+        if (AnimeID.HasValue)
+        {
+            var series = metadataService.GetShokoSeriesByAnidbID(AnimeID.Value);
+            if (series is not null && user is not null)
+                await actionService.ExecuteSeriesUserAction(action, series, user);
+            else if (series is not null)
+                await actionService.ExecuteSeriesAction(action, series);
+        }
+        else if (GroupID.HasValue)
+        {
+            var group = metadataService.GetShokoGroupByID(GroupID.Value);
+            if (group is not null && user is not null)
+                await actionService.ExecuteGroupUserAction(action, group, user);
+            else if (group is not null)
+                await actionService.ExecuteGroupAction(action, group);
+        }
+        else if (EpisodeID.HasValue)
+        {
+            var episode = metadataService.GetShokoEpisodeByID(EpisodeID.Value);
+            if (episode is not null && user is not null)
+                await actionService.ExecuteEpisodeUserAction(action, episode, user);
+            else if (episode is not null)
+                await actionService.ExecuteEpisodeAction(action, episode);
+        }
+        else if (user is not null)
+        {
+            await actionService.ExecuteGlobalUserAction(action, user);
+        }
+        else
+        {
+            await actionService.ExecuteGlobalAction(action);
+        }
+
+        _logger.LogInformation("Finished executing action \"{Action}\"", _actionName ?? ActionID.ToString());
+    }
+
+    private string ScopeToName() => (UserID.HasValue, GroupID.HasValue ? 1 : AnimeID.HasValue ? 2 : EpisodeID.HasValue ? 3 : 0) switch
+    {
+        (false, 0) => "User",
+        (true, 0) => "Global User",
+        (false, 1) => "Group",
+        (true, 1) => "Group User",
+        (false, 2) => "Series",
+        (true, 2) => "Series User",
+        (false, 3) => "Episode",
+        (true, 3) => "Episode User",
+        _ => "Unknown",
+    };
+}

--- a/Shoko.Server/Scheduling/Jobs/Actions/ExecuteActionJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Actions/ExecuteActionJob.cs
@@ -15,7 +15,7 @@ namespace Shoko.Server.Scheduling.Jobs.Actions;
 ///   Job that executes a registered plugin action by its identifier,
 ///   optionally scoped to a specific user and/or entity (series, group,
 ///   episode).
-///   Enqueued by <see cref="IActionService.ScheduleExecuteOfGlobalAction"/>
+///   Enqueued by <see cref="IActionService.ScheduleExecuteOfGlobalSystemAction"/>
 ///   and its overloads.
 /// </summary>
 [DatabaseRequired]
@@ -132,7 +132,7 @@ internal class ExecuteActionJob(
             if (series is not null && user is not null)
                 await actionService.ExecuteSeriesUserAction(action, series, user);
             else if (series is not null)
-                await actionService.ExecuteSeriesAction(action, series);
+                await actionService.ExecuteSeriesSystemAction(action, series);
         }
         else if (GroupID.HasValue)
         {
@@ -140,7 +140,7 @@ internal class ExecuteActionJob(
             if (group is not null && user is not null)
                 await actionService.ExecuteGroupUserAction(action, group, user);
             else if (group is not null)
-                await actionService.ExecuteGroupAction(action, group);
+                await actionService.ExecuteGroupSystemAction(action, group);
         }
         else if (EpisodeID.HasValue)
         {
@@ -148,7 +148,7 @@ internal class ExecuteActionJob(
             if (episode is not null && user is not null)
                 await actionService.ExecuteEpisodeUserAction(action, episode, user);
             else if (episode is not null)
-                await actionService.ExecuteEpisodeAction(action, episode);
+                await actionService.ExecuteEpisodeSystemAction(action, episode);
         }
         else if (user is not null)
         {
@@ -156,7 +156,7 @@ internal class ExecuteActionJob(
         }
         else
         {
-            await actionService.ExecuteGlobalAction(action);
+            await actionService.ExecuteGlobalSystemAction(action);
         }
 
         _logger.LogInformation("Finished executing action \"{Action}\"", _actionName ?? ActionID.ToString());

--- a/Shoko.Server/Services/ActionService.cs
+++ b/Shoko.Server/Services/ActionService.cs
@@ -209,7 +209,7 @@ public class ActionService : IActionService
         if (scopes is not null)
         {
             var scopeSet = scopes.ToHashSet();
-            query = query.Where(a => scopeSet.Overlaps(a.Scopes));
+            query = query.Where(a => a.Scopes.Any(actionScope => scopeSet.Any(filterScope => actionScope.HasFlag(filterScope))));
         }
 
         if (categories is not null)

--- a/Shoko.Server/Services/ActionService.cs
+++ b/Shoko.Server/Services/ActionService.cs
@@ -26,6 +26,7 @@ using Shoko.Server.Providers.AniDB;
 using Shoko.Server.Providers.AniDB.Interfaces;
 using Shoko.Server.Providers.AniDB.UDP.Info;
 using Shoko.Server.Providers.TMDB;
+using Shoko.Server.Plugin;
 using Shoko.Server.Repositories.Cached;
 using Shoko.Server.Repositories.Cached.AniDB;
 using Shoko.Server.Repositories.Direct;
@@ -188,7 +189,7 @@ public class ActionService : IActionService
             var info = new ExecutableActionInfo
             {
                 ID = UuidUtility.GetV5(actionType.FullName!, pluginInfo.ID),
-                Name = action.Name,
+                Name = action.Name ?? actionType.GetDisplayName(name => name.TrimEnd(" Action")),
                 Description = action.Description ?? string.Empty,
                 Category = action.Category,
                 CategoryName = categoryName,

--- a/Shoko.Server/Services/ActionService.cs
+++ b/Shoko.Server/Services/ActionService.cs
@@ -2,13 +2,21 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Action.Services;
 using Shoko.Abstractions.Extensions;
 using Shoko.Abstractions.Metadata.Anidb.Enums;
 using Shoko.Abstractions.Metadata.Anidb.Services;
 using Shoko.Abstractions.Metadata.Services;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Abstractions.Metadata.Tmdb.Services;
 using Shoko.Abstractions.Plugin;
+using Shoko.Abstractions.User;
+using Shoko.Abstractions.Utilities;
 using Shoko.Abstractions.Video.Services;
 using Shoko.QueueProcessor.Abstractions;
 using Shoko.QueueProcessor.Scheduling;
@@ -23,12 +31,18 @@ using Shoko.Server.Repositories.Cached.AniDB;
 using Shoko.Server.Repositories.Direct;
 using Shoko.Server.Scheduling.Jobs.Actions;
 using Shoko.Server.Scheduling.Jobs.AniDB;
+using Shoko.Server.Scheduling.Jobs.Plex;
 using Shoko.Server.Scheduling.Jobs.Shoko;
 using Shoko.Server.Settings;
 
 namespace Shoko.Server.Services;
 
-public class ActionService
+/// <summary>
+///   Service for executing Shoko actions (import, metadata refresh, etc.) and
+///   for registering, discovering, and executing plugin-provided actions.
+///   Implements <see cref="IActionService"/> for the plugin action system.
+/// </summary>
+public class ActionService : IActionService
 {
     private readonly ILogger<ActionService> _logger;
 
@@ -52,7 +66,7 @@ public class ActionService
 
     private readonly HttpXmlUtils _xmlUtils;
 
-    private readonly IPluginPackageManager _pluginPackageManager;
+    private readonly IPluginManager _pluginManager;
 
     private readonly VideoLocalRepository _videoLocals;
 
@@ -76,9 +90,18 @@ public class ActionService
 
     private readonly AnimeEpisodeRepository _animeEpisodes;
 
-    private readonly ScheduledUpdateRepository _scheduledUpdates;
-
     private readonly AniDB_Anime_RelationRepository _anidbAnimeRelations;
+
+    private readonly ITmdbLinkingService _tmdbLinkingService;
+
+    private readonly JMMUserRepository _jmmUsers;
+
+    /// <summary>
+    ///   Registered plugin action types and their metadata. Populated once
+    ///   during <see cref="AddParts"/>. A fresh instance is created from the
+    ///   type on each execution via <see cref="IPluginManager.GetExport{T}"/>.
+    /// </summary>
+    private readonly List<(Type ActionType, ExecutableActionInfo Info)> _registeredActions = [];
 
     public ActionService(
         ILogger<ActionService> logger,
@@ -92,7 +115,7 @@ public class ActionService
         TmdbMetadataService tmdbService,
         DatabaseFactory databaseFactory,
         HttpXmlUtils xmlUtils,
-        IPluginPackageManager pluginPackageManager,
+        IPluginManager pluginManager,
         VideoLocalRepository videoLocals,
         VideoLocal_PlaceRepository videoLocalPlaces,
         StoredReleaseInfoRepository storedReleaseInfos,
@@ -104,8 +127,9 @@ public class ActionService
         CrossRef_File_EpisodeRepository crossRefFileEpisodes,
         AnimeSeriesRepository animeSeries,
         AnimeEpisodeRepository animeEpisodes,
-        ScheduledUpdateRepository scheduledUpdates,
-        AniDB_Anime_RelationRepository anidbAnimeRelations
+        AniDB_Anime_RelationRepository anidbAnimeRelations,
+        ITmdbLinkingService tmdbLinkingService,
+        JMMUserRepository jmmUsers
     )
     {
         _logger = logger;
@@ -119,7 +143,7 @@ public class ActionService
         _tmdbService = tmdbService;
         _databaseFactory = databaseFactory;
         _xmlUtils = xmlUtils;
-        _pluginPackageManager = pluginPackageManager;
+        _pluginManager = pluginManager;
         _videoLocals = videoLocals;
         _videoLocalPlaces = videoLocalPlaces;
         _storedReleaseInfos = storedReleaseInfos;
@@ -131,9 +155,336 @@ public class ActionService
         _crossRefFileEpisodes = crossRefFileEpisodes;
         _animeSeries = animeSeries;
         _animeEpisodes = animeEpisodes;
-        _scheduledUpdates = scheduledUpdates;
         _anidbAnimeRelations = anidbAnimeRelations;
+        _tmdbLinkingService = tmdbLinkingService;
+        _jmmUsers = jmmUsers;
     }
+
+    #region IActionService
+
+    /// <inheritdoc />
+    public void AddParts(IEnumerable<IExecutableAction> actions)
+    {
+        if (_registeredActions.Count > 0)
+            return;
+
+        foreach (var action in actions)
+        {
+            var actionType = action.GetType();
+            var pluginInfo = _pluginManager.GetPluginInfo(actionType.Assembly);
+            if (pluginInfo is null)
+                continue;
+
+            var scopes = GetActionScopes(actionType);
+            if (scopes.Count == 0)
+                continue;
+
+            var categoryName = action.Category switch
+            {
+                ActionCategory.PluginInferred => pluginInfo.Name,
+                _ => action.Category.ToString(),
+            };
+
+            var info = new ExecutableActionInfo
+            {
+                ID = UuidUtility.GetV5(actionType.FullName!, pluginInfo.ID),
+                Name = action.Name,
+                Description = action.Description ?? string.Empty,
+                Category = action.Category,
+                CategoryName = categoryName,
+                Scopes = scopes,
+                RequiresConfirmation = action.RequiresConfirmation,
+                PluginInfo = pluginInfo,
+            };
+
+            _registeredActions.Add((actionType, info));
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<ExecutableActionInfo> GetActions(IEnumerable<ActionScope>? scopes = null, IEnumerable<ActionCategory>? categories = null, IEnumerable<string>? categoryNames = null)
+    {
+        var query = _registeredActions.Select(ra => ra.Info).AsEnumerable();
+
+        if (scopes is not null)
+        {
+            var scopeSet = scopes.ToHashSet();
+            query = query.Where(a => scopeSet.Overlaps(a.Scopes));
+        }
+
+        if (categories is not null)
+        {
+            var categorySet = categories.ToHashSet();
+            query = query.Where(a => categorySet.Contains(a.Category));
+        }
+
+        if (categoryNames is not null)
+        {
+            var categoryNameSet = categoryNames.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            query = query.Where(a => categoryNameSet.Contains(a.CategoryName));
+        }
+
+        return query
+            .OrderBy(a => a.Category)
+            .ThenBy(a => a.CategoryName)
+            .ThenBy(a => a.Name)
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    public ExecutableActionInfo? GetActionById(Guid actionId)
+        => _registeredActions.FirstOrDefault(ra => ra.Info.ID == actionId).Info;
+
+    /// <inheritdoc />
+    public async Task ExecuteGlobalAction(ExecutableActionInfo actionInfo, CancellationToken cancellationToken = default)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.Global))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support global execution.");
+
+        if (ResolveAction(actionInfo) is not IExecutableGlobalAction globalAction)
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableGlobalAction)}.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await globalAction.Execute(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task ScheduleExecuteOfGlobalAction(ExecutableActionInfo actionInfo, CancellationToken cancellationToken = default, bool prioritize = false)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.Global))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support global execution.");
+
+        return _scheduler.StartJob<ExecuteActionJob>(j => j.ActionID = actionInfo.ID, prioritize: prioritize);
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteGlobalUserAction(ExecutableActionInfo actionInfo, IUser user, CancellationToken cancellationToken = default)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.GlobalUser))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support global user execution.");
+
+        if (ResolveAction(actionInfo) is not IExecutableGlobalUserAction globalUserAction)
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableGlobalUserAction)}.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await globalUserAction.Execute(user, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task ScheduleExecuteOfGlobalUserAction(ExecutableActionInfo actionInfo, IUser user, CancellationToken cancellationToken = default, bool prioritize = false)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.GlobalUser))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support global user execution.");
+
+        return _scheduler.StartJob<ExecuteActionJob>(j =>
+        {
+            j.ActionID = actionInfo.ID;
+            j.UserID = user.ID;
+        }, prioritize: prioritize);
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteSeriesAction(ExecutableActionInfo actionInfo, IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.Series))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support series execution.");
+
+        if (ResolveAction(actionInfo) is not IExecutableSeriesAction seriesAction)
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableSeriesAction)}.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await seriesAction.Execute(series, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task ScheduleExecuteOfSeriesAction(ExecutableActionInfo actionInfo, IShokoSeries series, CancellationToken cancellationToken = default, bool prioritize = false)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.Series))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support series execution.");
+
+        return _scheduler.StartJob<ExecuteActionJob>(j =>
+        {
+            j.ActionID = actionInfo.ID;
+            j.AnimeID = series.AnidbAnimeID;
+        }, prioritize: prioritize);
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteSeriesUserAction(ExecutableActionInfo actionInfo, IShokoSeries series, IUser user, CancellationToken cancellationToken = default)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.SeriesUser))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support series user execution.");
+
+        if (ResolveAction(actionInfo) is not IExecutableSeriesUserAction seriesUserAction)
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableSeriesUserAction)}.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await seriesUserAction.Execute(series, user, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task ScheduleExecuteOfSeriesUserAction(ExecutableActionInfo actionInfo, IShokoSeries series, IUser user, CancellationToken cancellationToken = default, bool prioritize = false)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.SeriesUser))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support series user execution.");
+
+        return _scheduler.StartJob<ExecuteActionJob>(j =>
+        {
+            j.ActionID = actionInfo.ID;
+            j.AnimeID = series.AnidbAnimeID;
+            j.UserID = user.ID;
+        }, prioritize: prioritize);
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteGroupAction(ExecutableActionInfo actionInfo, IShokoGroup group, CancellationToken cancellationToken = default)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.Group))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support group execution.");
+
+        if (ResolveAction(actionInfo) is not IExecutableGroupAction groupAction)
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableGroupAction)}.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await groupAction.Execute(group, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task ScheduleExecuteOfGroupAction(ExecutableActionInfo actionInfo, IShokoGroup group, CancellationToken cancellationToken = default, bool prioritize = false)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.Group))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support group execution.");
+
+        return _scheduler.StartJob<ExecuteActionJob>(j =>
+        {
+            j.ActionID = actionInfo.ID;
+            j.GroupID = group.ID;
+        }, prioritize: prioritize);
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteGroupUserAction(ExecutableActionInfo actionInfo, IShokoGroup group, IUser user, CancellationToken cancellationToken = default)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.GroupUser))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support group user execution.");
+
+        if (ResolveAction(actionInfo) is not IExecutableGroupUserAction groupUserAction)
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableGroupUserAction)}.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await groupUserAction.Execute(group, user, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task ScheduleExecuteOfGroupUserAction(ExecutableActionInfo actionInfo, IShokoGroup group, IUser user, CancellationToken cancellationToken = default, bool prioritize = false)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.GroupUser))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support group user execution.");
+
+        return _scheduler.StartJob<ExecuteActionJob>(j =>
+        {
+            j.ActionID = actionInfo.ID;
+            j.GroupID = group.ID;
+            j.UserID = user.ID;
+        }, prioritize: prioritize);
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteEpisodeAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, CancellationToken cancellationToken = default)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.Episode))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support episode execution.");
+
+        if (ResolveAction(actionInfo) is not IExecutableEpisodeAction episodeAction)
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableEpisodeAction)}.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await episodeAction.Execute(episode, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task ScheduleExecuteOfEpisodeAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, CancellationToken cancellationToken = default, bool prioritize = false)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.Episode))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support episode execution.");
+
+        return _scheduler.StartJob<ExecuteActionJob>(j =>
+        {
+            j.ActionID = actionInfo.ID;
+            j.EpisodeID = episode.ID;
+        }, prioritize: prioritize);
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteEpisodeUserAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, IUser user, CancellationToken cancellationToken = default)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.EpisodeUser))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support episode user execution.");
+
+        if (ResolveAction(actionInfo) is not IExecutableEpisodeUserAction episodeUserAction)
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableEpisodeUserAction)}.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await episodeUserAction.Execute(episode, user, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task ScheduleExecuteOfEpisodeUserAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, IUser user, CancellationToken cancellationToken = default, bool prioritize = false)
+    {
+        if (!actionInfo.Scopes.Contains(ActionScope.EpisodeUser))
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support episode user execution.");
+
+        return _scheduler.StartJob<ExecuteActionJob>(j =>
+        {
+            j.ActionID = actionInfo.ID;
+            j.EpisodeID = episode.ID;
+            j.UserID = user.ID;
+        }, prioritize: prioritize);
+    }
+
+    /// <summary>
+    ///   Collects all <see cref="ActionScope"/> values that an executable
+    ///   action supports, based on which sub-interfaces its type implements.
+    /// </summary>
+    private static IReadOnlySet<ActionScope> GetActionScopes(Type actionType)
+    {
+        var result = new HashSet<ActionScope>();
+        if (typeof(IExecutableGlobalAction).IsAssignableFrom(actionType))
+            result.Add(ActionScope.Global);
+        if (typeof(IExecutableGlobalUserAction).IsAssignableFrom(actionType))
+            result.Add(ActionScope.GlobalUser);
+
+        if (typeof(IExecutableGroupAction).IsAssignableFrom(actionType))
+            result.Add(ActionScope.Group);
+        if (typeof(IExecutableGroupUserAction).IsAssignableFrom(actionType))
+            result.Add(ActionScope.GroupUser);
+
+        if (typeof(IExecutableSeriesAction).IsAssignableFrom(actionType))
+            result.Add(ActionScope.Series);
+        if (typeof(IExecutableSeriesUserAction).IsAssignableFrom(actionType))
+            result.Add(ActionScope.SeriesUser);
+
+        if (typeof(IExecutableEpisodeAction).IsAssignableFrom(actionType))
+            result.Add(ActionScope.Episode);
+        if (typeof(IExecutableEpisodeUserAction).IsAssignableFrom(actionType))
+            result.Add(ActionScope.EpisodeUser);
+
+        return result;
+    }
+
+    private IExecutableAction ResolveAction(ExecutableActionInfo actionInfo)
+    {
+        var (actionType, _) = _registeredActions.FirstOrDefault(ra => ra.Info.ID == actionInfo.ID);
+        var instance = (
+            actionType is not null
+                ? _pluginManager.GetExport<IExecutableAction>(actionType)
+                : null
+        ) ??
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) is not registered.");
+        return instance;
+    }
+
+    #endregion
 
     public async Task RunImport_IntegrityCheck()
     {
@@ -639,4 +990,57 @@ public class ActionService
         return unverifiedAnimeIDs.Count;
     }
 
+    public Task RunImport_SyncVotes()
+        => _scheduler.StartJob<SyncAniDBVotesJob>(c => (c.UserID, c.Export) = (0, true));
+
+    public Task PurgeAllTmdbLinks()
+    {
+        _tmdbLinkingService.RemoveAllLinks(true, true);
+        _tmdbLinkingService.ResetAutoLinkingState(false);
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateAniDBCalendar()
+        => _scheduler.StartJob<GetAniDBCalendarJob>(c => c.ForceRefresh = true);
+
+    public async Task PlexSyncAll()
+    {
+        foreach (var user in _jmmUsers.GetAll())
+        {
+            if (string.IsNullOrEmpty(user.PlexToken))
+                continue;
+            await _scheduler.StartJob<SyncPlexWatchedStatesJob>(c => c.User = user);
+        }
+    }
+
+    public async Task AddAllManualLinksToMyList()
+    {
+        var files = _videoLocals.GetManuallyLinkedVideos();
+        foreach (var vl in files)
+            await _scheduler.StartJob<AddFileToMyListJob>(c => c.Hash = vl.Hash);
+    }
+
+    public Task GetAniDBNotifications()
+        => _scheduler.StartJob<CheckAniDBNotificationsJob>(c => c.ForceRefresh = true);
+
+    public Task AVDumpMismatchedFiles()
+    {
+        var settings = _settingsProvider.GetSettings();
+        if (string.IsNullOrWhiteSpace(settings.AniDb.AVDumpKey))
+            return Task.CompletedTask;
+
+        var mismatchedFiles = _videoLocals.GetAll()
+            .Where(file => !file.IsEmpty() && file.MediaInfo != null)
+            .Select(file => (Video: file, AniDB: file.ReleaseInfo))
+            .Where(tuple => tuple.AniDB is { ProviderName: "AniDB", IsCorrupted: false } && tuple.Video.MediaInfo?.MenuStreams.Count != 0 != tuple.AniDB.IsChaptered)
+            .Select(tuple => (Path: tuple.Video.FirstResolvedPlace?.Path!, tuple.Video))
+            .Where(tuple => !string.IsNullOrEmpty(tuple.Path))
+            .ToDictionary(tuple => tuple.Video.VideoLocalID, tuple => tuple.Path);
+
+        foreach (var (fileId, filePath) in mismatchedFiles)
+            _scheduler.StartJob<AVDumpFilesJob>(a => a.Videos = new() { { fileId, filePath } });
+
+        _logger.LogInformation("Queued {QueuedAnimeCount} files for avdumping", mismatchedFiles.Count);
+        return Task.CompletedTask;
+    }
 }

--- a/Shoko.Server/Services/ActionService.cs
+++ b/Shoko.Server/Services/ActionService.cs
@@ -236,22 +236,22 @@ public class ActionService : IActionService
         => _registeredActions.FirstOrDefault(ra => ra.Info.ID == actionId).Info;
 
     /// <inheritdoc />
-    public async Task ExecuteGlobalAction(ExecutableActionInfo actionInfo, CancellationToken cancellationToken = default)
+    public async Task ExecuteGlobalSystemAction(ExecutableActionInfo actionInfo, CancellationToken cancellationToken = default)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.Global))
+        if (!actionInfo.Scopes.Contains(ActionScope.SystemAndGlobal))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support global execution.");
 
-        if (ResolveAction(actionInfo) is not IExecutableGlobalAction globalAction)
-            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableGlobalAction)}.");
+        if (ResolveAction(actionInfo) is not IExecutableGlobalSystemAction globalAction)
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableGlobalSystemAction)}.");
 
         cancellationToken.ThrowIfCancellationRequested();
         await globalAction.Execute(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public Task ScheduleExecuteOfGlobalAction(ExecutableActionInfo actionInfo, CancellationToken cancellationToken = default, bool prioritize = false)
+    public Task ScheduleExecuteOfGlobalSystemAction(ExecutableActionInfo actionInfo, CancellationToken cancellationToken = default, bool prioritize = false)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.Global))
+        if (!actionInfo.Scopes.Contains(ActionScope.SystemAndGlobal))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support global execution.");
 
         return _scheduler.StartJob<ExecuteActionJob>(j => j.ActionID = actionInfo.ID, prioritize: prioritize);
@@ -260,7 +260,7 @@ public class ActionService : IActionService
     /// <inheritdoc />
     public async Task ExecuteGlobalUserAction(ExecutableActionInfo actionInfo, IUser user, CancellationToken cancellationToken = default)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.GlobalUser))
+        if (!actionInfo.Scopes.Contains(ActionScope.UserAndGlobal))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support global user execution.");
 
         if (ResolveAction(actionInfo) is not IExecutableGlobalUserAction globalUserAction)
@@ -273,7 +273,7 @@ public class ActionService : IActionService
     /// <inheritdoc />
     public Task ScheduleExecuteOfGlobalUserAction(ExecutableActionInfo actionInfo, IUser user, CancellationToken cancellationToken = default, bool prioritize = false)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.GlobalUser))
+        if (!actionInfo.Scopes.Contains(ActionScope.UserAndGlobal))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support global user execution.");
 
         return _scheduler.StartJob<ExecuteActionJob>(j =>
@@ -284,22 +284,22 @@ public class ActionService : IActionService
     }
 
     /// <inheritdoc />
-    public async Task ExecuteSeriesAction(ExecutableActionInfo actionInfo, IShokoSeries series, CancellationToken cancellationToken = default)
+    public async Task ExecuteSeriesSystemAction(ExecutableActionInfo actionInfo, IShokoSeries series, CancellationToken cancellationToken = default)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.Series))
+        if (!actionInfo.Scopes.Contains(ActionScope.SystemAndSeries))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support series execution.");
 
-        if (ResolveAction(actionInfo) is not IExecutableSeriesAction seriesAction)
-            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableSeriesAction)}.");
+        if (ResolveAction(actionInfo) is not IExecutableSeriesSystemAction seriesAction)
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableSeriesSystemAction)}.");
 
         cancellationToken.ThrowIfCancellationRequested();
         await seriesAction.Execute(series, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public Task ScheduleExecuteOfSeriesAction(ExecutableActionInfo actionInfo, IShokoSeries series, CancellationToken cancellationToken = default, bool prioritize = false)
+    public Task ScheduleExecuteOfSeriesSystemAction(ExecutableActionInfo actionInfo, IShokoSeries series, CancellationToken cancellationToken = default, bool prioritize = false)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.Series))
+        if (!actionInfo.Scopes.Contains(ActionScope.SystemAndSeries))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support series execution.");
 
         return _scheduler.StartJob<ExecuteActionJob>(j =>
@@ -312,7 +312,7 @@ public class ActionService : IActionService
     /// <inheritdoc />
     public async Task ExecuteSeriesUserAction(ExecutableActionInfo actionInfo, IShokoSeries series, IUser user, CancellationToken cancellationToken = default)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.SeriesUser))
+        if (!actionInfo.Scopes.Contains(ActionScope.UserAndSeries))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support series user execution.");
 
         if (ResolveAction(actionInfo) is not IExecutableSeriesUserAction seriesUserAction)
@@ -325,7 +325,7 @@ public class ActionService : IActionService
     /// <inheritdoc />
     public Task ScheduleExecuteOfSeriesUserAction(ExecutableActionInfo actionInfo, IShokoSeries series, IUser user, CancellationToken cancellationToken = default, bool prioritize = false)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.SeriesUser))
+        if (!actionInfo.Scopes.Contains(ActionScope.UserAndSeries))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support series user execution.");
 
         return _scheduler.StartJob<ExecuteActionJob>(j =>
@@ -337,22 +337,22 @@ public class ActionService : IActionService
     }
 
     /// <inheritdoc />
-    public async Task ExecuteGroupAction(ExecutableActionInfo actionInfo, IShokoGroup group, CancellationToken cancellationToken = default)
+    public async Task ExecuteGroupSystemAction(ExecutableActionInfo actionInfo, IShokoGroup group, CancellationToken cancellationToken = default)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.Group))
+        if (!actionInfo.Scopes.Contains(ActionScope.SystemAndGroup))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support group execution.");
 
-        if (ResolveAction(actionInfo) is not IExecutableGroupAction groupAction)
-            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableGroupAction)}.");
+        if (ResolveAction(actionInfo) is not IExecutableGroupSystemAction groupAction)
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableGroupSystemAction)}.");
 
         cancellationToken.ThrowIfCancellationRequested();
         await groupAction.Execute(group, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public Task ScheduleExecuteOfGroupAction(ExecutableActionInfo actionInfo, IShokoGroup group, CancellationToken cancellationToken = default, bool prioritize = false)
+    public Task ScheduleExecuteOfGroupSystemAction(ExecutableActionInfo actionInfo, IShokoGroup group, CancellationToken cancellationToken = default, bool prioritize = false)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.Group))
+        if (!actionInfo.Scopes.Contains(ActionScope.SystemAndGroup))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support group execution.");
 
         return _scheduler.StartJob<ExecuteActionJob>(j =>
@@ -365,7 +365,7 @@ public class ActionService : IActionService
     /// <inheritdoc />
     public async Task ExecuteGroupUserAction(ExecutableActionInfo actionInfo, IShokoGroup group, IUser user, CancellationToken cancellationToken = default)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.GroupUser))
+        if (!actionInfo.Scopes.Contains(ActionScope.UserAndGroup))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support group user execution.");
 
         if (ResolveAction(actionInfo) is not IExecutableGroupUserAction groupUserAction)
@@ -378,7 +378,7 @@ public class ActionService : IActionService
     /// <inheritdoc />
     public Task ScheduleExecuteOfGroupUserAction(ExecutableActionInfo actionInfo, IShokoGroup group, IUser user, CancellationToken cancellationToken = default, bool prioritize = false)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.GroupUser))
+        if (!actionInfo.Scopes.Contains(ActionScope.UserAndGroup))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support group user execution.");
 
         return _scheduler.StartJob<ExecuteActionJob>(j =>
@@ -390,22 +390,22 @@ public class ActionService : IActionService
     }
 
     /// <inheritdoc />
-    public async Task ExecuteEpisodeAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, CancellationToken cancellationToken = default)
+    public async Task ExecuteEpisodeSystemAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, CancellationToken cancellationToken = default)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.Episode))
+        if (!actionInfo.Scopes.Contains(ActionScope.SystemAndEpisode))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support episode execution.");
 
-        if (ResolveAction(actionInfo) is not IExecutableEpisodeAction episodeAction)
-            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableEpisodeAction)}.");
+        if (ResolveAction(actionInfo) is not IExecutableEpisodeSystemAction episodeAction)
+            throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not implement {nameof(IExecutableEpisodeSystemAction)}.");
 
         cancellationToken.ThrowIfCancellationRequested();
         await episodeAction.Execute(episode, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public Task ScheduleExecuteOfEpisodeAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, CancellationToken cancellationToken = default, bool prioritize = false)
+    public Task ScheduleExecuteOfEpisodeSystemAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, CancellationToken cancellationToken = default, bool prioritize = false)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.Episode))
+        if (!actionInfo.Scopes.Contains(ActionScope.SystemAndEpisode))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support episode execution.");
 
         return _scheduler.StartJob<ExecuteActionJob>(j =>
@@ -418,7 +418,7 @@ public class ActionService : IActionService
     /// <inheritdoc />
     public async Task ExecuteEpisodeUserAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, IUser user, CancellationToken cancellationToken = default)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.EpisodeUser))
+        if (!actionInfo.Scopes.Contains(ActionScope.UserAndEpisode))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support episode user execution.");
 
         if (ResolveAction(actionInfo) is not IExecutableEpisodeUserAction episodeUserAction)
@@ -431,7 +431,7 @@ public class ActionService : IActionService
     /// <inheritdoc />
     public Task ScheduleExecuteOfEpisodeUserAction(ExecutableActionInfo actionInfo, IShokoEpisode episode, IUser user, CancellationToken cancellationToken = default, bool prioritize = false)
     {
-        if (!actionInfo.Scopes.Contains(ActionScope.EpisodeUser))
+        if (!actionInfo.Scopes.Contains(ActionScope.UserAndEpisode))
             throw new InvalidOperationException($"The action '{actionInfo.Name}' ({actionInfo.ID}) does not support episode user execution.");
 
         return _scheduler.StartJob<ExecuteActionJob>(j =>
@@ -449,25 +449,25 @@ public class ActionService : IActionService
     private static IReadOnlySet<ActionScope> GetActionScopes(Type actionType)
     {
         var result = new HashSet<ActionScope>();
-        if (typeof(IExecutableGlobalAction).IsAssignableFrom(actionType))
-            result.Add(ActionScope.Global);
+        if (typeof(IExecutableGlobalSystemAction).IsAssignableFrom(actionType))
+            result.Add(ActionScope.SystemAndGlobal);
         if (typeof(IExecutableGlobalUserAction).IsAssignableFrom(actionType))
-            result.Add(ActionScope.GlobalUser);
+            result.Add(ActionScope.UserAndGlobal);
 
-        if (typeof(IExecutableGroupAction).IsAssignableFrom(actionType))
-            result.Add(ActionScope.Group);
+        if (typeof(IExecutableGroupSystemAction).IsAssignableFrom(actionType))
+            result.Add(ActionScope.SystemAndGroup);
         if (typeof(IExecutableGroupUserAction).IsAssignableFrom(actionType))
-            result.Add(ActionScope.GroupUser);
+            result.Add(ActionScope.UserAndGroup);
 
-        if (typeof(IExecutableSeriesAction).IsAssignableFrom(actionType))
-            result.Add(ActionScope.Series);
+        if (typeof(IExecutableSeriesSystemAction).IsAssignableFrom(actionType))
+            result.Add(ActionScope.SystemAndSeries);
         if (typeof(IExecutableSeriesUserAction).IsAssignableFrom(actionType))
-            result.Add(ActionScope.SeriesUser);
+            result.Add(ActionScope.UserAndSeries);
 
-        if (typeof(IExecutableEpisodeAction).IsAssignableFrom(actionType))
-            result.Add(ActionScope.Episode);
+        if (typeof(IExecutableEpisodeSystemAction).IsAssignableFrom(actionType))
+            result.Add(ActionScope.SystemAndEpisode);
         if (typeof(IExecutableEpisodeUserAction).IsAssignableFrom(actionType))
-            result.Add(ActionScope.EpisodeUser);
+            result.Add(ActionScope.UserAndEpisode);
 
         return result;
     }

--- a/Shoko.Server/Services/Actions/AniDB/AVDumpMismatchedFilesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/AVDumpMismatchedFilesAction.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.AniDB;
+
+/// <summary>
+///   Queue AVDump jobs for files whose media info and AniDB data are
+///   mismatched (e.g., chapter states differ).
+/// </summary>
+internal sealed class AVDumpMismatchedFilesAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "AVDump Mismatched Files";
+    public string? Description => "Queue AVDump jobs for files whose local media info and AniDB data are mismatched.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public Task Execute(CancellationToken cancellationToken = default)
+        => actionService.AVDumpMismatchedFiles();
+}

--- a/Shoko.Server/Services/Actions/AniDB/AVDumpMismatchedFilesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/AVDumpMismatchedFilesAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 ///   Queue AVDump jobs for files whose media info and AniDB data are
 ///   mismatched (e.g., chapter states differ).
 /// </summary>
-internal sealed class AVDumpMismatchedFilesAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class AVDumpMismatchedFilesAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "AVDump Mismatched Files";
     public string? Description => "Queue AVDump jobs for files whose local media info and AniDB data are mismatched.";

--- a/Shoko.Server/Services/Actions/AniDB/AVDumpMismatchedFilesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/AVDumpMismatchedFilesAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 ///   Queue AVDump jobs for files whose media info and AniDB data are
 ///   mismatched (e.g., chapter states differ).
 /// </summary>
-internal sealed class AVDumpMismatchedFilesAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class AVDumpMismatchedFilesAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "AVDump Mismatched Files";
     public string? Description => "Queue AVDump jobs for files whose local media info and AniDB data are mismatched.";

--- a/Shoko.Server/Services/Actions/AniDB/AddAllManualLinksToMyListAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/AddAllManualLinksToMyListAction.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.AniDB;
+
+/// <summary>
+///   Forcibly runs AddToMyList commands for all manually linked files.
+/// </summary>
+internal sealed class AddAllManualLinksToMyListAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Add All Manual Links to MyList";
+    public string? Description => "Forcibly run AddToMyList commands for all files with manual links.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public Task Execute(CancellationToken cancellationToken = default)
+        => actionService.AddAllManualLinksToMyList();
+}

--- a/Shoko.Server/Services/Actions/AniDB/AddAllManualLinksToMyListAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/AddAllManualLinksToMyListAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Forcibly runs AddToMyList commands for all manually linked files.
 /// </summary>
-internal sealed class AddAllManualLinksToMyListAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class AddAllManualLinksToMyListAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Add All Manual Links to MyList";
     public string? Description => "Forcibly run AddToMyList commands for all files with manual links.";

--- a/Shoko.Server/Services/Actions/AniDB/AddAllManualLinksToMyListAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/AddAllManualLinksToMyListAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Forcibly runs AddToMyList commands for all manually linked files.
 /// </summary>
-internal sealed class AddAllManualLinksToMyListAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class AddAllManualLinksToMyListAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Add All Manual Links to MyList";
     public string? Description => "Forcibly run AddToMyList commands for all files with manual links.";

--- a/Shoko.Server/Services/Actions/AniDB/DownloadMissingAnidbAnimeDataAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/DownloadMissingAnidbAnimeDataAction.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.AniDB;
+
+/// <summary>
+///   Download missing AniDB XML data for anime, and fix cross-references with
+///   incomplete data.
+/// </summary>
+internal sealed class DownloadMissingAnidbAnimeDataAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Download Missing AniDB Anime Data";
+    public string? Description => "Download missing AniDB XML data and fix cross-references with incomplete data.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await actionService.DownloadMissingAnidbAnimeXmls();
+        await actionService.ScheduleMissingAnidbAnimeForFiles();
+    }
+}

--- a/Shoko.Server/Services/Actions/AniDB/DownloadMissingAnidbAnimeDataAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/DownloadMissingAnidbAnimeDataAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 ///   Download missing AniDB XML data for anime, and fix cross-references with
 ///   incomplete data.
 /// </summary>
-internal sealed class DownloadMissingAnidbAnimeDataAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class DownloadMissingAnidbAnimeDataAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Download Missing AniDB Anime Data";
     public string? Description => "Download missing AniDB XML data and fix cross-references with incomplete data.";

--- a/Shoko.Server/Services/Actions/AniDB/DownloadMissingAnidbAnimeDataAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/DownloadMissingAnidbAnimeDataAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 ///   Download missing AniDB XML data for anime, and fix cross-references with
 ///   incomplete data.
 /// </summary>
-internal sealed class DownloadMissingAnidbAnimeDataAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class DownloadMissingAnidbAnimeDataAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Download Missing AniDB Anime Data";
     public string? Description => "Download missing AniDB XML data and fix cross-references with incomplete data.";

--- a/Shoko.Server/Services/Actions/AniDB/DownloadMissingAnidbCreatorsAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/DownloadMissingAnidbCreatorsAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Download all missing AniDB creator data via the UDP API.
 /// </summary>
-internal sealed class DownloadMissingAnidbCreatorsAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class DownloadMissingAnidbCreatorsAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Download Missing AniDB Creators";
     public string? Description => "Download all missing or incomplete AniDB creator data via the UDP API.";

--- a/Shoko.Server/Services/Actions/AniDB/DownloadMissingAnidbCreatorsAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/DownloadMissingAnidbCreatorsAction.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.AniDB;
+
+/// <summary>
+///   Download all missing AniDB creator data via the UDP API.
+/// </summary>
+internal sealed class DownloadMissingAnidbCreatorsAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Download Missing AniDB Creators";
+    public string? Description => "Download all missing or incomplete AniDB creator data via the UDP API.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await actionService.ScheduleMissingAnidbCreators();
+    }
+}

--- a/Shoko.Server/Services/Actions/AniDB/DownloadMissingAnidbCreatorsAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/DownloadMissingAnidbCreatorsAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Download all missing AniDB creator data via the UDP API.
 /// </summary>
-internal sealed class DownloadMissingAnidbCreatorsAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class DownloadMissingAnidbCreatorsAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Download Missing AniDB Creators";
     public string? Description => "Download all missing or incomplete AniDB creator data via the UDP API.";

--- a/Shoko.Server/Services/Actions/AniDB/GetAnidbNotificationsAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/GetAnidbNotificationsAction.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.AniDB;
+
+/// <summary>
+///   Fetch unread notifications and messages from AniDB.
+/// </summary>
+internal sealed class GetAnidbNotificationsAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Get AniDB Notifications";
+    public string? Description => "Fetch unread notifications and messages from AniDB.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public Task Execute(CancellationToken cancellationToken = default)
+        => actionService.GetAniDBNotifications();
+}

--- a/Shoko.Server/Services/Actions/AniDB/GetAnidbNotificationsAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/GetAnidbNotificationsAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Fetch unread notifications and messages from AniDB.
 /// </summary>
-internal sealed class GetAnidbNotificationsAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class GetAnidbNotificationsAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Get AniDB Notifications";
     public string? Description => "Fetch unread notifications and messages from AniDB.";

--- a/Shoko.Server/Services/Actions/AniDB/GetAnidbNotificationsAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/GetAnidbNotificationsAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Fetch unread notifications and messages from AniDB.
 /// </summary>
-internal sealed class GetAnidbNotificationsAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class GetAnidbNotificationsAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Get AniDB Notifications";
     public string? Description => "Fetch unread notifications and messages from AniDB.";

--- a/Shoko.Server/Services/Actions/AniDB/RefreshAnidbMovedFilesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/RefreshAnidbMovedFilesAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Process any pending AniDB file-moved notifications.
 /// </summary>
-internal sealed class RefreshAnidbMovedFilesAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class RefreshAnidbMovedFilesAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Refresh AniDB Moved Files";
     public string? Description => "Process pending AniDB file-moved notifications and update affected files.";

--- a/Shoko.Server/Services/Actions/AniDB/RefreshAnidbMovedFilesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/RefreshAnidbMovedFilesAction.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.AniDB;
+
+/// <summary>
+///   Process any pending AniDB file-moved notifications.
+/// </summary>
+internal sealed class RefreshAnidbMovedFilesAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Refresh AniDB Moved Files";
+    public string? Description => "Process pending AniDB file-moved notifications and update affected files.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await actionService.RefreshAniDBMovedFiles(true);
+    }
+}

--- a/Shoko.Server/Services/Actions/AniDB/RefreshAnidbMovedFilesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/RefreshAnidbMovedFilesAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Process any pending AniDB file-moved notifications.
 /// </summary>
-internal sealed class RefreshAnidbMovedFilesAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class RefreshAnidbMovedFilesAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Refresh AniDB Moved Files";
     public string? Description => "Process pending AniDB file-moved notifications and update affected files.";

--- a/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoForceSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoForceSeriesAction.cs
@@ -12,7 +12,7 @@ namespace Shoko.Server.Services.Actions.AniDB.Series;
 ///   Force a complete update of AniDB info for the series, bypassing time
 ///   checks and HTTP bans. Requires user confirmation.
 /// </summary>
-internal sealed class UpdateAnidbInfoForceSeriesAction(IAnidbService anidbService) : IExecutableSeriesSystemAction
+public sealed class UpdateAnidbInfoForceSeriesAction(IAnidbService anidbService) : IExecutableSeriesSystemAction
 {
     public string Name => "Update AniDB Info - Force";
     public string? Description => "Forces a complete update from AniDB, bypassing usual checks and bans.";

--- a/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoForceSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoForceSeriesAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Anidb.Enums;
+using Shoko.Abstractions.Metadata.Anidb.Services;
+using Shoko.Abstractions.Metadata.Shoko;
+
+namespace Shoko.Server.Services.Actions.AniDB.Series;
+
+/// <summary>
+///   Force a complete update of AniDB info for the series, bypassing time
+///   checks and HTTP bans. Requires user confirmation.
+/// </summary>
+internal sealed class UpdateAnidbInfoForceSeriesAction(IAnidbService anidbService) : IExecutableSeriesAction
+{
+    public string Name => "Update AniDB Info - Force";
+    public string? Description => "Forces a complete update from AniDB, bypassing usual checks and bans.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+        => anidbService.ScheduleRefreshOfAnimeByID(series.AnidbAnimeID, AnidbRefreshMethod.Remote | AnidbRefreshMethod.IgnoreTimeCheck | AnidbRefreshMethod.IgnoreHttpBans);
+}

--- a/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoForceSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoForceSeriesAction.cs
@@ -12,7 +12,7 @@ namespace Shoko.Server.Services.Actions.AniDB.Series;
 ///   Force a complete update of AniDB info for the series, bypassing time
 ///   checks and HTTP bans. Requires user confirmation.
 /// </summary>
-internal sealed class UpdateAnidbInfoForceSeriesAction(IAnidbService anidbService) : IExecutableSeriesAction
+internal sealed class UpdateAnidbInfoForceSeriesAction(IAnidbService anidbService) : IExecutableSeriesSystemAction
 {
     public string Name => "Update AniDB Info - Force";
     public string? Description => "Forces a complete update from AniDB, bypassing usual checks and bans.";

--- a/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoRemoteSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoRemoteSeriesAction.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Anidb.Enums;
+using Shoko.Abstractions.Metadata.Anidb.Services;
+using Shoko.Abstractions.Metadata.Shoko;
+
+namespace Shoko.Server.Services.Actions.AniDB.Series;
+
+/// <summary>
+///   Update AniDB info for the series using the remote API, respecting
+///   the usual time and ban checks.
+/// </summary>
+internal sealed class UpdateAnidbInfoRemoteSeriesAction(IAnidbService anidbService) : IExecutableSeriesAction
+{
+    public string Name => "Update AniDB Info - Remote";
+    public string? Description => "Gets the latest series information from the AniDB remote API, respecting usual checks.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+        => anidbService.ScheduleRefreshOfAnimeByID(series.AnidbAnimeID, AnidbRefreshMethod.Remote);
+}

--- a/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoRemoteSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoRemoteSeriesAction.cs
@@ -12,7 +12,7 @@ namespace Shoko.Server.Services.Actions.AniDB.Series;
 ///   Update AniDB info for the series using the remote API, respecting
 ///   the usual time and ban checks.
 /// </summary>
-internal sealed class UpdateAnidbInfoRemoteSeriesAction(IAnidbService anidbService) : IExecutableSeriesAction
+internal sealed class UpdateAnidbInfoRemoteSeriesAction(IAnidbService anidbService) : IExecutableSeriesSystemAction
 {
     public string Name => "Update AniDB Info - Remote";
     public string? Description => "Gets the latest series information from the AniDB remote API, respecting usual checks.";

--- a/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoRemoteSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoRemoteSeriesAction.cs
@@ -12,7 +12,7 @@ namespace Shoko.Server.Services.Actions.AniDB.Series;
 ///   Update AniDB info for the series using the remote API, respecting
 ///   the usual time and ban checks.
 /// </summary>
-internal sealed class UpdateAnidbInfoRemoteSeriesAction(IAnidbService anidbService) : IExecutableSeriesSystemAction
+public sealed class UpdateAnidbInfoRemoteSeriesAction(IAnidbService anidbService) : IExecutableSeriesSystemAction
 {
     public string Name => "Update AniDB Info - Remote";
     public string? Description => "Gets the latest series information from the AniDB remote API, respecting usual checks.";

--- a/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoSeriesAction.cs
@@ -12,7 +12,7 @@ namespace Shoko.Server.Services.Actions.AniDB.Series;
 ///   Update AniDB info for the series, using cached data if available and
 ///   falling back to the remote API.
 /// </summary>
-internal sealed class UpdateAnidbInfoSeriesAction(IAnidbService anidbService) : IExecutableSeriesAction
+internal sealed class UpdateAnidbInfoSeriesAction(IAnidbService anidbService) : IExecutableSeriesSystemAction
 {
     public string Name => "Update AniDB Info";
     public string? Description => "Gets the latest series information from the AniDB database.";

--- a/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoSeriesAction.cs
@@ -12,7 +12,7 @@ namespace Shoko.Server.Services.Actions.AniDB.Series;
 ///   Update AniDB info for the series, using cached data if available and
 ///   falling back to the remote API.
 /// </summary>
-internal sealed class UpdateAnidbInfoSeriesAction(IAnidbService anidbService) : IExecutableSeriesSystemAction
+public sealed class UpdateAnidbInfoSeriesAction(IAnidbService anidbService) : IExecutableSeriesSystemAction
 {
     public string Name => "Update AniDB Info";
     public string? Description => "Gets the latest series information from the AniDB database.";

--- a/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoSeriesAction.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Anidb.Enums;
+using Shoko.Abstractions.Metadata.Anidb.Services;
+using Shoko.Abstractions.Metadata.Shoko;
+
+namespace Shoko.Server.Services.Actions.AniDB.Series;
+
+/// <summary>
+///   Update AniDB info for the series, using cached data if available and
+///   falling back to the remote API.
+/// </summary>
+internal sealed class UpdateAnidbInfoSeriesAction(IAnidbService anidbService) : IExecutableSeriesAction
+{
+    public string Name => "Update AniDB Info";
+    public string? Description => "Gets the latest series information from the AniDB database.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+        => anidbService.ScheduleRefreshOfAnimeByID(series.AnidbAnimeID, AnidbRefreshMethod.Cache | AnidbRefreshMethod.DeferToRemoteIfUnsuccessful);
+}

--- a/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoXmlCacheSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoXmlCacheSeriesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.AniDB.Series;
 /// <summary>
 ///   Update AniDB info for the series using only locally cached XML data.
 /// </summary>
-internal sealed class UpdateAnidbInfoXmlCacheSeriesAction(IAnidbService anidbService) : IExecutableSeriesSystemAction
+public sealed class UpdateAnidbInfoXmlCacheSeriesAction(IAnidbService anidbService) : IExecutableSeriesSystemAction
 {
     public string Name => "Update AniDB Info - XML Cache";
     public string? Description => "Updates AniDB data using information from local XML cache.";

--- a/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoXmlCacheSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoXmlCacheSeriesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.AniDB.Series;
 /// <summary>
 ///   Update AniDB info for the series using only locally cached XML data.
 /// </summary>
-internal sealed class UpdateAnidbInfoXmlCacheSeriesAction(IAnidbService anidbService) : IExecutableSeriesAction
+internal sealed class UpdateAnidbInfoXmlCacheSeriesAction(IAnidbService anidbService) : IExecutableSeriesSystemAction
 {
     public string Name => "Update AniDB Info - XML Cache";
     public string? Description => "Updates AniDB data using information from local XML cache.";

--- a/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoXmlCacheSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/Series/UpdateAnidbInfoXmlCacheSeriesAction.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Anidb.Enums;
+using Shoko.Abstractions.Metadata.Anidb.Services;
+using Shoko.Abstractions.Metadata.Shoko;
+
+namespace Shoko.Server.Services.Actions.AniDB.Series;
+
+/// <summary>
+///   Update AniDB info for the series using only locally cached XML data.
+/// </summary>
+internal sealed class UpdateAnidbInfoXmlCacheSeriesAction(IAnidbService anidbService) : IExecutableSeriesAction
+{
+    public string Name => "Update AniDB Info - XML Cache";
+    public string? Description => "Updates AniDB data using information from local XML cache.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+        => anidbService.ScheduleRefreshOfAnimeByID(series.AnidbAnimeID, AnidbRefreshMethod.Cache);
+}

--- a/Shoko.Server/Services/Actions/AniDB/SyncAnidbMyListAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/SyncAnidbMyListAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Sync all local state to the AniDB MyList. This overwrites AniDB data.
 /// </summary>
-internal sealed class SyncAnidbMyListAction(IJobFactory jobFactory) : IExecutableGlobalAction
+internal sealed class SyncAnidbMyListAction(IJobFactory jobFactory) : IExecutableGlobalSystemAction
 {
     public string Name => "Sync AniDB MyList";
     public string? Description => "Sync all local state to the AniDB MyList. This can overwrite AniDB data irreversibly.";

--- a/Shoko.Server/Services/Actions/AniDB/SyncAnidbMyListAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/SyncAnidbMyListAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.AniDB;
+
+namespace Shoko.Server.Services.Actions.AniDB;
+
+/// <summary>
+///   Sync all local state to the AniDB MyList. This overwrites AniDB data.
+/// </summary>
+internal sealed class SyncAnidbMyListAction(IJobFactory jobFactory) : IExecutableGlobalAction
+{
+    public string Name => "Sync AniDB MyList";
+    public string? Description => "Sync all local state to the AniDB MyList. This can overwrite AniDB data irreversibly.";
+    public ActionCategory Category => ActionCategory.AniDB;
+    public bool RequiresConfirmation => true;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await jobFactory.Execute<SyncAniDBMyListJob>(j => j.ForceRefresh = true);
+    }
+}

--- a/Shoko.Server/Services/Actions/AniDB/SyncAnidbMyListAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/SyncAnidbMyListAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Sync all local state to the AniDB MyList. This overwrites AniDB data.
 /// </summary>
-internal sealed class SyncAnidbMyListAction(IJobFactory jobFactory) : IExecutableGlobalSystemAction
+public sealed class SyncAnidbMyListAction(IJobFactory jobFactory) : IExecutableGlobalSystemAction
 {
     public string Name => "Sync AniDB MyList";
     public string? Description => "Sync all local state to the AniDB MyList. This can overwrite AniDB data irreversibly.";

--- a/Shoko.Server/Services/Actions/AniDB/SyncAnidbVotesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/SyncAnidbVotesAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Sync local votes to AniDB.
 /// </summary>
-internal sealed class SyncAnidbVotesAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class SyncAnidbVotesAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Sync AniDB Votes";
     public string? Description => "Export local votes to AniDB.";

--- a/Shoko.Server/Services/Actions/AniDB/SyncAnidbVotesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/SyncAnidbVotesAction.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.AniDB;
+
+/// <summary>
+///   Sync local votes to AniDB.
+/// </summary>
+internal sealed class SyncAnidbVotesAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Sync AniDB Votes";
+    public string? Description => "Export local votes to AniDB.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public Task Execute(CancellationToken cancellationToken = default)
+        => actionService.RunImport_SyncVotes();
+}

--- a/Shoko.Server/Services/Actions/AniDB/SyncAnidbVotesAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/SyncAnidbVotesAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Sync local votes to AniDB.
 /// </summary>
-internal sealed class SyncAnidbVotesAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class SyncAnidbVotesAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Sync AniDB Votes";
     public string? Description => "Export local votes to AniDB.";

--- a/Shoko.Server/Services/Actions/AniDB/UpdateAllAnidbInfoAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/UpdateAllAnidbInfoAction.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.AniDB;
+
+/// <summary>
+///   Refresh all AniDB anime info from the remote API.
+/// </summary>
+internal sealed class UpdateAllAnidbInfoAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Update All AniDB Info";
+    public string? Description => "Refresh all AniDB anime information from the remote API.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await actionService.RunImport_UpdateAllAniDB();
+    }
+}

--- a/Shoko.Server/Services/Actions/AniDB/UpdateAllAnidbInfoAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/UpdateAllAnidbInfoAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Refresh all AniDB anime info from the remote API.
 /// </summary>
-internal sealed class UpdateAllAnidbInfoAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class UpdateAllAnidbInfoAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All AniDB Info";
     public string? Description => "Refresh all AniDB anime information from the remote API.";

--- a/Shoko.Server/Services/Actions/AniDB/UpdateAllAnidbInfoAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/UpdateAllAnidbInfoAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Refresh all AniDB anime info from the remote API.
 /// </summary>
-internal sealed class UpdateAllAnidbInfoAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class UpdateAllAnidbInfoAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All AniDB Info";
     public string? Description => "Refresh all AniDB anime information from the remote API.";

--- a/Shoko.Server/Services/Actions/AniDB/UpdateAnidbCalendarAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/UpdateAnidbCalendarAction.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.AniDB;
+
+/// <summary>
+///   Update the AniDB calendar data for use on the dashboard.
+/// </summary>
+internal sealed class UpdateAnidbCalendarAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Update AniDB Calendar";
+    public string? Description => "Update the AniDB calendar data for use on the dashboard.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public Task Execute(CancellationToken cancellationToken = default)
+        => actionService.UpdateAniDBCalendar();
+}

--- a/Shoko.Server/Services/Actions/AniDB/UpdateAnidbCalendarAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/UpdateAnidbCalendarAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Update the AniDB calendar data for use on the dashboard.
 /// </summary>
-internal sealed class UpdateAnidbCalendarAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class UpdateAnidbCalendarAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update AniDB Calendar";
     public string? Description => "Update the AniDB calendar data for use on the dashboard.";

--- a/Shoko.Server/Services/Actions/AniDB/UpdateAnidbCalendarAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/UpdateAnidbCalendarAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Update the AniDB calendar data for use on the dashboard.
 /// </summary>
-internal sealed class UpdateAnidbCalendarAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class UpdateAnidbCalendarAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update AniDB Calendar";
     public string? Description => "Update the AniDB calendar data for use on the dashboard.";

--- a/Shoko.Server/Services/Actions/AniDB/UpdateMissingAnidbFileInfoAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/UpdateMissingAnidbFileInfoAction.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.AniDB;
+
+/// <summary>
+///   Update AniDB release info for files with missing or incomplete group data.
+/// </summary>
+internal sealed class UpdateMissingAnidbFileInfoAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Update Missing AniDB File Info";
+    public string? Description => "Update AniDB release info for files with missing or incomplete group information.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await actionService.UpdateAnidbReleaseInfo();
+    }
+}

--- a/Shoko.Server/Services/Actions/AniDB/UpdateMissingAnidbFileInfoAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/UpdateMissingAnidbFileInfoAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Update AniDB release info for files with missing or incomplete group data.
 /// </summary>
-internal sealed class UpdateMissingAnidbFileInfoAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class UpdateMissingAnidbFileInfoAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update Missing AniDB File Info";
     public string? Description => "Update AniDB release info for files with missing or incomplete group information.";

--- a/Shoko.Server/Services/Actions/AniDB/UpdateMissingAnidbFileInfoAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/UpdateMissingAnidbFileInfoAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Update AniDB release info for files with missing or incomplete group data.
 /// </summary>
-internal sealed class UpdateMissingAnidbFileInfoAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class UpdateMissingAnidbFileInfoAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update Missing AniDB File Info";
     public string? Description => "Update AniDB release info for files with missing or incomplete group information.";

--- a/Shoko.Server/Services/Actions/AniDB/VerifyAllRelationsAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/VerifyAllRelationsAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Verify all unverified AniDB relations by fetching current data via the UDP API.
 /// </summary>
-internal sealed class VerifyAllRelationsAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class VerifyAllRelationsAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Verify All Relations";
     public string? Description => "Verify all unverified AniDB relations by fetching current data via the UDP API.";

--- a/Shoko.Server/Services/Actions/AniDB/VerifyAllRelationsAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/VerifyAllRelationsAction.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.AniDB;
+
+/// <summary>
+///   Verify all unverified AniDB relations by fetching current data via the UDP API.
+/// </summary>
+internal sealed class VerifyAllRelationsAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Verify All Relations";
+    public string? Description => "Verify all unverified AniDB relations by fetching current data via the UDP API.";
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await actionService.VerifyAllUnverifiedRelations();
+    }
+}

--- a/Shoko.Server/Services/Actions/AniDB/VerifyAllRelationsAction.cs
+++ b/Shoko.Server/Services/Actions/AniDB/VerifyAllRelationsAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.AniDB;
 /// <summary>
 ///   Verify all unverified AniDB relations by fetching current data via the UDP API.
 /// </summary>
-internal sealed class VerifyAllRelationsAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class VerifyAllRelationsAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Verify All Relations";
     public string? Description => "Verify all unverified AniDB relations by fetching current data via the UDP API.";

--- a/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesAllDataAction.cs
+++ b/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesAllDataAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Destructive.Series;
 /// <summary>
 ///   Completely remove all data and files for the series.
 /// </summary>
-internal sealed class DeleteSeriesAllDataAction(
+public sealed class DeleteSeriesAllDataAction(
     AnimeSeriesRepository seriesRepo,
     AnimeSeriesService seriesService
 ) : IExecutableSeriesSystemAction

--- a/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesAllDataAction.cs
+++ b/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesAllDataAction.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Services.Actions.Destructive.Series;
+
+/// <summary>
+///   Completely remove all data and files for the series.
+/// </summary>
+internal sealed class DeleteSeriesAllDataAction(
+    AnimeSeriesRepository seriesRepo,
+    AnimeSeriesService seriesService
+) : IExecutableSeriesAction
+{
+    public string Name => "Delete Series - All Series Data and Files";
+    public string? Description => "Removes ALL DATA AND FILES relating to the series. Use with caution, as you may get temp banned from AniDB if it's abused.";
+    public ActionCategory Category => ActionCategory.Destructive;
+    public bool RequiresConfirmation => true;
+
+    public async Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        var animeSeries = seriesRepo.GetByAnimeID(series.AnidbAnimeID);
+        if (animeSeries is null) return;
+        await seriesService.DeleteSeries(animeSeries, true, true, true);
+    }
+}

--- a/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesAllDataAction.cs
+++ b/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesAllDataAction.cs
@@ -14,7 +14,7 @@ namespace Shoko.Server.Services.Actions.Destructive.Series;
 internal sealed class DeleteSeriesAllDataAction(
     AnimeSeriesRepository seriesRepo,
     AnimeSeriesService seriesService
-) : IExecutableSeriesAction
+) : IExecutableSeriesSystemAction
 {
     public string Name => "Delete Series - All Series Data and Files";
     public string? Description => "Removes ALL DATA AND FILES relating to the series. Use with caution, as you may get temp banned from AniDB if it's abused.";

--- a/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesKeepFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesKeepFilesAction.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Services.Actions.Destructive.Series;
+
+/// <summary>
+///   Delete the series from Shoko but keep the files on disk.
+/// </summary>
+internal sealed class DeleteSeriesKeepFilesAction(
+    AnimeSeriesRepository seriesRepo,
+    AnimeSeriesService seriesService
+) : IExecutableSeriesAction
+{
+    public string Name => "Delete Series - Keep Files";
+    public string? Description => "Deletes the series from Shoko but does not delete the files. Cached AniDB data is preserved.";
+    public ActionCategory Category => ActionCategory.Destructive;
+    public bool RequiresConfirmation => true;
+
+    public async Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        var animeSeries = seriesRepo.GetByAnimeID(series.AnidbAnimeID);
+        if (animeSeries is null) return;
+        await seriesService.DeleteSeries(animeSeries, false, true, false);
+    }
+}

--- a/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesKeepFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesKeepFilesAction.cs
@@ -14,7 +14,7 @@ namespace Shoko.Server.Services.Actions.Destructive.Series;
 internal sealed class DeleteSeriesKeepFilesAction(
     AnimeSeriesRepository seriesRepo,
     AnimeSeriesService seriesService
-) : IExecutableSeriesAction
+) : IExecutableSeriesSystemAction
 {
     public string Name => "Delete Series - Keep Files";
     public string? Description => "Deletes the series from Shoko but does not delete the files. Cached AniDB data is preserved.";

--- a/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesKeepFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesKeepFilesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Destructive.Series;
 /// <summary>
 ///   Delete the series from Shoko but keep the files on disk.
 /// </summary>
-internal sealed class DeleteSeriesKeepFilesAction(
+public sealed class DeleteSeriesKeepFilesAction(
     AnimeSeriesRepository seriesRepo,
     AnimeSeriesService seriesService
 ) : IExecutableSeriesSystemAction

--- a/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesRemoveFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesRemoveFilesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Destructive.Series;
 /// <summary>
 ///   Delete the series along with its files from disk.
 /// </summary>
-internal sealed class DeleteSeriesRemoveFilesAction(
+public sealed class DeleteSeriesRemoveFilesAction(
     AnimeSeriesRepository seriesRepo,
     AnimeSeriesService seriesService
 ) : IExecutableSeriesSystemAction

--- a/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesRemoveFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesRemoveFilesAction.cs
@@ -14,7 +14,7 @@ namespace Shoko.Server.Services.Actions.Destructive.Series;
 internal sealed class DeleteSeriesRemoveFilesAction(
     AnimeSeriesRepository seriesRepo,
     AnimeSeriesService seriesService
-) : IExecutableSeriesAction
+) : IExecutableSeriesSystemAction
 {
     public string Name => "Delete Series - Remove Files";
     public string? Description => "Deletes the series from Shoko along with the files.";

--- a/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesRemoveFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Destructive/Series/DeleteSeriesRemoveFilesAction.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Services.Actions.Destructive.Series;
+
+/// <summary>
+///   Delete the series along with its files from disk.
+/// </summary>
+internal sealed class DeleteSeriesRemoveFilesAction(
+    AnimeSeriesRepository seriesRepo,
+    AnimeSeriesService seriesService
+) : IExecutableSeriesAction
+{
+    public string Name => "Delete Series - Remove Files";
+    public string? Description => "Deletes the series from Shoko along with the files.";
+    public ActionCategory Category => ActionCategory.Destructive;
+    public bool RequiresConfirmation => true;
+
+    public async Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        var animeSeries = seriesRepo.GetByAnimeID(series.AnidbAnimeID);
+        if (animeSeries is null) return;
+        await seriesService.DeleteSeries(animeSeries, true, true, false);
+    }
+}

--- a/Shoko.Server/Services/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Images;
 /// <summary>
 ///   Purge all unused TMDB images that are not linked to any entity.
 /// </summary>
-internal sealed class PurgeAllUnusedTmdbImagesAction(IImageManager imageManager) : IExecutableGlobalSystemAction
+public sealed class PurgeAllUnusedTmdbImagesAction(IImageManager imageManager) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge Unused TMDB Images";
     public string? Description => "Remove all TMDB images that are not linked to any entity.";

--- a/Shoko.Server/Services/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Enums;
+using Shoko.Abstractions.Metadata.Services;
+
+namespace Shoko.Server.Services.Actions.Images;
+
+/// <summary>
+///   Purge all unused TMDB images that are not linked to any entity.
+/// </summary>
+internal sealed class PurgeAllUnusedTmdbImagesAction(IImageManager imageManager) : IExecutableGlobalAction
+{
+    public string Name => "Purge Unused TMDB Images";
+    public string? Description => "Remove all TMDB images that are not linked to any entity.";
+    public ActionCategory Category => ActionCategory.Images;
+    public bool RequiresConfirmation => true;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await imageManager.SchedulePurgeOfOrphanedImages(0, DataSource.TMDB);
+    }
+}

--- a/Shoko.Server/Services/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Images;
 /// <summary>
 ///   Purge all unused TMDB images that are not linked to any entity.
 /// </summary>
-internal sealed class PurgeAllUnusedTmdbImagesAction(IImageManager imageManager) : IExecutableGlobalAction
+internal sealed class PurgeAllUnusedTmdbImagesAction(IImageManager imageManager) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge Unused TMDB Images";
     public string? Description => "Remove all TMDB images that are not linked to any entity.";

--- a/Shoko.Server/Services/Actions/Images/UpdateAllImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Images/UpdateAllImagesAction.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Services;
+
+namespace Shoko.Server.Services.Actions.Images;
+
+/// <summary>
+///   Schedule auto-downloads for all missing images across all entities.
+/// </summary>
+internal sealed class UpdateAllImagesAction(IImageManager imageManager) : IExecutableGlobalAction
+{
+    public string Name => "Update All Images";
+    public string? Description => "Schedule downloads for all missing images across all entities.";
+    public ActionCategory Category => ActionCategory.Images;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await imageManager.ScheduleAllAutoDownloads();
+    }
+}

--- a/Shoko.Server/Services/Actions/Images/UpdateAllImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Images/UpdateAllImagesAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Images;
 /// <summary>
 ///   Schedule auto-downloads for all missing images across all entities.
 /// </summary>
-internal sealed class UpdateAllImagesAction(IImageManager imageManager) : IExecutableGlobalSystemAction
+public sealed class UpdateAllImagesAction(IImageManager imageManager) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All Images";
     public string? Description => "Schedule downloads for all missing images across all entities.";

--- a/Shoko.Server/Services/Actions/Images/UpdateAllImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Images/UpdateAllImagesAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Images;
 /// <summary>
 ///   Schedule auto-downloads for all missing images across all entities.
 /// </summary>
-internal sealed class UpdateAllImagesAction(IImageManager imageManager) : IExecutableGlobalAction
+internal sealed class UpdateAllImagesAction(IImageManager imageManager) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All Images";
     public string? Description => "Schedule downloads for all missing images across all entities.";

--- a/Shoko.Server/Services/Actions/Images/ValidateAllImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Images/ValidateAllImagesAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Images;
 /// <summary>
 ///   Validate all images and re-download any that are corrupted or invalid.
 /// </summary>
-internal sealed class ValidateAllImagesAction(IImageManager imageManager) : IExecutableGlobalSystemAction
+public sealed class ValidateAllImagesAction(IImageManager imageManager) : IExecutableGlobalSystemAction
 {
     public string Name => "Validate All Images";
     public string? Description => "Validate all images and re-download any that are corrupted or invalid.";

--- a/Shoko.Server/Services/Actions/Images/ValidateAllImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Images/ValidateAllImagesAction.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Services;
+
+namespace Shoko.Server.Services.Actions.Images;
+
+/// <summary>
+///   Validate all images and re-download any that are corrupted or invalid.
+/// </summary>
+internal sealed class ValidateAllImagesAction(IImageManager imageManager) : IExecutableGlobalAction
+{
+    public string Name => "Validate All Images";
+    public string? Description => "Validate all images and re-download any that are corrupted or invalid.";
+    public ActionCategory Category => ActionCategory.Images;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await imageManager.ScheduleValidateAllImages(prioritize: true);
+    }
+}

--- a/Shoko.Server/Services/Actions/Images/ValidateAllImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Images/ValidateAllImagesAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Images;
 /// <summary>
 ///   Validate all images and re-download any that are corrupted or invalid.
 /// </summary>
-internal sealed class ValidateAllImagesAction(IImageManager imageManager) : IExecutableGlobalAction
+internal sealed class ValidateAllImagesAction(IImageManager imageManager) : IExecutableGlobalSystemAction
 {
     public string Name => "Validate All Images";
     public string? Description => "Validate all images and re-download any that are corrupted or invalid.";

--- a/Shoko.Server/Services/Actions/Import/Group/RehashGroupFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Group/RehashGroupFilesAction.cs
@@ -14,7 +14,7 @@ namespace Shoko.Server.Services.Actions.Import.Group;
 /// <summary>
 ///   Rehash all files for the group.
 /// </summary>
-internal sealed class RehashGroupFilesAction(
+public sealed class RehashGroupFilesAction(
     AnimeGroupRepository groupRepo,
     IQueueScheduler scheduler
 ) : IExecutableGroupSystemAction

--- a/Shoko.Server/Services/Actions/Import/Group/RehashGroupFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Group/RehashGroupFilesAction.cs
@@ -17,7 +17,7 @@ namespace Shoko.Server.Services.Actions.Import.Group;
 internal sealed class RehashGroupFilesAction(
     AnimeGroupRepository groupRepo,
     IQueueScheduler scheduler
-) : IExecutableGroupAction
+) : IExecutableGroupSystemAction
 {
     public string Name => "Rehash Files";
     public string? Description => "Rehashes every file associated with the group.";

--- a/Shoko.Server/Services/Actions/Import/Group/RehashGroupFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Group/RehashGroupFilesAction.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.QueueProcessor.Scheduling;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Scheduling.Jobs.Shoko;
+
+namespace Shoko.Server.Services.Actions.Import.Group;
+
+/// <summary>
+///   Rehash all files for the group.
+/// </summary>
+internal sealed class RehashGroupFilesAction(
+    AnimeGroupRepository groupRepo,
+    IQueueScheduler scheduler
+) : IExecutableGroupAction
+{
+    public string Name => "Rehash Files";
+    public string? Description => "Rehashes every file associated with the group.";
+    public ActionCategory Category => ActionCategory.Import;
+
+    public async Task Execute(IShokoGroup group, CancellationToken cancellationToken = default)
+    {
+        var animeGroup = groupRepo.GetByID(group.ID);
+        if (animeGroup is null) return;
+
+        var files = animeGroup.AllSeries
+            .SelectMany(s => s.VideoLocals)
+            .DistinctBy(v => v.VideoLocalID)
+            .ToList();
+
+        foreach (var file in files)
+        {
+            var filePath = file.FirstResolvedPlace?.Path;
+            if (string.IsNullOrEmpty(filePath))
+                continue;
+            await scheduler.StartJob<HashFileJob>(c => (c.FilePath, c.ForceHash) = (filePath, true), prioritize: true);
+        }
+    }
+}

--- a/Shoko.Server/Services/Actions/Import/Group/RelocateGroupFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Group/RelocateGroupFilesAction.cs
@@ -12,7 +12,7 @@ namespace Shoko.Server.Services.Actions.Import.Group;
 /// <summary>
 ///   Relocate all files for the group.
 /// </summary>
-internal sealed class RelocateGroupFilesAction(
+public sealed class RelocateGroupFilesAction(
     AnimeGroupRepository groupRepo,
     IVideoRelocationService relocationService
 ) : IExecutableGroupSystemAction

--- a/Shoko.Server/Services/Actions/Import/Group/RelocateGroupFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Group/RelocateGroupFilesAction.cs
@@ -15,7 +15,7 @@ namespace Shoko.Server.Services.Actions.Import.Group;
 internal sealed class RelocateGroupFilesAction(
     AnimeGroupRepository groupRepo,
     IVideoRelocationService relocationService
-) : IExecutableGroupAction
+) : IExecutableGroupSystemAction
 {
     public string Name => "Relocate Files";
     public string? Description => "Renames and/or moves every file associated with the group.";

--- a/Shoko.Server/Services/Actions/Import/Group/RelocateGroupFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Group/RelocateGroupFilesAction.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Abstractions.Video.Services;
+using Shoko.Server.Repositories.Cached;
+
+namespace Shoko.Server.Services.Actions.Import.Group;
+
+/// <summary>
+///   Relocate all files for the group.
+/// </summary>
+internal sealed class RelocateGroupFilesAction(
+    AnimeGroupRepository groupRepo,
+    IVideoRelocationService relocationService
+) : IExecutableGroupAction
+{
+    public string Name => "Relocate Files";
+    public string? Description => "Renames and/or moves every file associated with the group.";
+    public ActionCategory Category => ActionCategory.Import;
+
+    public async Task Execute(IShokoGroup group, CancellationToken cancellationToken = default)
+    {
+        var animeGroup = groupRepo.GetByID(group.ID);
+        if (animeGroup is null) return;
+
+        var files = animeGroup.AllSeries
+            .SelectMany(s => s.VideoLocals)
+            .DistinctBy(v => v.VideoLocalID)
+            .ToList();
+
+        foreach (var file in files)
+            await relocationService.ScheduleAutoRelocationForVideo(file);
+    }
+}

--- a/Shoko.Server/Services/Actions/Import/Group/RescanGroupFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Group/RescanGroupFilesAction.cs
@@ -12,7 +12,7 @@ namespace Shoko.Server.Services.Actions.Import.Group;
 /// <summary>
 ///   Rescan all files for the group, re-running release matching.
 /// </summary>
-internal sealed class RescanGroupFilesAction(
+public sealed class RescanGroupFilesAction(
     AnimeGroupRepository groupRepo,
     IVideoReleaseService releaseService
 ) : IExecutableGroupSystemAction

--- a/Shoko.Server/Services/Actions/Import/Group/RescanGroupFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Group/RescanGroupFilesAction.cs
@@ -15,7 +15,7 @@ namespace Shoko.Server.Services.Actions.Import.Group;
 internal sealed class RescanGroupFilesAction(
     AnimeGroupRepository groupRepo,
     IVideoReleaseService releaseService
-) : IExecutableGroupAction
+) : IExecutableGroupSystemAction
 {
     public string Name => "Rescan Files";
     public string? Description => "Rescans every file associated with the group.";

--- a/Shoko.Server/Services/Actions/Import/Group/RescanGroupFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Group/RescanGroupFilesAction.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Abstractions.Video.Services;
+using Shoko.Server.Repositories.Cached;
+
+namespace Shoko.Server.Services.Actions.Import.Group;
+
+/// <summary>
+///   Rescan all files for the group, re-running release matching.
+/// </summary>
+internal sealed class RescanGroupFilesAction(
+    AnimeGroupRepository groupRepo,
+    IVideoReleaseService releaseService
+) : IExecutableGroupAction
+{
+    public string Name => "Rescan Files";
+    public string? Description => "Rescans every file associated with the group.";
+    public ActionCategory Category => ActionCategory.Import;
+
+    public async Task Execute(IShokoGroup group, CancellationToken cancellationToken = default)
+    {
+        var animeGroup = groupRepo.GetByID(group.ID);
+        if (animeGroup is null) return;
+
+        var files = animeGroup.AllSeries
+            .SelectMany(s => s.VideoLocals)
+            .DistinctBy(v => v.VideoLocalID)
+            .ToList();
+
+        foreach (var file in files)
+            await releaseService.ScheduleFindReleaseForVideo(file, force: true);
+    }
+}

--- a/Shoko.Server/Services/Actions/Import/ImportNewFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/ImportNewFilesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Import;
 ///   Scan managed folders for new files and import them without running the
 ///   full metadata/image pipeline.
 /// </summary>
-internal sealed class ImportNewFilesAction(IVideoService videoService) : IExecutableGlobalSystemAction
+public sealed class ImportNewFilesAction(IVideoService videoService) : IExecutableGlobalSystemAction
 {
     public string Name => "Import New Files";
     public string? Description => "Scan managed folders for new files, hash them, and find releases.";

--- a/Shoko.Server/Services/Actions/Import/ImportNewFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/ImportNewFilesAction.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Video.Services;
+
+namespace Shoko.Server.Services.Actions.Import;
+
+/// <summary>
+///   Scan managed folders for new files and import them without running the
+///   full metadata/image pipeline.
+/// </summary>
+internal sealed class ImportNewFilesAction(IVideoService videoService) : IExecutableGlobalAction
+{
+    public string Name => "Import New Files";
+    public string? Description => "Scan managed folders for new files, hash them, and find releases.";
+    public ActionCategory Category => ActionCategory.Import;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await videoService.ScheduleScanForManagedFolders(onlyNewFiles: true);
+    }
+}

--- a/Shoko.Server/Services/Actions/Import/ImportNewFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/ImportNewFilesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Import;
 ///   Scan managed folders for new files and import them without running the
 ///   full metadata/image pipeline.
 /// </summary>
-internal sealed class ImportNewFilesAction(IVideoService videoService) : IExecutableGlobalAction
+internal sealed class ImportNewFilesAction(IVideoService videoService) : IExecutableGlobalSystemAction
 {
     public string Name => "Import New Files";
     public string? Description => "Scan managed folders for new files, hash them, and find releases.";

--- a/Shoko.Server/Services/Actions/Import/RemoveMissingFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/RemoveMissingFilesAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.Import;
 /// <summary>
 ///   Remove database records for files that are no longer accessible on disk.
 /// </summary>
-internal sealed class RemoveMissingFilesAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class RemoveMissingFilesAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Remove Missing Files";
     public string? Description => "Remove database records for files that are no longer accessible on disk.";

--- a/Shoko.Server/Services/Actions/Import/RemoveMissingFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/RemoveMissingFilesAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.Import;
 /// <summary>
 ///   Remove database records for files that are no longer accessible on disk.
 /// </summary>
-internal sealed class RemoveMissingFilesAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class RemoveMissingFilesAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Remove Missing Files";
     public string? Description => "Remove database records for files that are no longer accessible on disk.";

--- a/Shoko.Server/Services/Actions/Import/RemoveMissingFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/RemoveMissingFilesAction.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.Import;
+
+/// <summary>
+///   Remove database records for files that are no longer accessible on disk.
+/// </summary>
+internal sealed class RemoveMissingFilesAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Remove Missing Files";
+    public string? Description => "Remove database records for files that are no longer accessible on disk.";
+    public ActionCategory Category => ActionCategory.Import;
+    public bool RequiresConfirmation => true;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await actionService.RemoveRecordsWithoutPhysicalFiles(true);
+    }
+}

--- a/Shoko.Server/Services/Actions/Import/RunImportAction.cs
+++ b/Shoko.Server/Services/Actions/Import/RunImportAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.Actions;
+
+namespace Shoko.Server.Services.Actions.Import;
+
+/// <summary>
+///   Run the full import pipeline: scan for new files, hash them, find releases,
+///   update metadata, and download missing images.
+/// </summary>
+internal sealed class RunImportAction(IJobFactory jobFactory) : IExecutableGlobalAction
+{
+    public string Name => "Run Import";
+    public string? Description => "Check for new files, hash them, scan for metadata matches, and download missing images.";
+    public ActionCategory Category => ActionCategory.Import;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await jobFactory.Execute<ImportJob>();
+    }
+}

--- a/Shoko.Server/Services/Actions/Import/RunImportAction.cs
+++ b/Shoko.Server/Services/Actions/Import/RunImportAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Import;
 ///   Run the full import pipeline: scan for new files, hash them, find releases,
 ///   update metadata, and download missing images.
 /// </summary>
-internal sealed class RunImportAction(IJobFactory jobFactory) : IExecutableGlobalAction
+internal sealed class RunImportAction(IJobFactory jobFactory) : IExecutableGlobalSystemAction
 {
     public string Name => "Run Import";
     public string? Description => "Check for new files, hash them, scan for metadata matches, and download missing images.";

--- a/Shoko.Server/Services/Actions/Import/RunImportAction.cs
+++ b/Shoko.Server/Services/Actions/Import/RunImportAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Import;
 ///   Run the full import pipeline: scan for new files, hash them, find releases,
 ///   update metadata, and download missing images.
 /// </summary>
-internal sealed class RunImportAction(IJobFactory jobFactory) : IExecutableGlobalSystemAction
+public sealed class RunImportAction(IJobFactory jobFactory) : IExecutableGlobalSystemAction
 {
     public string Name => "Run Import";
     public string? Description => "Check for new files, hash them, scan for metadata matches, and download missing images.";

--- a/Shoko.Server/Services/Actions/Import/Series/RehashSeriesFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Series/RehashSeriesFilesAction.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.QueueProcessor.Scheduling;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Scheduling.Jobs.Shoko;
+
+namespace Shoko.Server.Services.Actions.Import.Series;
+
+/// <summary>
+///   Rehash all files for the series.
+/// </summary>
+internal sealed class RehashSeriesFilesAction(
+    AnimeSeriesRepository seriesRepo,
+    IQueueScheduler scheduler
+) : IExecutableSeriesAction
+{
+    public string Name => "Rehash Files";
+    public string? Description => "Rehashes every file associated with the series.";
+    public ActionCategory Category => ActionCategory.Import;
+
+    public async Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        var animeSeries = seriesRepo.GetByAnimeID(series.AnidbAnimeID);
+        if (animeSeries is null) return;
+
+        foreach (var file in animeSeries.VideoLocals)
+        {
+            var filePath = file.FirstResolvedPlace?.Path;
+            if (string.IsNullOrEmpty(filePath))
+                continue;
+            await scheduler.StartJob<HashFileJob>(c => (c.FilePath, c.ForceHash) = (filePath, true), prioritize: true);
+        }
+    }
+}

--- a/Shoko.Server/Services/Actions/Import/Series/RehashSeriesFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Series/RehashSeriesFilesAction.cs
@@ -16,7 +16,7 @@ namespace Shoko.Server.Services.Actions.Import.Series;
 internal sealed class RehashSeriesFilesAction(
     AnimeSeriesRepository seriesRepo,
     IQueueScheduler scheduler
-) : IExecutableSeriesAction
+) : IExecutableSeriesSystemAction
 {
     public string Name => "Rehash Files";
     public string? Description => "Rehashes every file associated with the series.";

--- a/Shoko.Server/Services/Actions/Import/Series/RehashSeriesFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Series/RehashSeriesFilesAction.cs
@@ -13,7 +13,7 @@ namespace Shoko.Server.Services.Actions.Import.Series;
 /// <summary>
 ///   Rehash all files for the series.
 /// </summary>
-internal sealed class RehashSeriesFilesAction(
+public sealed class RehashSeriesFilesAction(
     AnimeSeriesRepository seriesRepo,
     IQueueScheduler scheduler
 ) : IExecutableSeriesSystemAction

--- a/Shoko.Server/Services/Actions/Import/Series/RelocateSeriesFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Series/RelocateSeriesFilesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Import.Series;
 /// <summary>
 ///   Relocate all files for the series.
 /// </summary>
-internal sealed class RelocateSeriesFilesAction(
+public sealed class RelocateSeriesFilesAction(
     AnimeSeriesRepository seriesRepo,
     IVideoRelocationService relocationService
 ) : IExecutableSeriesSystemAction

--- a/Shoko.Server/Services/Actions/Import/Series/RelocateSeriesFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Series/RelocateSeriesFilesAction.cs
@@ -14,7 +14,7 @@ namespace Shoko.Server.Services.Actions.Import.Series;
 internal sealed class RelocateSeriesFilesAction(
     AnimeSeriesRepository seriesRepo,
     IVideoRelocationService relocationService
-) : IExecutableSeriesAction
+) : IExecutableSeriesSystemAction
 {
     public string Name => "Relocate Files";
     public string? Description => "Renames and/or moves every file associated with the series.";

--- a/Shoko.Server/Services/Actions/Import/Series/RelocateSeriesFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Series/RelocateSeriesFilesAction.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Abstractions.Video.Services;
+using Shoko.Server.Repositories.Cached;
+
+namespace Shoko.Server.Services.Actions.Import.Series;
+
+/// <summary>
+///   Relocate all files for the series.
+/// </summary>
+internal sealed class RelocateSeriesFilesAction(
+    AnimeSeriesRepository seriesRepo,
+    IVideoRelocationService relocationService
+) : IExecutableSeriesAction
+{
+    public string Name => "Relocate Files";
+    public string? Description => "Renames and/or moves every file associated with the series.";
+    public ActionCategory Category => ActionCategory.Import;
+
+    public async Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        var animeSeries = seriesRepo.GetByAnimeID(series.AnidbAnimeID);
+        if (animeSeries is null) return;
+
+        foreach (var file in animeSeries.VideoLocals)
+            await relocationService.ScheduleAutoRelocationForVideo(file);
+    }
+}

--- a/Shoko.Server/Services/Actions/Import/Series/RescanSeriesFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Series/RescanSeriesFilesAction.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Abstractions.Video.Services;
+using Shoko.Server.Repositories.Cached;
+
+namespace Shoko.Server.Services.Actions.Import.Series;
+
+/// <summary>
+///   Rescan all files for the series, re-running release matching.
+/// </summary>
+internal sealed class RescanSeriesFilesAction(
+    AnimeSeriesRepository seriesRepo,
+    IVideoReleaseService releaseService
+) : IExecutableSeriesAction
+{
+    public string Name => "Rescan Files";
+    public string? Description => "Rescans every file associated with the series.";
+    public ActionCategory Category => ActionCategory.Import;
+
+    public async Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        var animeSeries = seriesRepo.GetByAnimeID(series.AnidbAnimeID);
+        if (animeSeries is null) return;
+
+        foreach (var file in animeSeries.VideoLocals)
+            await releaseService.ScheduleFindReleaseForVideo(file, force: true);
+    }
+}

--- a/Shoko.Server/Services/Actions/Import/Series/RescanSeriesFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Series/RescanSeriesFilesAction.cs
@@ -14,7 +14,7 @@ namespace Shoko.Server.Services.Actions.Import.Series;
 internal sealed class RescanSeriesFilesAction(
     AnimeSeriesRepository seriesRepo,
     IVideoReleaseService releaseService
-) : IExecutableSeriesAction
+) : IExecutableSeriesSystemAction
 {
     public string Name => "Rescan Files";
     public string? Description => "Rescans every file associated with the series.";

--- a/Shoko.Server/Services/Actions/Import/Series/RescanSeriesFilesAction.cs
+++ b/Shoko.Server/Services/Actions/Import/Series/RescanSeriesFilesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Import.Series;
 /// <summary>
 ///   Rescan all files for the series, re-running release matching.
 /// </summary>
-internal sealed class RescanSeriesFilesAction(
+public sealed class RescanSeriesFilesAction(
     AnimeSeriesRepository seriesRepo,
     IVideoReleaseService releaseService
 ) : IExecutableSeriesSystemAction

--- a/Shoko.Server/Services/Actions/Maintenance/CreateMissingSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/CreateMissingSeriesAction.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.Maintenance;
+
+/// <summary>
+///   Create anime series entries for files that have release info but no
+///   corresponding series.
+/// </summary>
+internal sealed class CreateMissingSeriesAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Create Missing Series";
+    public string? Description => "Create series entries for files that have release info but no corresponding series.";
+    public ActionCategory Category => ActionCategory.Maintenance;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await actionService.CreateMissingSeries();
+    }
+}

--- a/Shoko.Server/Services/Actions/Maintenance/CreateMissingSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/CreateMissingSeriesAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 ///   Create anime series entries for files that have release info but no
 ///   corresponding series.
 /// </summary>
-internal sealed class CreateMissingSeriesAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class CreateMissingSeriesAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Create Missing Series";
     public string? Description => "Create series entries for files that have release info but no corresponding series.";

--- a/Shoko.Server/Services/Actions/Maintenance/CreateMissingSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/CreateMissingSeriesAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 ///   Create anime series entries for files that have release info but no
 ///   corresponding series.
 /// </summary>
-internal sealed class CreateMissingSeriesAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class CreateMissingSeriesAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Create Missing Series";
     public string? Description => "Create series entries for files that have release info but no corresponding series.";

--- a/Shoko.Server/Services/Actions/Maintenance/PlexSyncAllAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/PlexSyncAllAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 /// <summary>
 ///   Sync watch states with Plex for all users with a Plex token.
 /// </summary>
-internal sealed class PlexSyncAllAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class PlexSyncAllAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Plex Sync All";
     public string? Description => "Sync watch states with Plex for all users with a configured Plex token.";

--- a/Shoko.Server/Services/Actions/Maintenance/PlexSyncAllAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/PlexSyncAllAction.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.Maintenance;
+
+/// <summary>
+///   Sync watch states with Plex for all users with a Plex token.
+/// </summary>
+internal sealed class PlexSyncAllAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Plex Sync All";
+    public string? Description => "Sync watch states with Plex for all users with a configured Plex token.";
+    public ActionCategory Category => ActionCategory.Sync;
+
+    public Task Execute(CancellationToken cancellationToken = default)
+        => actionService.PlexSyncAll();
+}

--- a/Shoko.Server/Services/Actions/Maintenance/PlexSyncAllAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/PlexSyncAllAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 /// <summary>
 ///   Sync watch states with Plex for all users with a Plex token.
 /// </summary>
-internal sealed class PlexSyncAllAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class PlexSyncAllAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Plex Sync All";
     public string? Description => "Sync watch states with Plex for all users with a configured Plex token.";

--- a/Shoko.Server/Services/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Video.Services;
+
+namespace Shoko.Server.Services.Actions.Maintenance;
+
+/// <summary>
+///   Purge all unused (unlinked) releases from the database, optionally
+///   filtered by provider.
+/// </summary>
+internal sealed class PurgeAllUnusedReleasesAction(IVideoReleaseService releaseService) : IExecutableGlobalAction
+{
+    public string Name => "Purge Unused Releases";
+    public string? Description => "Remove all unused (unlinked) releases from the database, optionally filtered by provider.";
+    public ActionCategory Category => ActionCategory.Destructive;
+    public bool RequiresConfirmation => true;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await releaseService.PurgeUnusedReleases();
+    }
+}

--- a/Shoko.Server/Services/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 ///   Purge all unused (unlinked) releases from the database, optionally
 ///   filtered by provider.
 /// </summary>
-internal sealed class PurgeAllUnusedReleasesAction(IVideoReleaseService releaseService) : IExecutableGlobalAction
+internal sealed class PurgeAllUnusedReleasesAction(IVideoReleaseService releaseService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge Unused Releases";
     public string? Description => "Remove all unused (unlinked) releases from the database, optionally filtered by provider.";

--- a/Shoko.Server/Services/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 ///   Purge all unused (unlinked) releases from the database, optionally
 ///   filtered by provider.
 /// </summary>
-internal sealed class PurgeAllUnusedReleasesAction(IVideoReleaseService releaseService) : IExecutableGlobalSystemAction
+public sealed class PurgeAllUnusedReleasesAction(IVideoReleaseService releaseService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge Unused Releases";
     public string? Description => "Remove all unused (unlinked) releases from the database, optionally filtered by provider.";

--- a/Shoko.Server/Services/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 ///   Purge all used (linked) releases from the database, optionally filtered
 ///   by provider.
 /// </summary>
-internal sealed class PurgeAllUsedReleasesAction(IVideoReleaseService releaseService) : IExecutableGlobalAction
+internal sealed class PurgeAllUsedReleasesAction(IVideoReleaseService releaseService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge Used Releases";
     public string? Description => "Remove all used (linked) releases from the database, optionally filtered by provider.";

--- a/Shoko.Server/Services/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 ///   Purge all used (linked) releases from the database, optionally filtered
 ///   by provider.
 /// </summary>
-internal sealed class PurgeAllUsedReleasesAction(IVideoReleaseService releaseService) : IExecutableGlobalSystemAction
+public sealed class PurgeAllUsedReleasesAction(IVideoReleaseService releaseService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge Used Releases";
     public string? Description => "Remove all used (linked) releases from the database, optionally filtered by provider.";

--- a/Shoko.Server/Services/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Video.Services;
+
+namespace Shoko.Server.Services.Actions.Maintenance;
+
+/// <summary>
+///   Purge all used (linked) releases from the database, optionally filtered
+///   by provider.
+/// </summary>
+internal sealed class PurgeAllUsedReleasesAction(IVideoReleaseService releaseService) : IExecutableGlobalAction
+{
+    public string Name => "Purge Used Releases";
+    public string? Description => "Remove all used (linked) releases from the database, optionally filtered by provider.";
+    public ActionCategory Category => ActionCategory.Destructive;
+    public bool RequiresConfirmation => true;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await releaseService.PurgeUsedReleases();
+    }
+}

--- a/Shoko.Server/Services/Actions/Maintenance/RecreateAllGroupsAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/RecreateAllGroupsAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 ///   Delete all existing groups and recreate them from scratch based on
 ///   current settings.
 /// </summary>
-internal sealed class RecreateAllGroupsAction(AnimeGroupCreator groupCreator) : IExecutableGlobalAction
+internal sealed class RecreateAllGroupsAction(AnimeGroupCreator groupCreator) : IExecutableGlobalSystemAction
 {
     public string Name => "Recreate All Groups";
     public string? Description => "Delete all groups and recreate them from scratch based on current settings.";

--- a/Shoko.Server/Services/Actions/Maintenance/RecreateAllGroupsAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/RecreateAllGroupsAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Server.Tasks;
+
+namespace Shoko.Server.Services.Actions.Maintenance;
+
+/// <summary>
+///   Delete all existing groups and recreate them from scratch based on
+///   current settings.
+/// </summary>
+internal sealed class RecreateAllGroupsAction(AnimeGroupCreator groupCreator) : IExecutableGlobalAction
+{
+    public string Name => "Recreate All Groups";
+    public string? Description => "Delete all groups and recreate them from scratch based on current settings.";
+    public ActionCategory Category => ActionCategory.Maintenance;
+    public bool RequiresConfirmation => true;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await groupCreator.RecreateAllGroups();
+    }
+}

--- a/Shoko.Server/Services/Actions/Maintenance/RecreateAllGroupsAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/RecreateAllGroupsAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 ///   Delete all existing groups and recreate them from scratch based on
 ///   current settings.
 /// </summary>
-internal sealed class RecreateAllGroupsAction(AnimeGroupCreator groupCreator) : IExecutableGlobalSystemAction
+public sealed class RecreateAllGroupsAction(AnimeGroupCreator groupCreator) : IExecutableGlobalSystemAction
 {
     public string Name => "Recreate All Groups";
     public string? Description => "Delete all groups and recreate them from scratch based on current settings.";

--- a/Shoko.Server/Services/Actions/Maintenance/RenameAllGroupsAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/RenameAllGroupsAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 ///   Rename all groups that do not have a custom name set, using the current
 ///   language preferences.
 /// </summary>
-internal sealed class RenameAllGroupsAction(IShokoGroupManager groupManager) : IExecutableGlobalAction
+internal sealed class RenameAllGroupsAction(IShokoGroupManager groupManager) : IExecutableGlobalSystemAction
 {
     public string Name => "Rename All Groups";
     public string? Description => "Rename all groups without a custom name using the current language preferences.";

--- a/Shoko.Server/Services/Actions/Maintenance/RenameAllGroupsAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/RenameAllGroupsAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Services;
+
+namespace Shoko.Server.Services.Actions.Maintenance;
+
+/// <summary>
+///   Rename all groups that do not have a custom name set, using the current
+///   language preferences.
+/// </summary>
+internal sealed class RenameAllGroupsAction(IShokoGroupManager groupManager) : IExecutableGlobalAction
+{
+    public string Name => "Rename All Groups";
+    public string? Description => "Rename all groups without a custom name using the current language preferences.";
+    public ActionCategory Category => ActionCategory.Maintenance;
+
+    public Task Execute(CancellationToken cancellationToken = default)
+    {
+        groupManager.RenameAllGroups();
+        return Task.CompletedTask;
+    }
+}

--- a/Shoko.Server/Services/Actions/Maintenance/RenameAllGroupsAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/RenameAllGroupsAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 ///   Rename all groups that do not have a custom name set, using the current
 ///   language preferences.
 /// </summary>
-internal sealed class RenameAllGroupsAction(IShokoGroupManager groupManager) : IExecutableGlobalSystemAction
+public sealed class RenameAllGroupsAction(IShokoGroupManager groupManager) : IExecutableGlobalSystemAction
 {
     public string Name => "Rename All Groups";
     public string? Description => "Rename all groups without a custom name using the current language preferences.";

--- a/Shoko.Server/Services/Actions/Maintenance/UpdateAllMediaInfoAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/UpdateAllMediaInfoAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 /// <summary>
 ///   Update media info for all files in the collection.
 /// </summary>
-internal sealed class UpdateAllMediaInfoAction(IQueueScheduler scheduler) : IExecutableGlobalAction
+internal sealed class UpdateAllMediaInfoAction(IQueueScheduler scheduler) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All Media Info";
     public string? Description => "Re-read and update media info for all files in the collection.";

--- a/Shoko.Server/Services/Actions/Maintenance/UpdateAllMediaInfoAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/UpdateAllMediaInfoAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 /// <summary>
 ///   Update media info for all files in the collection.
 /// </summary>
-internal sealed class UpdateAllMediaInfoAction(IQueueScheduler scheduler) : IExecutableGlobalSystemAction
+public sealed class UpdateAllMediaInfoAction(IQueueScheduler scheduler) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All Media Info";
     public string? Description => "Re-read and update media info for all files in the collection.";

--- a/Shoko.Server/Services/Actions/Maintenance/UpdateAllMediaInfoAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/UpdateAllMediaInfoAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.QueueProcessor.Scheduling;
+using Shoko.Server.Scheduling.Jobs.Actions;
+
+namespace Shoko.Server.Services.Actions.Maintenance;
+
+/// <summary>
+///   Update media info for all files in the collection.
+/// </summary>
+internal sealed class UpdateAllMediaInfoAction(IQueueScheduler scheduler) : IExecutableGlobalAction
+{
+    public string Name => "Update All Media Info";
+    public string? Description => "Re-read and update media info for all files in the collection.";
+    public ActionCategory Category => ActionCategory.Maintenance;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await scheduler.StartJob<MediaInfoAllFilesJob>();
+    }
+}

--- a/Shoko.Server/Services/Actions/Maintenance/UpdateSeriesStatsAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/UpdateSeriesStatsAction.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.Maintenance;
+
+/// <summary>
+///   Recalculate stats for all series and re-apply group filters.
+/// </summary>
+internal sealed class UpdateSeriesStatsAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Update Series Stats";
+    public string? Description => "Recalculate statistics for all series and re-apply group filters.";
+    public ActionCategory Category => ActionCategory.Maintenance;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await actionService.UpdateAllStats();
+    }
+}

--- a/Shoko.Server/Services/Actions/Maintenance/UpdateSeriesStatsAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/UpdateSeriesStatsAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 /// <summary>
 ///   Recalculate stats for all series and re-apply group filters.
 /// </summary>
-internal sealed class UpdateSeriesStatsAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class UpdateSeriesStatsAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update Series Stats";
     public string? Description => "Recalculate statistics for all series and re-apply group filters.";

--- a/Shoko.Server/Services/Actions/Maintenance/UpdateSeriesStatsAction.cs
+++ b/Shoko.Server/Services/Actions/Maintenance/UpdateSeriesStatsAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.Maintenance;
 /// <summary>
 ///   Recalculate stats for all series and re-apply group filters.
 /// </summary>
-internal sealed class UpdateSeriesStatsAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class UpdateSeriesStatsAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update Series Stats";
     public string? Description => "Recalculate statistics for all series and re-apply group filters.";

--- a/Shoko.Server/Services/Actions/Tmdb/DownloadMissingTmdbPeopleAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/DownloadMissingTmdbPeopleAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Download any missing TMDB person (cast/crew) data.
 /// </summary>
-internal sealed class DownloadMissingTmdbPeopleAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
+public sealed class DownloadMissingTmdbPeopleAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Download Missing TMDB People";
     public string? Description => "Download any missing TMDB person (cast and crew) data.";

--- a/Shoko.Server/Services/Actions/Tmdb/DownloadMissingTmdbPeopleAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/DownloadMissingTmdbPeopleAction.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb;
+
+/// <summary>
+///   Download any missing TMDB person (cast/crew) data.
+/// </summary>
+internal sealed class DownloadMissingTmdbPeopleAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+{
+    public string Name => "Download Missing TMDB People";
+    public string? Description => "Download any missing TMDB person (cast and crew) data.";
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await tmdbService.RepairMissingPeople();
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/DownloadMissingTmdbPeopleAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/DownloadMissingTmdbPeopleAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Download any missing TMDB person (cast/crew) data.
 /// </summary>
-internal sealed class DownloadMissingTmdbPeopleAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+internal sealed class DownloadMissingTmdbPeopleAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Download Missing TMDB People";
     public string? Description => "Download any missing TMDB person (cast and crew) data.";

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Remove all AniDB-TMDB links and reset the auto-linking state.
 /// </summary>
-internal sealed class PurgeAllTmdbLinksAction(ActionService actionService) : IExecutableGlobalAction
+internal sealed class PurgeAllTmdbLinksAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge All TMDB Links";
     public string? Description => "Remove all AniDB-TMDB links and reset the auto-linking state.";

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+
+namespace Shoko.Server.Services.Actions.Tmdb;
+
+/// <summary>
+///   Remove all AniDB-TMDB links and reset the auto-linking state.
+/// </summary>
+internal sealed class PurgeAllTmdbLinksAction(ActionService actionService) : IExecutableGlobalAction
+{
+    public string Name => "Purge All TMDB Links";
+    public string? Description => "Remove all AniDB-TMDB links and reset the auto-linking state.";
+    public ActionCategory Category => ActionCategory.TMDB;
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(CancellationToken cancellationToken = default)
+        => actionService.PurgeAllTmdbLinks();
+}

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
@@ -8,7 +8,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Remove all AniDB-TMDB links and reset the auto-linking state.
 /// </summary>
-internal sealed class PurgeAllTmdbLinksAction(ActionService actionService) : IExecutableGlobalSystemAction
+public sealed class PurgeAllTmdbLinksAction(ActionService actionService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge All TMDB Links";
     public string? Description => "Remove all AniDB-TMDB links and reset the auto-linking state.";

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Purge all TMDB movie collections from the local database.
 /// </summary>
-internal sealed class PurgeAllTmdbMovieCollectionsAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
+public sealed class PurgeAllTmdbMovieCollectionsAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge TMDB Movie Collections";
     public string? Description => "Remove all TMDB movie collections from the local database.";

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Purge all TMDB movie collections from the local database.
 /// </summary>
-internal sealed class PurgeAllTmdbMovieCollectionsAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+internal sealed class PurgeAllTmdbMovieCollectionsAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge TMDB Movie Collections";
     public string? Description => "Remove all TMDB movie collections from the local database.";

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb;
+
+/// <summary>
+///   Purge all TMDB movie collections from the local database.
+/// </summary>
+internal sealed class PurgeAllTmdbMovieCollectionsAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+{
+    public string Name => "Purge TMDB Movie Collections";
+    public string? Description => "Remove all TMDB movie collections from the local database.";
+    public ActionCategory Category => ActionCategory.TMDB;
+    public bool RequiresConfirmation => true;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await tmdbService.PurgeAllMovieCollections();
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Purge all TMDB show alternate orderings from the local database.
 /// </summary>
-internal sealed class PurgeAllTmdbShowAlternateOrderingsAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+internal sealed class PurgeAllTmdbShowAlternateOrderingsAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge TMDB Show Alternate Orderings";
     public string? Description => "Remove all TMDB show alternate orderings (episode groups) from the local database.";

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Purge all TMDB show alternate orderings from the local database.
 /// </summary>
-internal sealed class PurgeAllTmdbShowAlternateOrderingsAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
+public sealed class PurgeAllTmdbShowAlternateOrderingsAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge TMDB Show Alternate Orderings";
     public string? Description => "Remove all TMDB show alternate orderings (episode groups) from the local database.";

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb;
+
+/// <summary>
+///   Purge all TMDB show alternate orderings from the local database.
+/// </summary>
+internal sealed class PurgeAllTmdbShowAlternateOrderingsAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+{
+    public string Name => "Purge TMDB Show Alternate Orderings";
+    public string? Description => "Remove all TMDB show alternate orderings (episode groups) from the local database.";
+    public ActionCategory Category => ActionCategory.TMDB;
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(CancellationToken cancellationToken = default)
+    {
+        tmdbService.PurgeAllShowEpisodeGroups();
+        return Task.CompletedTask;
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Purge all TMDB movies that are not linked to any AniDB anime.
 /// </summary>
-internal sealed class PurgeAllUnusedTmdbMoviesAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+internal sealed class PurgeAllUnusedTmdbMoviesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge Unused TMDB Movies";
     public string? Description => "Remove all TMDB movies that are not linked to any AniDB anime.";

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Purge all TMDB movies that are not linked to any AniDB anime.
 /// </summary>
-internal sealed class PurgeAllUnusedTmdbMoviesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
+public sealed class PurgeAllUnusedTmdbMoviesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge Unused TMDB Movies";
     public string? Description => "Remove all TMDB movies that are not linked to any AniDB anime.";

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb;
+
+/// <summary>
+///   Purge all TMDB movies that are not linked to any AniDB anime.
+/// </summary>
+internal sealed class PurgeAllUnusedTmdbMoviesAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+{
+    public string Name => "Purge Unused TMDB Movies";
+    public string? Description => "Remove all TMDB movies that are not linked to any AniDB anime.";
+    public ActionCategory Category => ActionCategory.TMDB;
+    public bool RequiresConfirmation => true;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await tmdbService.PurgeAllUnusedMovies();
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Purge all TMDB shows that are not linked to any AniDB anime.
 /// </summary>
-internal sealed class PurgeAllUnusedTmdbShowsAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+internal sealed class PurgeAllUnusedTmdbShowsAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge Unused TMDB Shows";
     public string? Description => "Remove all TMDB shows that are not linked to any AniDB anime.";

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb;
+
+/// <summary>
+///   Purge all TMDB shows that are not linked to any AniDB anime.
+/// </summary>
+internal sealed class PurgeAllUnusedTmdbShowsAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+{
+    public string Name => "Purge Unused TMDB Shows";
+    public string? Description => "Remove all TMDB shows that are not linked to any AniDB anime.";
+    public ActionCategory Category => ActionCategory.TMDB;
+    public bool RequiresConfirmation => true;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await tmdbService.PurgeAllUnusedShows();
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Purge all TMDB shows that are not linked to any AniDB anime.
 /// </summary>
-internal sealed class PurgeAllUnusedTmdbShowsAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
+public sealed class PurgeAllUnusedTmdbShowsAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Purge Unused TMDB Shows";
     public string? Description => "Remove all TMDB shows that are not linked to any AniDB anime.";

--- a/Shoko.Server/Services/Actions/Tmdb/SearchForTmdbMatchesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/SearchForTmdbMatchesAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Scan for TMDB matches for all AniDB anime that are not yet linked.
 /// </summary>
-internal sealed class SearchForTmdbMatchesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
+public sealed class SearchForTmdbMatchesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Search for TMDB Matches";
     public string? Description => "Scan for TMDB show and movie matches for all unlinked AniDB anime.";

--- a/Shoko.Server/Services/Actions/Tmdb/SearchForTmdbMatchesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/SearchForTmdbMatchesAction.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 /// <summary>
 ///   Scan for TMDB matches for all AniDB anime that are not yet linked.
 /// </summary>
-internal sealed class SearchForTmdbMatchesAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+internal sealed class SearchForTmdbMatchesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Search for TMDB Matches";
     public string? Description => "Scan for TMDB show and movie matches for all unlinked AniDB anime.";

--- a/Shoko.Server/Services/Actions/Tmdb/SearchForTmdbMatchesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/SearchForTmdbMatchesAction.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb;
+
+/// <summary>
+///   Scan for TMDB matches for all AniDB anime that are not yet linked.
+/// </summary>
+internal sealed class SearchForTmdbMatchesAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+{
+    public string Name => "Search for TMDB Matches";
+    public string? Description => "Scan for TMDB show and movie matches for all unlinked AniDB anime.";
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await tmdbService.ScanForMatches();
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/Series/AutoMatchTmdbEpisodesSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/AutoMatchTmdbEpisodesSeriesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Automatically match TMDB episodes for the series.
 /// </summary>
-internal sealed class AutoMatchTmdbEpisodesSeriesAction(TmdbLinkingService linkingService) : IExecutableSeriesSystemAction
+public sealed class AutoMatchTmdbEpisodesSeriesAction(TmdbLinkingService linkingService) : IExecutableSeriesSystemAction
 {
     public string Name => "Auto-Match TMDB Episodes";
     public string? Description => "Automatically matches Shoko episodes with TMDB episodes.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/AutoMatchTmdbEpisodesSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/AutoMatchTmdbEpisodesSeriesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Automatically match TMDB episodes for the series.
 /// </summary>
-internal sealed class AutoMatchTmdbEpisodesSeriesAction(TmdbLinkingService linkingService) : IExecutableSeriesAction
+internal sealed class AutoMatchTmdbEpisodesSeriesAction(TmdbLinkingService linkingService) : IExecutableSeriesSystemAction
 {
     public string Name => "Auto-Match TMDB Episodes";
     public string? Description => "Automatically matches Shoko episodes with TMDB episodes.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/AutoMatchTmdbEpisodesSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/AutoMatchTmdbEpisodesSeriesAction.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb.Series;
+
+/// <summary>
+///   Automatically match TMDB episodes for the series.
+/// </summary>
+internal sealed class AutoMatchTmdbEpisodesSeriesAction(TmdbLinkingService linkingService) : IExecutableSeriesAction
+{
+    public string Name => "Auto-Match TMDB Episodes";
+    public string? Description => "Automatically matches Shoko episodes with TMDB episodes.";
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    public Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        var tmdbShowId = series.TmdbShowCrossReferences is [{ } first, ..]
+            ? first.TmdbShowID
+            : 0;
+        if (tmdbShowId is 0)
+            return Task.CompletedTask;
+
+        linkingService.MatchAnidbToTmdbEpisodes(series.AnidbAnimeID, tmdbShowId, null, useExisting: true, useExistingOtherShows: null, saveToDatabase: true);
+        return Task.CompletedTask;
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/Series/AutoSearchTmdbSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/AutoSearchTmdbSeriesAction.cs
@@ -1,0 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb.Series;
+
+/// <summary>
+///   Automatically search for a TMDB match for the series.
+/// </summary>
+internal sealed class AutoSearchTmdbSeriesAction(TmdbMetadataService tmdbService) : IExecutableSeriesAction
+{
+    public string Name => "Auto-Search TMDB Match";
+    public string? Description => "Automatically searches for a TMDB match.";
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    public Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+        => tmdbService.ScheduleSearchForMatch(series.AnidbAnimeID, false);
+}

--- a/Shoko.Server/Services/Actions/Tmdb/Series/AutoSearchTmdbSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/AutoSearchTmdbSeriesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Automatically search for a TMDB match for the series.
 /// </summary>
-internal sealed class AutoSearchTmdbSeriesAction(TmdbMetadataService tmdbService) : IExecutableSeriesAction
+internal sealed class AutoSearchTmdbSeriesAction(TmdbMetadataService tmdbService) : IExecutableSeriesSystemAction
 {
     public string Name => "Auto-Search TMDB Match";
     public string? Description => "Automatically searches for a TMDB match.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/AutoSearchTmdbSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/AutoSearchTmdbSeriesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Automatically search for a TMDB match for the series.
 /// </summary>
-internal sealed class AutoSearchTmdbSeriesAction(TmdbMetadataService tmdbService) : IExecutableSeriesSystemAction
+public sealed class AutoSearchTmdbSeriesAction(TmdbMetadataService tmdbService) : IExecutableSeriesSystemAction
 {
     public string Name => "Auto-Search TMDB Match";
     public string? Description => "Automatically searches for a TMDB match.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/DownloadTmdbMovieImagesSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/DownloadTmdbMovieImagesSeriesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Download images for all TMDB movies linked to the series.
 /// </summary>
-internal sealed class DownloadTmdbMovieImagesSeriesAction(IJobFactory jobFactory) : IExecutableSeriesSystemAction
+public sealed class DownloadTmdbMovieImagesSeriesAction(IJobFactory jobFactory) : IExecutableSeriesSystemAction
 {
     public string Name => "Download TMDB Movie Images";
     public string? Description => "Download any missing images for linked TMDB movies.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/DownloadTmdbMovieImagesSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/DownloadTmdbMovieImagesSeriesAction.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb.Series;
+
+/// <summary>
+///   Download images for all TMDB movies linked to the series.
+/// </summary>
+internal sealed class DownloadTmdbMovieImagesSeriesAction(IJobFactory jobFactory) : IExecutableSeriesAction
+{
+    public string Name => "Download TMDB Movie Images";
+    public string? Description => "Download any missing images for linked TMDB movies.";
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    public async Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        foreach (var xref in series.TmdbMovieCrossReferences)
+            await jobFactory.Execute<DownloadTmdbMovieImagesJob>(j =>
+            {
+                j.TmdbMovieID = xref.TmdbMovieID;
+                j.ForceDownload = false;
+            });
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/Series/DownloadTmdbMovieImagesSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/DownloadTmdbMovieImagesSeriesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Download images for all TMDB movies linked to the series.
 /// </summary>
-internal sealed class DownloadTmdbMovieImagesSeriesAction(IJobFactory jobFactory) : IExecutableSeriesAction
+internal sealed class DownloadTmdbMovieImagesSeriesAction(IJobFactory jobFactory) : IExecutableSeriesSystemAction
 {
     public string Name => "Download TMDB Movie Images";
     public string? Description => "Download any missing images for linked TMDB movies.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/RefreshTmdbMoviesSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/RefreshTmdbMoviesSeriesAction.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb.Series;
+
+/// <summary>
+///   Refresh all TMDB movies linked to the series.
+/// </summary>
+internal sealed class RefreshTmdbMoviesSeriesAction(IJobFactory jobFactory) : IExecutableSeriesAction
+{
+    public string Name => "Refresh TMDB Movies";
+    public string? Description => "Refresh all linked TMDB movie metadata.";
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    public async Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        foreach (var xref in series.TmdbMovieCrossReferences)
+            await jobFactory.Execute<UpdateTmdbMovieJob>(j =>
+            {
+                j.TmdbMovieID = xref.TmdbMovieID;
+                j.ForceRefresh = false;
+                j.DownloadImages = false;
+            });
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/Series/RefreshTmdbMoviesSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/RefreshTmdbMoviesSeriesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Refresh all TMDB movies linked to the series.
 /// </summary>
-internal sealed class RefreshTmdbMoviesSeriesAction(IJobFactory jobFactory) : IExecutableSeriesSystemAction
+public sealed class RefreshTmdbMoviesSeriesAction(IJobFactory jobFactory) : IExecutableSeriesSystemAction
 {
     public string Name => "Refresh TMDB Movies";
     public string? Description => "Refresh all linked TMDB movie metadata.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/RefreshTmdbMoviesSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/RefreshTmdbMoviesSeriesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Refresh all TMDB movies linked to the series.
 /// </summary>
-internal sealed class RefreshTmdbMoviesSeriesAction(IJobFactory jobFactory) : IExecutableSeriesAction
+internal sealed class RefreshTmdbMoviesSeriesAction(IJobFactory jobFactory) : IExecutableSeriesSystemAction
 {
     public string Name => "Refresh TMDB Movies";
     public string? Description => "Refresh all linked TMDB movie metadata.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Reset all TMDB episode mappings for the series.
 /// </summary>
-internal sealed class ResetTmdbEpisodeMappingsSeriesAction(TmdbLinkingService linkingService) : IExecutableSeriesAction
+internal sealed class ResetTmdbEpisodeMappingsSeriesAction(TmdbLinkingService linkingService) : IExecutableSeriesSystemAction
 {
     public string Name => "Reset TMDB Episode Mappings";
     public string? Description => "Reset all TMDB episode mappings for the series.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb.Series;
+
+/// <summary>
+///   Reset all TMDB episode mappings for the series.
+/// </summary>
+internal sealed class ResetTmdbEpisodeMappingsSeriesAction(TmdbLinkingService linkingService) : IExecutableSeriesAction
+{
+    public string Name => "Reset TMDB Episode Mappings";
+    public string? Description => "Reset all TMDB episode mappings for the series.";
+    public ActionCategory Category => ActionCategory.TMDB;
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        linkingService.ResetAllEpisodeLinks(series.AnidbAnimeID, true);
+        return Task.CompletedTask;
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Reset all TMDB episode mappings for the series.
 /// </summary>
-internal sealed class ResetTmdbEpisodeMappingsSeriesAction(TmdbLinkingService linkingService) : IExecutableSeriesSystemAction
+public sealed class ResetTmdbEpisodeMappingsSeriesAction(TmdbLinkingService linkingService) : IExecutableSeriesSystemAction
 {
     public string Name => "Reset TMDB Episode Mappings";
     public string? Description => "Reset all TMDB episode mappings for the series.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/UpdateTmdbImagesForceSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/UpdateTmdbImagesForceSeriesAction.cs
@@ -1,0 +1,35 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb.Series;
+
+/// <summary>
+///   Force a complete redownload of TMDB images for the series.
+/// </summary>
+internal sealed class UpdateTmdbImagesForceSeriesAction(IJobFactory jobFactory) : IExecutableSeriesAction
+{
+    public string Name => "Update TMDB Images - Force";
+    public string? Description => "Forces a complete redownload of images from TMDB.";
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    public async Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        foreach (var xref in series.TmdbShowCrossReferences)
+            await jobFactory.Execute<DownloadTmdbShowImagesJob>(j =>
+            {
+                j.TmdbShowID = xref.TmdbShowID;
+                j.ForceDownload = true;
+            });
+        foreach (var xref in series.TmdbMovieCrossReferences)
+            await jobFactory.Execute<DownloadTmdbMovieImagesJob>(j =>
+            {
+                j.TmdbMovieID = xref.TmdbMovieID;
+                j.ForceDownload = true;
+            });
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/Series/UpdateTmdbImagesForceSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/UpdateTmdbImagesForceSeriesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Force a complete redownload of TMDB images for the series.
 /// </summary>
-internal sealed class UpdateTmdbImagesForceSeriesAction(IJobFactory jobFactory) : IExecutableSeriesAction
+internal sealed class UpdateTmdbImagesForceSeriesAction(IJobFactory jobFactory) : IExecutableSeriesSystemAction
 {
     public string Name => "Update TMDB Images - Force";
     public string? Description => "Forces a complete redownload of images from TMDB.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/UpdateTmdbImagesForceSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/UpdateTmdbImagesForceSeriesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Force a complete redownload of TMDB images for the series.
 /// </summary>
-internal sealed class UpdateTmdbImagesForceSeriesAction(IJobFactory jobFactory) : IExecutableSeriesSystemAction
+public sealed class UpdateTmdbImagesForceSeriesAction(IJobFactory jobFactory) : IExecutableSeriesSystemAction
 {
     public string Name => "Update TMDB Images - Force";
     public string? Description => "Forces a complete redownload of images from TMDB.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/UpdateTmdbInfoSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/UpdateTmdbInfoSeriesAction.cs
@@ -13,7 +13,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// </summary>
 internal sealed class UpdateTmdbInfoSeriesAction(
     IJobFactory jobFactory
-) : IExecutableSeriesAction
+) : IExecutableSeriesSystemAction
 {
     public string Name => "Update TMDB Info";
     public string? Description => "Gets the latest series information from TMDB.";

--- a/Shoko.Server/Services/Actions/Tmdb/Series/UpdateTmdbInfoSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/UpdateTmdbInfoSeriesAction.cs
@@ -1,0 +1,39 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb.Series;
+
+/// <summary>
+///   Update all TMDB shows linked to the series.
+/// </summary>
+internal sealed class UpdateTmdbInfoSeriesAction(
+    IJobFactory jobFactory
+) : IExecutableSeriesAction
+{
+    public string Name => "Update TMDB Info";
+    public string? Description => "Gets the latest series information from TMDB.";
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    public async Task Execute(IShokoSeries series, CancellationToken cancellationToken = default)
+    {
+        foreach (var xref in series.TmdbShowCrossReferences)
+            await jobFactory.Execute<UpdateTmdbShowJob>(j =>
+            {
+                j.TmdbShowID = xref.TmdbShowID;
+                j.ForceRefresh = false;
+                j.DownloadImages = false;
+            });
+        foreach (var xref in series.TmdbMovieCrossReferences)
+            await jobFactory.Execute<UpdateTmdbMovieJob>(j =>
+            {
+                j.TmdbMovieID = xref.TmdbMovieID;
+                j.ForceRefresh = false;
+                j.DownloadImages = false;
+            });
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/Series/UpdateTmdbInfoSeriesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/Series/UpdateTmdbInfoSeriesAction.cs
@@ -11,7 +11,7 @@ namespace Shoko.Server.Services.Actions.Tmdb.Series;
 /// <summary>
 ///   Update all TMDB shows linked to the series.
 /// </summary>
-internal sealed class UpdateTmdbInfoSeriesAction(
+public sealed class UpdateTmdbInfoSeriesAction(
     IJobFactory jobFactory
 ) : IExecutableSeriesSystemAction
 {

--- a/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbMoviesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbMoviesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 ///   Update all TMDB movies in the local database from the remote API.
 ///   Only refreshes metadata; does not download images.
 /// </summary>
-internal sealed class UpdateAllTmdbMoviesAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+internal sealed class UpdateAllTmdbMoviesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All TMDB Movies";
     public string? Description => "Update all TMDB movie metadata in the local database without downloading images.";

--- a/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbMoviesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbMoviesAction.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb;
+
+/// <summary>
+///   Update all TMDB movies in the local database from the remote API.
+///   Only refreshes metadata; does not download images.
+/// </summary>
+internal sealed class UpdateAllTmdbMoviesAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+{
+    public string Name => "Update All TMDB Movies";
+    public string? Description => "Update all TMDB movie metadata in the local database without downloading images.";
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await tmdbService.UpdateAllMovies(true, false);
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbMoviesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbMoviesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 ///   Update all TMDB movies in the local database from the remote API.
 ///   Only refreshes metadata; does not download images.
 /// </summary>
-internal sealed class UpdateAllTmdbMoviesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
+public sealed class UpdateAllTmdbMoviesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All TMDB Movies";
     public string? Description => "Update all TMDB movie metadata in the local database without downloading images.";

--- a/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbMoviesWithImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbMoviesWithImagesAction.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb;
+
+/// <summary>
+///   Update all TMDB movies in the local database from the remote API,
+///   including downloading any missing images.
+/// </summary>
+internal sealed class UpdateAllTmdbMoviesWithImagesAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+{
+    public string Name => "Update All TMDB Movies (with Images)";
+    public string? Description => "Update all TMDB movie metadata and download any missing images.";
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await tmdbService.UpdateAllMovies(true, true);
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbMoviesWithImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbMoviesWithImagesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 ///   Update all TMDB movies in the local database from the remote API,
 ///   including downloading any missing images.
 /// </summary>
-internal sealed class UpdateAllTmdbMoviesWithImagesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
+public sealed class UpdateAllTmdbMoviesWithImagesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All TMDB Movies (with Images)";
     public string? Description => "Update all TMDB movie metadata and download any missing images.";

--- a/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbMoviesWithImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbMoviesWithImagesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 ///   Update all TMDB movies in the local database from the remote API,
 ///   including downloading any missing images.
 /// </summary>
-internal sealed class UpdateAllTmdbMoviesWithImagesAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+internal sealed class UpdateAllTmdbMoviesWithImagesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All TMDB Movies (with Images)";
     public string? Description => "Update all TMDB movie metadata and download any missing images.";

--- a/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbShowsAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbShowsAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 ///   Update all TMDB shows in the local database from the remote API.
 ///   Only refreshes metadata; does not download images.
 /// </summary>
-internal sealed class UpdateAllTmdbShowsAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+internal sealed class UpdateAllTmdbShowsAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All TMDB Shows";
     public string? Description => "Update all TMDB show metadata in the local database without downloading images.";

--- a/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbShowsAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbShowsAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 ///   Update all TMDB shows in the local database from the remote API.
 ///   Only refreshes metadata; does not download images.
 /// </summary>
-internal sealed class UpdateAllTmdbShowsAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
+public sealed class UpdateAllTmdbShowsAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All TMDB Shows";
     public string? Description => "Update all TMDB show metadata in the local database without downloading images.";

--- a/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbShowsAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbShowsAction.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb;
+
+/// <summary>
+///   Update all TMDB shows in the local database from the remote API.
+///   Only refreshes metadata; does not download images.
+/// </summary>
+internal sealed class UpdateAllTmdbShowsAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+{
+    public string Name => "Update All TMDB Shows";
+    public string? Description => "Update all TMDB show metadata in the local database without downloading images.";
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await tmdbService.UpdateAllShows(true, false);
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbShowsWithImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbShowsWithImagesAction.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Action;
+using Shoko.Abstractions.Action.Enums;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Services.Actions.Tmdb;
+
+/// <summary>
+///   Update all TMDB shows in the local database from the remote API,
+///   including downloading any missing images.
+/// </summary>
+internal sealed class UpdateAllTmdbShowsWithImagesAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+{
+    public string Name => "Update All TMDB Shows (with Images)";
+    public string? Description => "Update all TMDB show metadata and download any missing images.";
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    public async Task Execute(CancellationToken cancellationToken = default)
+    {
+        await tmdbService.UpdateAllShows(true, true);
+    }
+}

--- a/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbShowsWithImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbShowsWithImagesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 ///   Update all TMDB shows in the local database from the remote API,
 ///   including downloading any missing images.
 /// </summary>
-internal sealed class UpdateAllTmdbShowsWithImagesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
+public sealed class UpdateAllTmdbShowsWithImagesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All TMDB Shows (with Images)";
     public string? Description => "Update all TMDB show metadata and download any missing images.";

--- a/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbShowsWithImagesAction.cs
+++ b/Shoko.Server/Services/Actions/Tmdb/UpdateAllTmdbShowsWithImagesAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Services.Actions.Tmdb;
 ///   Update all TMDB shows in the local database from the remote API,
 ///   including downloading any missing images.
 /// </summary>
-internal sealed class UpdateAllTmdbShowsWithImagesAction(TmdbMetadataService tmdbService) : IExecutableGlobalAction
+internal sealed class UpdateAllTmdbShowsWithImagesAction(TmdbMetadataService tmdbService) : IExecutableGlobalSystemAction
 {
     public string Name => "Update All TMDB Shows (with Images)";
     public string? Description => "Update all TMDB show metadata and download any missing images.";

--- a/Shoko.Server/Services/SystemService.cs
+++ b/Shoko.Server/Services/SystemService.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NLog.Extensions.Logging;
 using NLog.Web;
+using Shoko.Abstractions.Action.Services;
 using Shoko.Abstractions.Config;
 using Shoko.Abstractions.Config.Services;
 using Shoko.Abstractions.Connectivity.Services;
@@ -411,6 +412,7 @@ public class SystemService : ISystemService
             services.AddSingleton<IFuzzySearchService, FuzzySearchService>();
             services.AddSingleton<LegacyFilterConverter>();
             services.AddSingleton<ActionService>();
+            services.AddSingleton<IActionService>(sp => sp.GetRequiredService<ActionService>());
             services.AddSingleton<AnimeSeriesService>();
             services.AddSingleton<AnimeGroupService>();
             services.AddSingleton<ShokoGroupManager>();

--- a/Shoko.Server/Services/UserDataService.cs
+++ b/Shoko.Server/Services/UserDataService.cs
@@ -341,6 +341,19 @@ public class UserDataService(
             }
         }
 
+        // Even without a watched status change, other video user data updates
+        // (progress, stream index, client data, etc.) should still trigger a
+        // stats update so LastVideoUpdate is kept in sync.
+        if (shouldSave && !watchedStatusChanged && updateStatsNow)
+        {
+            var xrefs = video.CrossReferences;
+            foreach (var episodeXref in xrefs)
+            {
+                if (episodeXref.ShokoEpisode?.Series is AnimeSeries series)
+                    toUpdateSeries.TryAdd(series.AnimeSeriesID, series);
+            }
+        }
+
         // We run these events _after_ invoking the above event(s) so the series event(s) are fired after the episode and video event(s).
         if (updateStatsNow && toUpdateSeries.Count > 0)
         {


### PR DESCRIPTION
Implemented the plugin-registrable actions system as specified by the RFC
discussion [#1380](https://github.com/ShokoAnime/ShokoServer/discussions/1380), allowing plugins (and core) to register discrete, invokable
units of work that appear in the Actions menu and can be triggered by ID via the
API.

**Abstractions layer** (Shoko.Abstractions.Action):
- Added `IExecutableAction` base interface with `Name` (nullable; inferred from
  class name split on PascalCase if not set), `Description`, `Category` (hard
  enum `ActionCategory`, defaults to `Mischievous`), and `RequiresConfirmation`
  properties.
- Added scope sub-interfaces distinguishing system-level (admin) from user-level
  variants: `IExecutableGlobalSystemAction`, `IExecutableGlobalUserAction`,
  `IExecutableGroupSystemAction`, `IExecutableGroupUserAction`,
  `IExecutableSeriesSystemAction`, `IExecutableSeriesUserAction`,
  `IExecutableEpisodeSystemAction`, `IExecutableEpisodeUserAction`.
- Added `ExecutableActionInfo` DTO with stable UUIDv5 derived from class name +
  plugin ID namespace.
- Added `IActionService` for registration (`AddParts`), discovery
  (`GetActions`), direct execution, and queued scheduling.
- Expanded `ActionCategory` enum with explicit hex values (e.g.
  `Maintenance = 0xF1`, `Mischievous = 0xF2`, `Destructive = 0xFE`,
  `PluginInferred = 0xFF`) and doc comments on all members.
- Added `ActionScope` as a `[Flags]` enum with `System`, `User`, `Global`,
  `Group`, `Series`, `Episode` base flags and combined values (`SystemAndGlobal`,
  `UserAndGlobal`, `SystemAndGroup`, `UserAndGroup`, `SystemAndSeries`,
  `UserAndSeries`, `SystemAndEpisode`, `UserAndEpisode`).
- Added design overview docs for the abstractions:
  `ActionScope.md`, `ActionCategory.md`, and `IExecutableAction.md`
  (plugin author guide).

**Registration & DI**:
- `PluginManager.InitPlugins()` calls `IActionService.AddParts()` via
  `GetExports<IExecutableAction>`, same pattern as other plugin extension
  points.
- Action instances are transient via `ActivatorUtilities`; lifetime management
  is the plugin's responsibility.
- Stores action types, not cached instances; fresh instance created from type on
  each execution via `IPluginManager.GetExport<T>`.

**Service layer** (`ActionService`):
- Implements `IActionService` with `_registeredActions` list.
- `AddParts` resolves plugin info, derives UUIDs, collects all matching scopes
  via `typeof(T).IsAssignableFrom`, and propagates `RequiresConfirmation` -
  `GetActions` accepts `IEnumerable<ActionScope>?`,
  `IEnumerable<ActionCategory>?`, `IEnumerable<string>?` for set-based filtering
  (scope filtering via `HasFlag`-based overlap, category/category-name contains).
- Result ordering: category value (ensures deterministic core category
  ordering), then category name (ensures deterministic plugin ordering), then
  name (ensures deterministic action ordering).
- `Execute*` methods resolve a fresh instance each time, validate scope presence
  upfront, throw `InvalidOperationException` on mismatch - `ScheduleExecuteOf*`
  validates scope before enqueuing via `ExecuteActionJob`.
- Added 7 new methods migrated from the API controller: `RunImport_SyncVotes`,
  `PurgeAllTmdbLinks`, `UpdateAniDBCalendar`, `PlexSyncAll`,
  `AddAllManualLinksToMyList`, `GetAniDBNotifications`, `AVDumpMismatchedFiles`.

**Global action implementations** (Shoko.Server.Services.Actions):
- 35 `IExecutableGlobalSystemAction` classes across 5 domains:
  - Import (3): RunImport, ImportNewFiles, RemoveMissingFiles
  - AniDB (11): DownloadMissingAniDBAnimeData, Creators,
    UpdateAllAniDBInfo, UpdateMissingAniDBFileInfo,
    RefreshAniDBMovedFiles, VerifyAllRelations, SyncAniDBMyList,
    SyncAniDBVotes, UpdateAniDBCalendar,
    AddAllManualLinksToMyList, GetAniDBNotifications,
    AVDumpMismatchedFiles
  - TMDB (10): SearchForMatches, UpdateAllTMDBMovies (+WithImages),
    UpdateAllTMDBShows (+WithImages), DownloadMissingPeople,
    PurgeAllUnusedMovies, Collections, Shows,
    ShowAlternateOrderings, PurgeAllLinks
  - Images (3): UpdateAllImages, ValidateAllImages,
    PurgeAllUnusedTMDBImages
  - Maintenance (8): UpdateAllMediaInfo, UpdateSeriesStats,
    RecreateAllGroups, RenameAllGroups, CreateMissingSeries,
    PurgeAllUsedReleases, PurgeAllUnusedReleases, PlexSyncAll
- Destructive actions set `RequiresConfirmation = true`
- `RunImportAction` and `SyncAnidbMyListAction` use `IJobFactory`

**Series action implementations** (Shoko.Server.Services.Actions.*.Series):
- 17 `IExecutableSeriesSystemAction` classes across 4 sub-namespaces:
  - AniDB.Series (4): UpdateAnidbInfo (cache+remote fallback),
    UpdateAnidbInfoRemote (remote, respects checks),
    UpdateAnidbInfoForce (bypasses time check + HTTP bans,
    requires confirmation), UpdateAnidbInfoXmlCache (local XML only)
  - Tmdb.Series (7): AutoSearchTmdbMatch, UpdateTmdbInfo,
    UpdateTmdbImagesForce, RefreshTmdbMovies,
    DownloadTmdbMovieImages, AutoMatchTmdbEpisodes,
    ResetTmdbEpisodeMappings (requires confirmation)
  - Import.Series (3): RescanFiles, RehashFiles, RelocateFiles
  - Destructive.Series (3): DeleteKeepFiles, DeleteRemoveFiles,
    DeleteAllData (all require confirmation)
- Actions are self-contained: they inject services directly and
  operate on the `IShokoSeries` passed at invocation

**Group action implementations** (Shoko.Server.Services.Actions.Import.Group):
- 3 `IExecutableGroupSystemAction` classes mirroring the series file actions:
  RescanGroupFiles, RehashGroupFiles, RelocateGroupFiles
- Each iterates all series within the group to operate on their files

**Queue job** (`ExecuteActionJob`):
- Stores `ActionID`, `UserID`, `GroupID`, `AnimeID`, and `EpisodeID`
- Uses `PostInit` to hydrate display names via `IActionService`,
  `IUserService`, and `IMetadataService`
- `ScopeToName` infers the scope label from which of
  (GroupID, AnimeID, EpisodeID, UserID) are set,
  covering all 8 scope combinations
- Routes to the appropriate `IActionService.Execute*` method

**API layer** (v3):
- `GET /api/v3/Action/Actions` — lists global/user-scoped actions grouped
  by `CategoryName` (B2 shape), filtered by user permissions
- `POST /api/v3/Action/{actionID}/Execute?scope=` — invokes a
  global/user action; scope defaults by role priority; system-scoped
  actions require admin, user-scoped variants require any auth
- `GET /api/v3/Action/Group/Actions` — lists group-scoped actions
- `POST /api/v3/Action/Group/{groupID}/Action/{actionID}/Execute?scope=`
  — invokes a group/group-user action with group existence validation
- `GET /api/v3/Action/Series/Actions` — lists series-scoped actions
- `POST /api/v3/Action/Series/{seriesID}/Action/{actionID}/Execute?scope=`
  — invokes a series/series-user action with series existence
  validation
- `GET /api/v3/Action/Episode/Actions` — lists episode-scoped
  actions (hookup for future)
- `POST /api/v3/Action/Episode/{episodeID}/Action/{actionID}/Execute?scope=`
  — invokes an episode/episode-user action with episode existence
  validation
- Scope-aware auth: resolvedScope.HasFlag(ActionScope.System)
  gates admin actions uniformly across all entity levels
- Plugin info included in `ActionInfo` response DTO
- Old hardcoded endpoints marked `[Obsolete]`; implementation
  delegated to `ActionService`

**Differences from RFC #1380**:

**Interface hierarchy (scope inference via sub-interfaces):**
The RFC specifies a single `IExecutableAction` with a `Scope` property and a parameterless `Execute(CancellationToken)`. It does not address how entity context (the series, group, or episode to operate on) or the invoking user are actually passed into `Execute` — Gap 18 dismisses it as "an implementation detail."

This implementation instead defines 8 scope-specific sub-interfaces, each with an `Execute` signature that provides exactly the context the action needs:

- `IExecutableGlobalSystemAction` → `Execute(CancellationToken)` — no context
- `IExecutableGlobalUserAction` → `Execute(IUser, CancellationToken)` — user context
- `IExecutableSeriesSystemAction` → `Execute(IShokoSeries, CancellationToken)` — series context
- `IExecutableSeriesUserAction` → `Execute(IShokoSeries, IUser, CancellationToken)` — both
- (and so on for Group and Episode)

An action declares which scopes it supports by implementing the corresponding sub-interface(s). `ActionService.AddParts` detects every implemented interface via `typeof(T).IsAssignableFrom` and registers each as a supported scope on `ExecutableActionInfo.Scopes`. A single class can support multiple scopes (e.g. both `IExecutableGlobalSystemAction` and `IExecutableSeriesSystemAction`) by implementing both interfaces.

This design was chosen over the RFC's single-interface approach because:
- **DX and intent**: the interface an action implements is a self-documenting declaration of what it needs. No guesswork about whether `Execute` will receive a series, a user, or neither.
- **The RFC doesn't specify how entity/user context reaches Execute.** A single parameterless method with only `CancellationToken` provides no mechanism for the service to supply the series, group, or user the action should operate on. The sub-interface approach makes this explicit at the type level.
- **The scope set on `ExecutableActionInfo` is inferred from the interfaces, not declared as a property.** This eliminates a class of bugs where a plugin sets `Scope` to `Series` but forgets to handle the series parameter. Bare `IExecutableAction` without any sub-interface is not registered — at least one sub-interface must be implemented.

**Permission modeling (folded into ActionScope):**
The RFC's revised Gap 8 specifies a separate `ActionPermission` enum (`Admin`/`User`) orthogonal to `Scope`. This implementation folds permission into `ActionScope` itself via `[Flags]`:

```csharp
[Flags]
public enum ActionScope : byte
{
    System = 1 << 0,    // admin gate
    User   = 1 << 1,    // any authenticated user
    Global = 1 << 2,    // scope-level flags
    Group  = 1 << 3,
    Series = 1 << 4,
    Episode = 1 << 5,
}
```

Combined values like `SystemAndGlobal` describe both the entity scope and the permission level in a single value. The admin check at the API layer is a single uniform `resolvedScope.HasFlag(ActionScope.System)` regardless of which entity level the action targets — no per-entity-level conditionals needed.

Keeping base flags and entity-level flags on the same enum was a deliberate choice to simplify the `ExecutableActionInfo.Scopes` set: a multi-scope action (e.g. implementing both `IExecutableGlobalSystemAction` and `IExecutableGlobalUserAction`) stores `{ SystemAndGlobal, UserAndGlobal }` — both values carry the entity scope (`Global`) alongside the permission level (`System` or `User`), so a listing endpoint or plugin can filter by either axis with a single `HasFlag` call without joining across two enums.

This also extends the RFC's original `Global`/`Series` scope pair with `Group` and `Episode` scopes to match four of the entity levels Shoko supports. A `Video`-level scope was left out for now but can be added later if deemed necessary.

**Other differences:**
- `GetActions` uses set-based overlap filtering instead of single scope matching
- `CategoryName` string on `ExecutableActionInfo` carries the display label; `PluginInferred` category uses the plugin's name as the label rather than a core-owned `Generic` fallback (RFC Gap 1)
- `RequiresConfirmation` added as a UI hint for destructive actions (not specified in RFC but a natural follow-on)
- Direct execution (`Execute*` methods) exists on the service; the API always schedules through the job queue system, but plugins may use `Execute*` for immediate in-process execution
- Actions store types, not instances; fresh instance per invocation
- `ActionCategory` default changed back from `PluginInferred` to `Mischievous`, realigning with the original RFC's intent for a fixed core-owned fallback
- `Name` is nullable and inferred from the class name when not set (the RFC treats it as required)

Refs: [#1380](https://github.com/ShokoAnime/ShokoServer/discussions/1380)
