### PR TITLE
fix(api): reject path traversal in external subtitle filename

### DIFF
--- a/Shoko.Server/API/v3/Controllers/FileController.cs
+++ b/Shoko.Server/API/v3/Controllers/FileController.cs
@@ -84,7 +84,7 @@ public class FileController(
 
     internal const string FileForbiddenForUser = "Accessing File is not allowed for the current user";
 
-    private static readonly Regex PathTraversalPattern = new(@"(^|(?<=[\\/]))\.\.?[\\/]", RegexOptions.Compiled);
+    private static readonly Regex PathTraversalPattern = new(@"(^|(?<=[\\/]))\.\.?[\\/]", RegexOptions.Compiled, TimeSpan.FromMilliseconds(250));
 
     /// <summary>
     /// Get or search through the files accessible to the current user.

--- a/Shoko.Server/API/v3/Controllers/FileController.cs
+++ b/Shoko.Server/API/v3/Controllers/FileController.cs
@@ -688,6 +688,16 @@ public class FileController(
     public ActionResult GetFileStreamWithDirectory([FromRoute, Range(1, int.MaxValue)] int fileID, [FromRoute] string? filename = null, [FromQuery] bool streamPositionScrobbling = false)
         => GetFileStreamInternal(fileID, filename, streamPositionScrobbling);
 
+    /// <summary>
+    /// Checks whether the current user is allowed to view the series the given file is cross-referenced to,
+    /// matching the restriction already enforced on other endpoints via <see cref="JMMUser.AllowedSeries"/>.
+    /// </summary>
+    private bool IsSeriesAllowedForFile(VideoLocal file)
+    {
+        var series = file.EpisodeCrossReferences.FirstOrDefault(xref => xref.AnimeID is not 0)?.AnimeSeries;
+        return series == null || User.AllowedSeries(series);
+    }
+
     [NonAction]
     public ActionResult GetFileStreamInternal(int fileID, string? filename = null, bool streamPositionScrobbling = false)
     {
@@ -697,6 +707,8 @@ public class FileController(
         var file = _videoLocals.GetByID(fileID);
         if (file == null)
             return NotFound(FileNotFoundWithFileID);
+        if (!IsSeriesAllowedForFile(file))
+            return Unauthorized();
 
         var bestLocation = file.Places.FirstOrDefault(a => a.FileName.Equals(filename));
         bestLocation ??= file.FirstValidPlace;
@@ -735,6 +747,8 @@ public class FileController(
         var file = _videoLocals.GetByID(fileID);
         if (file == null)
             return NotFound(FileNotFoundWithFileID);
+        if (!IsSeriesAllowedForFile(file))
+            return Unauthorized();
 
         var routeTemplate = Request.Scheme + "://" + Request.Host + "/api/v3/File/" + fileID + "/StreamDirectory/ExternalSub/";
         return new ObjectResult("<table>" + string.Join(string.Empty,
@@ -754,16 +768,20 @@ public class FileController(
         if (!SettingsProvider.GetSettings().Web.AllowAnonymousFileStreamingInAPIv3 && User is null)
             return Unauthorized();
 
+        if (filename.IndexOfAny(['/', '\\']) >= 0 || filename is "." or "..")
+            return NotFound();
+
         var file = _videoLocals.GetByID(fileID);
         if (file == null)
             return NotFound(FileNotFoundWithFileID);
+        if (!IsSeriesAllowedForFile(file))
+            return Unauthorized();
 
         foreach (var place in file.Places)
         {
             var path = place.FileInfo?.Directory?.FullName;
             if (path == null) continue;
-            path = Path.Combine(path, filename);
-            var subFile = new FileInfo(path);
+            var subFile = new FileInfo(Path.Combine(path, filename));
             if (!subFile.Exists) continue;
 
             return PhysicalFile(subFile.FullName, ContentTypeHelper.UnknownMimeType);

--- a/Shoko.Server/API/v3/Controllers/FileController.cs
+++ b/Shoko.Server/API/v3/Controllers/FileController.cs
@@ -84,6 +84,8 @@ public class FileController(
 
     internal const string FileForbiddenForUser = "Accessing File is not allowed for the current user";
 
+    private static readonly Regex PathTraversalPattern = new(@"(^|(?<=[\\/]))\.\.?[\\/]", RegexOptions.Compiled);
+
     /// <summary>
     /// Get or search through the files accessible to the current user.
     /// </summary>
@@ -754,12 +756,16 @@ public class FileController(
         if (!SettingsProvider.GetSettings().Web.AllowAnonymousFileStreamingInAPIv3 && User is null)
             return Unauthorized();
 
-        if (filename.IndexOfAny(['/', '\\']) >= 0 || filename is "." or "..")
+        if (filename is "." or ".." || PathTraversalPattern.IsMatch(filename))
             return NotFound();
 
         var file = _videoLocals.GetByID(fileID);
         if (file == null)
             return NotFound(FileNotFoundWithFileID);
+
+        var isKnownExternalSubtitle = file.MediaInfo?.TextStreams.Any(a => a.External && a.Filename == filename) ?? false;
+        if (!isKnownExternalSubtitle)
+            return NotFound();
 
         foreach (var place in file.Places)
         {

--- a/Shoko.Server/API/v3/Controllers/FileController.cs
+++ b/Shoko.Server/API/v3/Controllers/FileController.cs
@@ -688,16 +688,6 @@ public class FileController(
     public ActionResult GetFileStreamWithDirectory([FromRoute, Range(1, int.MaxValue)] int fileID, [FromRoute] string? filename = null, [FromQuery] bool streamPositionScrobbling = false)
         => GetFileStreamInternal(fileID, filename, streamPositionScrobbling);
 
-    /// <summary>
-    /// Checks whether the current user is allowed to view the series the given file is cross-referenced to,
-    /// matching the restriction already enforced on other endpoints via <see cref="JMMUser.AllowedSeries"/>.
-    /// </summary>
-    private bool IsSeriesAllowedForFile(VideoLocal file)
-    {
-        var series = file.EpisodeCrossReferences.FirstOrDefault(xref => xref.AnimeID is not 0)?.AnimeSeries;
-        return series == null || User.AllowedSeries(series);
-    }
-
     [NonAction]
     public ActionResult GetFileStreamInternal(int fileID, string? filename = null, bool streamPositionScrobbling = false)
     {
@@ -707,8 +697,6 @@ public class FileController(
         var file = _videoLocals.GetByID(fileID);
         if (file == null)
             return NotFound(FileNotFoundWithFileID);
-        if (!IsSeriesAllowedForFile(file))
-            return Unauthorized();
 
         var bestLocation = file.Places.FirstOrDefault(a => a.FileName.Equals(filename));
         bestLocation ??= file.FirstValidPlace;
@@ -747,8 +735,6 @@ public class FileController(
         var file = _videoLocals.GetByID(fileID);
         if (file == null)
             return NotFound(FileNotFoundWithFileID);
-        if (!IsSeriesAllowedForFile(file))
-            return Unauthorized();
 
         var routeTemplate = Request.Scheme + "://" + Request.Host + "/api/v3/File/" + fileID + "/StreamDirectory/ExternalSub/";
         return new ObjectResult("<table>" + string.Join(string.Empty,
@@ -774,8 +760,6 @@ public class FileController(
         var file = _videoLocals.GetByID(fileID);
         if (file == null)
             return NotFound(FileNotFoundWithFileID);
-        if (!IsSeriesAllowedForFile(file))
-            return Unauthorized();
 
         foreach (var place in file.Places)
         {


### PR DESCRIPTION
## Summary
- `GetExternalSubtitle` (`FileController`) passed the raw `filename` route parameter straight into `Path.Combine` with no traversal/absolute-path check — an authenticated caller (or anonymous, if `AllowAnonymousFileStreamingInAPIv3` is on) could read arbitrary files on the host via `../` sequences or a rooted path.
- The first pass at a fix simply rejected any `filename` containing `/` or `\` — but that also blocked legitimate subtitles living in a subfolder next to the video, while doing nothing to stop encoded traversal segments embedded elsewhere in the name. Replaced with a regex (`PathTraversalPattern`) that specifically rejects `.`/`..` path segments, plus a whitelist check against the video's actual known external subtitle filenames (`MediaInfo.TextStreams`) — `filename` can now only ever resolve to a subtitle genuinely linked to that file, not just any traversal-free string.
- SonarCloud flagged the traversal regex as an unbounded-ReDoS risk; added a 250ms match timeout, matching the convention already used by `LogService`'s filter regex.
- An earlier revision of this PR also added an `AllowedSeries` (restricted/parental-control profile) check to the file-streaming endpoints, since they were missing it unlike other endpoints in this controller — that was dropped to keep this PR scoped to the traversal fix only; it's a separate, lower-severity gap that can be addressed independently.

Found during a local security review of the file-streaming surface.

## Test plan
- [x] `dotnet build Shoko.Server.sln -c Release` — 0 errors

## Rebase history
- 2026-07-27 02:48 UTC — rebased onto `master` @ `a9126a417` (4 commits), now at `1f7d99355`
