### PR TITLE
feat(api): example OIDC single sign-on implementation

### DIFF
--- a/Shoko.Server/API/v3/Controllers/InitController.cs
+++ b/Shoko.Server/API/v3/Controllers/InitController.cs
@@ -129,16 +129,20 @@ public class InitController : BaseController
             if (message.Equals("Complete!")) message = null;
             state = ServerStatus.StartupState.Starting;
         }
+        var oidc = SettingsProvider.GetSettings().Oidc;
+        var oidcEnabled = oidc.Enabled && !string.IsNullOrWhiteSpace(oidc.Authority) && !string.IsNullOrWhiteSpace(oidc.ClientID);
         if (!isLoggedIn)
             return new()
             {
                 State = state,
                 StartupMessage = message,
+                OidcEnabled = oidcEnabled,
             };
         return new()
         {
             State = state,
             StartupMessage = message,
+            OidcEnabled = oidcEnabled,
             BootstrappedAt = _systemService.BootstrappedAt.ToUniversalTime(),
             StartedAt = _systemService.StartedAt?.ToUniversalTime(),
             Uptime = _systemService.Uptime,

--- a/Shoko.Server/API/v3/Controllers/InitController.cs
+++ b/Shoko.Server/API/v3/Controllers/InitController.cs
@@ -129,16 +129,20 @@ public class InitController : BaseController
             if (message!.Equals("Complete!")) message = null;
             state = ServerStatus.StartupState.Starting;
         }
+        var oidc = SettingsProvider.GetSettings().Oidc;
+        var oidcEnabled = oidc.Enabled && !string.IsNullOrWhiteSpace(oidc.Authority) && !string.IsNullOrWhiteSpace(oidc.ClientID);
         if (!isLoggedIn)
             return new()
             {
                 State = state,
                 StartupMessage = message,
+                OidcEnabled = oidcEnabled,
             };
         return new()
         {
             State = state,
             StartupMessage = message,
+            OidcEnabled = oidcEnabled,
             BootstrappedAt = _systemService.BootstrappedAt.ToUniversalTime(),
             StartedAt = _systemService.StartedAt?.ToUniversalTime(),
             Uptime = _systemService.Uptime,

--- a/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
+++ b/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
@@ -16,7 +16,9 @@ using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
+using Shoko.Abstractions.Exceptions;
 using Shoko.Abstractions.User.Services;
+using Shoko.Abstractions.User.Update;
 using Shoko.Server.API.Annotations;
 using Shoko.Server.Models.Shoko;
 using Shoko.Server.Repositories.Cached;
@@ -37,6 +39,7 @@ namespace Shoko.Server.API.v3.Controllers;
 public class OidcAuthController(
     ISettingsProvider settingsProvider,
     JMMUserRepository userRepository,
+    AuthTokensRepository authTokensRepository,
     IUserService userService,
     IHttpClientFactory httpClientFactory,
     IDataProtectionProvider dataProtectionProvider
@@ -86,9 +89,19 @@ public class OidcAuthController(
         if (User.ExternalAuthID is null)
             return NoContent();
 
+        InvalidateProviderTokens(User.JMMUserID, User.ExternalAuthID);
         User.ExternalAuthID = null;
         userRepository.Save(User);
         return NoContent();
+    }
+
+    // Tokens are keyed by device name "OIDC — {authority} — {subject}", so a provider-scoped
+    // prefix match invalidates every token minted for this user under the given authority
+    // without needing to look up the OIDC settings, which may have already changed.
+    private void InvalidateProviderTokens(int userID, string externalAuthID)
+    {
+        var authority = externalAuthID.Split("::", 2)[0];
+        authTokensRepository.DeleteWithUserIDAndDevicePrefix(userID, $"OIDC — {authority}");
     }
 
     private async Task<ActionResult> StartAuthorizeAsync(string? returnUrl, int? linkUserID, string? forwardedProto)
@@ -130,10 +143,10 @@ public class OidcAuthController(
             return RedirectToWebUiWithError($"OIDC provider returned an error: {error}");
 
         if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state))
-            return BadRequest("Missing code or state.");
+            return RedirectToWebUiWithError("Missing code or state.");
 
         if (UnprotectState(state) is not { } statePayload || DateTime.UtcNow - statePayload.CreatedAt > StateLifetime)
-            return BadRequest("Invalid or expired sign-in attempt. Please try again.");
+            return RedirectToWebUiWithError("Invalid or expired sign-in attempt. Please try again.");
 
         var (settings, configuration, configError) = await GetEnabledConfigurationAsync();
         if (configError is not null)
@@ -144,10 +157,10 @@ public class OidcAuthController(
             return RedirectToWebUiWithError(exchangeError);
 
         var (claims, validationError) = await ValidateIdTokenAsync(configuration, settings, idToken!, statePayload.Nonce);
-        if (validationError is not null)
-            return RedirectToWebUiWithError(validationError);
+        if (validationError is not null || claims is null)
+            return RedirectToWebUiWithError(validationError ?? "ID token validation failed.");
 
-        var rawSubject = claims!.FindFirst("sub")?.Value;
+        var rawSubject = claims.FindFirst("sub")?.Value;
         if (string.IsNullOrEmpty(rawSubject))
             return RedirectToWebUiWithError("ID token is missing a subject claim.");
 
@@ -157,17 +170,19 @@ public class OidcAuthController(
 
         var (user, userError) = statePayload.LinkUserID is { } linkUserID
             ? LinkUser(linkUserID, externalAuthID)
-            : ResolveUser(externalAuthID);
+            : await ResolveUserAsync(externalAuthID, rawSubject, settings);
         if (userError is not null)
             return RedirectToWebUiWithError(userError);
 
         // Match the Shoko token's lifetime to the OIDC token's own expiry rather than a
         // fixed value — a fresh login always mints a new token, so several can coexist
         // with different expirations without any one of them ever being non-expiring.
-        if (GetExpiration(claims!) is not { } expiresAt || expiresAt <= DateTime.UtcNow.AddMinutes(1))
+        if (GetExpiration(claims) is not { } expiresAt || expiresAt <= DateTime.UtcNow.AddMinutes(1))
             return RedirectToWebUiWithError("ID token is missing a valid expiration.");
 
-        var apiToken = await userService.GenerateApiTokenForUser(user!, $"OIDC — {settings.Authority}", expiresAt);
+        // Subject is part of the device name (not just externalAuthID) so a provider-scoped
+        // Unlink() can target exactly the tokens minted for this identity via prefix match.
+        var apiToken = await userService.GenerateApiTokenForUser(user!, $"OIDC — {settings.Authority} — {rawSubject}", expiresAt);
         return RedirectToWebUiWithToken(apiToken.Token, statePayload.ReturnUrl);
     }
 
@@ -222,13 +237,36 @@ public class OidcAuthController(
 
     // Sign-in only ever resolves a user that was already explicitly linked via Link() —
     // never matches by username or email, which would let anyone controlling (or
-    // impersonating) the IdP take over a same-named local account.
-    private (JMMUser? User, string? Error) ResolveUser(string externalAuthID)
+    // impersonating) the IdP take over a same-named local account. The one opt-in exception
+    // is AutoCreateUsers, which provisions a brand new account rather than linking an
+    // existing one, so it can't be used to take over anything.
+    private async Task<(JMMUser? User, string? Error)> ResolveUserAsync(string externalAuthID, string rawSubject, OidcSettings settings)
     {
         var user = userRepository.GetByExternalAuthID(externalAuthID);
-        return user is not null
-            ? (user, null)
-            : (null, "No local Shoko account is linked to this SSO identity. Sign in locally and link your account first.");
+        if (user is not null)
+            return (user, null);
+
+        if (!settings.AutoCreateUsers)
+            return (null, "No local Shoko account is linked to this SSO identity. Sign in locally and link your account first.");
+
+        if (userRepository.GetByUsername(rawSubject) is not null)
+            return (null, $"Cannot auto-create a user for subject \"{rawSubject}\" — that username is already taken.");
+
+        try
+        {
+            var created = (JMMUser)await userService.CreateUser(new UserUpdate
+            {
+                Username = rawSubject,
+                Password = Convert.ToHexString(RandomNumberGenerator.GetBytes(32)),
+            });
+            created.ExternalAuthID = externalAuthID;
+            userRepository.Save(created);
+            return (created, null);
+        }
+        catch (GenericValidationException ex)
+        {
+            return (null, $"Could not auto-create a user for subject \"{rawSubject}\": {ex.Message}");
+        }
     }
 
     private (JMMUser? User, string? Error) LinkUser(int linkUserID, string externalAuthID)

--- a/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
+++ b/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Shoko.Abstractions.User.Services;
+using Shoko.Server.API.Annotations;
+using Shoko.Server.Models.Shoko;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Settings;
+
+namespace Shoko.Server.API.v3.Controllers;
+
+/// <summary>
+/// Optional OpenID Connect single sign-on. Disabled unless configured in
+/// Settings.Oidc. Never creates local accounts — a matching local account
+/// (by username or email) must already exist; SSO only links to it and
+/// mints the same kind of API token the local sign-in endpoint issues.
+/// </summary>
+[ApiController]
+[Route("/api/v{version:apiVersion}/Auth/Oidc")]
+[ApiV3]
+public class OidcAuthController(
+    ISettingsProvider settingsProvider,
+    JMMUserRepository userRepository,
+    IUserService userService,
+    IHttpClientFactory httpClientFactory,
+    IDataProtectionProvider dataProtectionProvider
+) : ControllerBase
+{
+    private const string ProtectorPurpose = "Shoko.Server.OidcAuth.State";
+    private static readonly TimeSpan StateLifetime = TimeSpan.FromMinutes(10);
+
+    private OidcSettings Settings => settingsProvider.GetSettings().Oidc;
+
+    private sealed record StatePayload(string Nonce, string? ReturnUrl, DateTime CreatedAt);
+
+    /// <summary>
+    /// Redirects the browser to the configured OIDC provider's authorization
+    /// endpoint.
+    /// </summary>
+    [HttpGet("Challenge")]
+    [AllowAnonymous]
+    public async Task<ActionResult> Challenge(
+        [FromQuery] string? returnUrl = null,
+        [FromHeader(Name = "X-Forwarded-Proto")] string? forwardedProto = null)
+    {
+        var settings = Settings;
+        if (!settings.Enabled || string.IsNullOrWhiteSpace(settings.Authority) || string.IsNullOrWhiteSpace(settings.ClientID))
+            return NotFound("OIDC sign-in is not enabled.");
+
+        OpenIdConnectConfiguration configuration;
+        try
+        {
+            configuration = await GetProviderConfigurationAsync(settings.Authority);
+        }
+        catch (Exception)
+        {
+            return RedirectToWebUiWithError("Could not reach the OIDC provider. Please try again later.");
+        }
+
+        var nonce = Guid.NewGuid().ToString("N");
+        var state = ProtectState(new StatePayload(nonce, returnUrl, DateTime.UtcNow));
+
+        var authorizeUrl = QueryHelpers.AddQueryString(configuration.AuthorizationEndpoint, new Dictionary<string, string?>
+        {
+            ["client_id"] = settings.ClientID,
+            ["response_type"] = "code",
+            ["scope"] = "openid profile email",
+            ["redirect_uri"] = BuildRedirectUri(forwardedProto),
+            ["state"] = state,
+            ["nonce"] = nonce,
+        });
+
+        return Redirect(authorizeUrl);
+    }
+
+    /// <summary>
+    /// Handles the redirect back from the OIDC provider, exchanges the code
+    /// for tokens, validates the ID token, and links/signs in the matching
+    /// local user.
+    /// </summary>
+    [HttpGet("Callback")]
+    [AllowAnonymous]
+    public async Task<ActionResult> Callback(
+        [FromQuery] string? code,
+        [FromQuery] string? state,
+        [FromQuery] string? error,
+        [FromHeader(Name = "X-Forwarded-Proto")] string? forwardedProto = null)
+    {
+        var settings = Settings;
+        if (!settings.Enabled || string.IsNullOrWhiteSpace(settings.Authority) || string.IsNullOrWhiteSpace(settings.ClientID))
+            return NotFound("OIDC sign-in is not enabled.");
+
+        if (!string.IsNullOrEmpty(error))
+            return RedirectToWebUiWithError($"OIDC provider returned an error: {error}");
+
+        if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state))
+            return BadRequest("Missing code or state.");
+
+        if (UnprotectState(state) is not { } statePayload || DateTime.UtcNow - statePayload.CreatedAt > StateLifetime)
+            return BadRequest("Invalid or expired sign-in attempt. Please try again.");
+
+        OpenIdConnectConfiguration configuration;
+        try
+        {
+            configuration = await GetProviderConfigurationAsync(settings.Authority);
+        }
+        catch (Exception)
+        {
+            return RedirectToWebUiWithError("Could not reach the OIDC provider. Please try again later.");
+        }
+
+        var (idToken, exchangeError) = await ExchangeCodeForIdTokenAsync(configuration, settings, code, forwardedProto);
+        if (exchangeError is not null)
+            return RedirectToWebUiWithError(exchangeError);
+
+        var (claims, validationError) = await ValidateIdTokenAsync(configuration, settings, idToken!, statePayload.Nonce);
+        if (validationError is not null)
+            return RedirectToWebUiWithError(validationError);
+
+        var subject = claims!.FindFirst("sub")?.Value;
+        if (string.IsNullOrEmpty(subject))
+            return RedirectToWebUiWithError("ID token is missing a subject claim.");
+
+        var (user, userError) = ResolveUser(claims, subject);
+        if (userError is not null)
+            return RedirectToWebUiWithError(userError);
+
+        var apiToken = await userService.GenerateApiTokenForUser(user!, "OIDC");
+        return RedirectToWebUiWithToken(apiToken.Token, user!.Username, statePayload.ReturnUrl);
+    }
+
+    private async Task<(string? IdToken, string? Error)> ExchangeCodeForIdTokenAsync(OpenIdConnectConfiguration configuration, OidcSettings settings, string code, string? forwardedProto)
+    {
+        var client = httpClientFactory.CreateClient("Default");
+        using var tokenResponse = await client.PostAsync(configuration.TokenEndpoint, new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["code"] = code,
+            ["redirect_uri"] = BuildRedirectUri(forwardedProto),
+            ["client_id"] = settings.ClientID!,
+            ["client_secret"] = settings.ClientSecret ?? string.Empty,
+        }));
+
+        if (!tokenResponse.IsSuccessStatusCode)
+            return (null, "Failed to exchange authorization code with the OIDC provider.");
+
+        var tokenPayload = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>();
+        if (!tokenPayload.TryGetProperty("id_token", out var idTokenElement))
+            return (null, "OIDC provider did not return an ID token.");
+
+        var idToken = idTokenElement.GetString();
+        return string.IsNullOrEmpty(idToken) ? (null, "OIDC provider returned an empty ID token.") : (idToken, null);
+    }
+
+    private static async Task<(ClaimsIdentity? Claims, string? Error)> ValidateIdTokenAsync(OpenIdConnectConfiguration configuration, OidcSettings settings, string idToken, string expectedNonce)
+    {
+        var handler = new JsonWebTokenHandler();
+        var validationResult = await handler.ValidateTokenAsync(idToken, new TokenValidationParameters
+        {
+            ValidIssuer = configuration.Issuer,
+            ValidAudience = settings.ClientID,
+            IssuerSigningKeys = configuration.SigningKeys,
+        });
+
+        if (!validationResult.IsValid)
+            return (null, "ID token validation failed.");
+
+        var claims = validationResult.ClaimsIdentity;
+        var tokenNonce = claims.FindFirst("nonce")?.Value;
+        if (tokenNonce is null || !CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(tokenNonce), Encoding.UTF8.GetBytes(expectedNonce)))
+            return (null, "ID token nonce mismatch.");
+
+        return (claims, null);
+    }
+
+    private (JMMUser? User, string? Error) ResolveUser(ClaimsIdentity claims, string subject)
+    {
+        var user = userRepository.GetByExternalAuthID(subject);
+        if (user is not null)
+            return (user, null);
+
+        // First SSO login for this external identity — link to a
+        // pre-existing local account by username or email, never create one.
+        // Only trust the email claim for matching if the provider marked it
+        // verified; an unverified email lets any IdP user claim someone else's.
+        var emailVerified = bool.TryParse(claims.FindFirst("email_verified")?.Value, out var verified) && verified;
+        var candidateNames = new[]
+        {
+            claims.FindFirst("preferred_username")?.Value,
+            emailVerified ? claims.FindFirst("email")?.Value : null,
+        }.Where(name => !string.IsNullOrWhiteSpace(name));
+
+        user = candidateNames.Select(userRepository.GetByUsername).FirstOrDefault(u => u is not null);
+        if (user is null)
+            return (null, "No local Shoko account matches your SSO identity. Ask an admin to check your username/email.");
+
+        user.ExternalAuthID = subject;
+        userRepository.Save(user);
+        return (user, null);
+    }
+
+    private static async Task<OpenIdConnectConfiguration> GetProviderConfigurationAsync(string authority)
+    {
+        var manager = new ConfigurationManager<OpenIdConnectConfiguration>(
+            authority.TrimEnd('/') + "/.well-known/openid-configuration",
+            new OpenIdConnectConfigurationRetriever());
+        return await manager.GetConfigurationAsync();
+    }
+
+    private string BuildRedirectUri(string? forwardedProto)
+    {
+        // Request.Scheme reflects the connection Kestrel actually accepted, which is
+        // http when Shoko sits behind a TLS-terminating reverse proxy. Honor
+        // X-Forwarded-Proto so the redirect_uri we send matches what's registered
+        // with the OIDC provider.
+        var scheme = !string.IsNullOrWhiteSpace(forwardedProto)
+            ? forwardedProto.Split(',')[0].Trim()
+            : Request.Scheme;
+        return $"{scheme}://{Request.Host}/api/v3/Auth/Oidc/Callback";
+    }
+
+    private string ProtectState(StatePayload payload)
+        => dataProtectionProvider.CreateProtector(ProtectorPurpose).Protect(JsonSerializer.Serialize(payload));
+
+    private StatePayload? UnprotectState(string state)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<StatePayload>(dataProtectionProvider.CreateProtector(ProtectorPurpose).Unprotect(state));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private ActionResult RedirectToWebUiWithToken(string token, string username, string? returnUrl)
+    {
+        var basePath = settingsProvider.GetSettings().Web.WebUIPublicPath.TrimEnd('/');
+        var target = string.IsNullOrWhiteSpace(returnUrl) ? basePath : returnUrl;
+        return Redirect($"{target}#oidcToken={Uri.EscapeDataString(token)}&oidcUsername={Uri.EscapeDataString(username)}");
+    }
+
+    private ActionResult RedirectToWebUiWithError(string message)
+    {
+        var basePath = settingsProvider.GetSettings().Web.WebUIPublicPath.TrimEnd('/');
+        return Redirect($"{basePath}#oidcError={Uri.EscapeDataString(message)}");
+    }
+}

--- a/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
+++ b/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
@@ -17,7 +17,6 @@ using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using Shoko.Abstractions.User.Services;
-using Shoko.Server.API;
 using Shoko.Server.API.Annotations;
 using Shoko.Server.Models.Shoko;
 using Shoko.Server.Repositories.Cached;
@@ -41,13 +40,10 @@ public class OidcAuthController(
     IUserService userService,
     IHttpClientFactory httpClientFactory,
     IDataProtectionProvider dataProtectionProvider
-) : ControllerBase
+) : BaseController(settingsProvider)
 {
     private const string ProtectorPurpose = "Shoko.Server.OidcAuth.State";
     private static readonly TimeSpan StateLifetime = TimeSpan.FromMinutes(10);
-
-    // Override Controller.User to be the JMMUser, matching BaseController's convention.
-    protected new JMMUser? User => HttpContext.User.Identity?.IsAuthenticated == true ? HttpContext.GetUser() : null;
 
     private OidcSettings Settings => settingsProvider.GetSettings().Oidc;
 
@@ -77,7 +73,7 @@ public class OidcAuthController(
     public async Task<ActionResult> Link(
         [FromQuery] string? returnUrl = null,
         [FromHeader(Name = "X-Forwarded-Proto")] string? forwardedProto = null)
-        => await StartAuthorizeAsync(returnUrl, linkUserID: User!.JMMUserID, forwardedProto);
+        => await StartAuthorizeAsync(returnUrl, linkUserID: User.JMMUserID, forwardedProto);
 
     /// <summary>
     /// Removes the external identity link from the currently signed-in
@@ -87,30 +83,19 @@ public class OidcAuthController(
     [Authorize]
     public ActionResult Unlink()
     {
-        var user = User!;
-        if (user.ExternalAuthID is null)
+        if (User.ExternalAuthID is null)
             return NoContent();
 
-        user.ExternalAuthID = null;
-        userRepository.Save(user);
+        User.ExternalAuthID = null;
+        userRepository.Save(User);
         return NoContent();
     }
 
     private async Task<ActionResult> StartAuthorizeAsync(string? returnUrl, int? linkUserID, string? forwardedProto)
     {
-        var settings = Settings;
-        if (!settings.Enabled || string.IsNullOrWhiteSpace(settings.Authority) || string.IsNullOrWhiteSpace(settings.ClientID))
-            return NotFound("OIDC sign-in is not enabled.");
-
-        OpenIdConnectConfiguration configuration;
-        try
-        {
-            configuration = await GetProviderConfigurationAsync(settings.Authority);
-        }
-        catch (Exception)
-        {
-            return RedirectToWebUiWithError("Could not reach the OIDC provider. Please try again later.");
-        }
+        var (settings, configuration, error) = await GetEnabledConfigurationAsync();
+        if (error is not null)
+            return error;
 
         var nonce = Guid.NewGuid().ToString("N");
         var state = ProtectState(new StatePayload(nonce, returnUrl, DateTime.UtcNow, linkUserID));
@@ -141,10 +126,6 @@ public class OidcAuthController(
         [FromQuery] string? error,
         [FromHeader(Name = "X-Forwarded-Proto")] string? forwardedProto = null)
     {
-        var settings = Settings;
-        if (!settings.Enabled || string.IsNullOrWhiteSpace(settings.Authority) || string.IsNullOrWhiteSpace(settings.ClientID))
-            return NotFound("OIDC sign-in is not enabled.");
-
         if (!string.IsNullOrEmpty(error))
             return RedirectToWebUiWithError($"OIDC provider returned an error: {error}");
 
@@ -154,15 +135,9 @@ public class OidcAuthController(
         if (UnprotectState(state) is not { } statePayload || DateTime.UtcNow - statePayload.CreatedAt > StateLifetime)
             return BadRequest("Invalid or expired sign-in attempt. Please try again.");
 
-        OpenIdConnectConfiguration configuration;
-        try
-        {
-            configuration = await GetProviderConfigurationAsync(settings.Authority);
-        }
-        catch (Exception)
-        {
-            return RedirectToWebUiWithError("Could not reach the OIDC provider. Please try again later.");
-        }
+        var (settings, configuration, configError) = await GetEnabledConfigurationAsync();
+        if (configError is not null)
+            return configError;
 
         var (idToken, exchangeError) = await ExchangeCodeForIdTokenAsync(configuration, settings, code, forwardedProto);
         if (exchangeError is not null)
@@ -272,6 +247,22 @@ public class OidcAuthController(
         user.ExternalAuthID = externalAuthID;
         userRepository.Save(user);
         return (user, null);
+    }
+
+    private async Task<(OidcSettings Settings, OpenIdConnectConfiguration Configuration, ActionResult? Error)> GetEnabledConfigurationAsync()
+    {
+        var settings = Settings;
+        if (!settings.Enabled || string.IsNullOrWhiteSpace(settings.Authority) || string.IsNullOrWhiteSpace(settings.ClientID))
+            return (settings, null!, NotFound("OIDC sign-in is not enabled."));
+
+        try
+        {
+            return (settings, await GetProviderConfigurationAsync(settings.Authority), null);
+        }
+        catch (Exception)
+        {
+            return (settings, null!, RedirectToWebUiWithError("Could not reach the OIDC provider. Please try again later."));
+        }
     }
 
     private static async Task<OpenIdConnectConfiguration> GetProviderConfigurationAsync(string authority)

--- a/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
+++ b/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
@@ -17,6 +17,7 @@ using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using Shoko.Abstractions.User.Services;
+using Shoko.Server.API;
 using Shoko.Server.API.Annotations;
 using Shoko.Server.Models.Shoko;
 using Shoko.Server.Repositories.Cached;
@@ -26,9 +27,10 @@ namespace Shoko.Server.API.v3.Controllers;
 
 /// <summary>
 /// Optional OpenID Connect single sign-on. Disabled unless configured in
-/// Settings.Oidc. Never creates local accounts — a matching local account
-/// (by username or email) must already exist; SSO only links to it and
-/// mints the same kind of API token the local sign-in endpoint issues.
+/// Settings.Oidc. Never creates or auto-matches local accounts by username
+/// or email — an already-authenticated user must explicitly link their
+/// account via <see cref="Link"/>. Sign-in only succeeds for a subject that
+/// has already been linked.
 /// </summary>
 [ApiController]
 [Route("/api/v{version:apiVersion}/Auth/Oidc")]
@@ -44,9 +46,14 @@ public class OidcAuthController(
     private const string ProtectorPurpose = "Shoko.Server.OidcAuth.State";
     private static readonly TimeSpan StateLifetime = TimeSpan.FromMinutes(10);
 
+    // Override Controller.User to be the JMMUser, matching BaseController's convention.
+    protected new JMMUser? User => HttpContext.User.Identity?.IsAuthenticated == true ? HttpContext.GetUser() : null;
+
     private OidcSettings Settings => settingsProvider.GetSettings().Oidc;
 
-    private sealed record StatePayload(string Nonce, string? ReturnUrl, DateTime CreatedAt);
+    // LinkUserID is only ever populated by the authenticated Link endpoint, never
+    // attacker-controlled — the payload is signed/encrypted by IDataProtector.
+    private sealed record StatePayload(string Nonce, string? ReturnUrl, DateTime CreatedAt, int? LinkUserID = null);
 
     /// <summary>
     /// Redirects the browser to the configured OIDC provider's authorization
@@ -57,6 +64,39 @@ public class OidcAuthController(
     public async Task<ActionResult> Challenge(
         [FromQuery] string? returnUrl = null,
         [FromHeader(Name = "X-Forwarded-Proto")] string? forwardedProto = null)
+        => await StartAuthorizeAsync(returnUrl, linkUserID: null, forwardedProto);
+
+    /// <summary>
+    /// Starts the OIDC flow to link the currently signed-in local account to
+    /// an external identity. Unlike <see cref="Challenge"/>, this requires an
+    /// authenticated session and never signs in as a different user — the
+    /// callback only ever links to the account that started this flow.
+    /// </summary>
+    [HttpGet("Link")]
+    [Authorize]
+    public async Task<ActionResult> Link(
+        [FromQuery] string? returnUrl = null,
+        [FromHeader(Name = "X-Forwarded-Proto")] string? forwardedProto = null)
+        => await StartAuthorizeAsync(returnUrl, linkUserID: User!.JMMUserID, forwardedProto);
+
+    /// <summary>
+    /// Removes the external identity link from the currently signed-in
+    /// local account, if any.
+    /// </summary>
+    [HttpPost("Unlink")]
+    [Authorize]
+    public ActionResult Unlink()
+    {
+        var user = User!;
+        if (user.ExternalAuthID is null)
+            return NoContent();
+
+        user.ExternalAuthID = null;
+        userRepository.Save(user);
+        return NoContent();
+    }
+
+    private async Task<ActionResult> StartAuthorizeAsync(string? returnUrl, int? linkUserID, string? forwardedProto)
     {
         var settings = Settings;
         if (!settings.Enabled || string.IsNullOrWhiteSpace(settings.Authority) || string.IsNullOrWhiteSpace(settings.ClientID))
@@ -73,7 +113,7 @@ public class OidcAuthController(
         }
 
         var nonce = Guid.NewGuid().ToString("N");
-        var state = ProtectState(new StatePayload(nonce, returnUrl, DateTime.UtcNow));
+        var state = ProtectState(new StatePayload(nonce, returnUrl, DateTime.UtcNow, linkUserID));
 
         var authorizeUrl = QueryHelpers.AddQueryString(configuration.AuthorizationEndpoint, new Dictionary<string, string?>
         {
@@ -132,16 +172,28 @@ public class OidcAuthController(
         if (validationError is not null)
             return RedirectToWebUiWithError(validationError);
 
-        var subject = claims!.FindFirst("sub")?.Value;
-        if (string.IsNullOrEmpty(subject))
+        var rawSubject = claims!.FindFirst("sub")?.Value;
+        if (string.IsNullOrEmpty(rawSubject))
             return RedirectToWebUiWithError("ID token is missing a subject claim.");
 
-        var (user, userError) = ResolveUser(claims, subject);
+        // Prefix with the authority so switching Settings.Oidc.Authority can never make an
+        // identity minted by a different provider resolve to the same external auth ID.
+        var externalAuthID = $"{settings.Authority}::{rawSubject}";
+
+        var (user, userError) = statePayload.LinkUserID is { } linkUserID
+            ? LinkUser(linkUserID, externalAuthID)
+            : ResolveUser(externalAuthID);
         if (userError is not null)
             return RedirectToWebUiWithError(userError);
 
-        var apiToken = await userService.GenerateApiTokenForUser(user!, "OIDC");
-        return RedirectToWebUiWithToken(apiToken.Token, user!.Username, statePayload.ReturnUrl);
+        // Match the Shoko token's lifetime to the OIDC token's own expiry rather than a
+        // fixed value — a fresh login always mints a new token, so several can coexist
+        // with different expirations without any one of them ever being non-expiring.
+        if (GetExpiration(claims!) is not { } expiresAt || expiresAt <= DateTime.UtcNow.AddMinutes(1))
+            return RedirectToWebUiWithError("ID token is missing a valid expiration.");
+
+        var apiToken = await userService.GenerateApiTokenForUser(user!, $"OIDC — {settings.Authority}", expiresAt);
+        return RedirectToWebUiWithToken(apiToken.Token, statePayload.ReturnUrl);
     }
 
     private async Task<(string? IdToken, string? Error)> ExchangeCodeForIdTokenAsync(OpenIdConnectConfiguration configuration, OidcSettings settings, string code, string? forwardedProto)
@@ -188,28 +240,36 @@ public class OidcAuthController(
         return (claims, null);
     }
 
-    private (JMMUser? User, string? Error) ResolveUser(ClaimsIdentity claims, string subject)
+    private static DateTime? GetExpiration(ClaimsIdentity claims)
+        => claims.FindFirst("exp")?.Value is { } expClaim && long.TryParse(expClaim, out var expSeconds)
+            ? DateTimeOffset.FromUnixTimeSeconds(expSeconds).UtcDateTime
+            : null;
+
+    // Sign-in only ever resolves a user that was already explicitly linked via Link() —
+    // never matches by username or email, which would let anyone controlling (or
+    // impersonating) the IdP take over a same-named local account.
+    private (JMMUser? User, string? Error) ResolveUser(string externalAuthID)
     {
-        var user = userRepository.GetByExternalAuthID(subject);
-        if (user is not null)
-            return (user, null);
+        var user = userRepository.GetByExternalAuthID(externalAuthID);
+        return user is not null
+            ? (user, null)
+            : (null, "No local Shoko account is linked to this SSO identity. Sign in locally and link your account first.");
+    }
 
-        // First SSO login for this external identity — link to a
-        // pre-existing local account by username or email, never create one.
-        // Only trust the email claim for matching if the provider marked it
-        // verified; an unverified email lets any IdP user claim someone else's.
-        var emailVerified = bool.TryParse(claims.FindFirst("email_verified")?.Value, out var verified) && verified;
-        var candidateNames = new[]
-        {
-            claims.FindFirst("preferred_username")?.Value,
-            emailVerified ? claims.FindFirst("email")?.Value : null,
-        }.Where(name => !string.IsNullOrWhiteSpace(name));
-
-        user = candidateNames.Select(userRepository.GetByUsername).FirstOrDefault(u => u is not null);
+    private (JMMUser? User, string? Error) LinkUser(int linkUserID, string externalAuthID)
+    {
+        var user = userRepository.GetByID(linkUserID);
         if (user is null)
-            return (null, "No local Shoko account matches your SSO identity. Ask an admin to check your username/email.");
+            return (null, "The account that started this link no longer exists.");
 
-        user.ExternalAuthID = subject;
+        var existingLink = userRepository.GetByExternalAuthID(externalAuthID);
+        if (existingLink is not null && existingLink.JMMUserID != user.JMMUserID)
+            return (null, "This SSO identity is already linked to a different local account.");
+
+        if (user.ExternalAuthID is not null && user.ExternalAuthID != externalAuthID)
+            return (null, "This local account is already linked to a different SSO identity. Unlink it first.");
+
+        user.ExternalAuthID = externalAuthID;
         userRepository.Save(user);
         return (user, null);
     }
@@ -249,16 +309,15 @@ public class OidcAuthController(
         }
     }
 
-    private ActionResult RedirectToWebUiWithToken(string token, string username, string? returnUrl)
+    private ActionResult RedirectToWebUiWithToken(string token, string? returnUrl)
     {
-        var basePath = settingsProvider.GetSettings().Web.WebUIPublicPath.TrimEnd('/');
-        var target = string.IsNullOrWhiteSpace(returnUrl) ? basePath : returnUrl;
-        return Redirect($"{target}#oidcToken={Uri.EscapeDataString(token)}&oidcUsername={Uri.EscapeDataString(username)}");
+        returnUrl ??= settingsProvider.GetSettings().Web.WebUIPublicPath;
+        return Redirect($"{returnUrl}#oidcToken={Uri.EscapeDataString(token)}");
     }
 
     private ActionResult RedirectToWebUiWithError(string message)
     {
-        var basePath = settingsProvider.GetSettings().Web.WebUIPublicPath.TrimEnd('/');
-        return Redirect($"{basePath}#oidcError={Uri.EscapeDataString(message)}");
+        var returnUrl = settingsProvider.GetSettings().Web.WebUIPublicPath;
+        return Redirect($"{returnUrl}#oidcError={Uri.EscapeDataString(message)}");
     }
 }

--- a/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
+++ b/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
@@ -51,18 +51,12 @@ public class OidcAuthController(
     private const string ProtectorPurpose = "Shoko.Server.OidcAuth.State";
     private static readonly TimeSpan StateLifetime = TimeSpan.FromMinutes(10);
 
-    // Discovery documents are cached/auto-refreshed per authority by ConfigurationManager
-    // itself — creating a new one per request would re-fetch on every single login. Keyed
-    // by authority so a change to Settings.Oidc.Authority picks up a fresh manager instead
-    // of reusing a stale one.
+    // One long-lived ConfigurationManager per authority — avoids re-fetching the discovery document on every login.
     private static readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> ConfigManagers = new();
 
     private OidcSettings Settings => settingsProvider.GetSettings().Oidc;
 
-    // LinkUserID is only ever populated by the authenticated Link endpoint, never
-    // attacker-controlled — the payload is signed/encrypted by IDataProtector.
-    // CodeVerifier is the PKCE verifier generated for this attempt; only ever compared
-    // against what we send back to the token endpoint under our own control.
+    // Signed/encrypted via IDataProtector — LinkUserID and CodeVerifier are never attacker-controlled.
     private sealed record StatePayload(string Nonce, string CodeVerifier, string? ReturnUrl, DateTime CreatedAt, int? LinkUserID = null);
 
     /// <summary>
@@ -102,9 +96,7 @@ public class OidcAuthController(
         return NoContent();
     }
 
-    // Tokens are keyed by device name "OIDC — {authority} — {subject}", so a provider-scoped
-    // prefix match invalidates every token minted for this user under the given authority
-    // without needing to look up the OIDC settings, which may have already changed.
+    // Tokens are keyed by device name "OIDC — {authority} — {subject}", so a prefix match invalidates them all.
     private void InvalidateProviderTokens(int userID, string externalAuthID)
     {
         var authority = externalAuthID.Split("::", 2)[0];
@@ -117,8 +109,7 @@ public class OidcAuthController(
         if (error is not null)
             return error;
 
-        // returnUrl must be a local path — otherwise a crafted Challenge/Link link could redirect
-        // the freshly minted API token (delivered via URL fragment) to an attacker-controlled origin.
+        // Local-only — the token is delivered via URL fragment on redirect, so an open redirect here would leak it.
         var safeReturnUrl = returnUrl is not null && Url.IsLocalUrl(returnUrl) ? returnUrl : null;
 
         var nonce = Guid.NewGuid().ToString("N");
@@ -140,8 +131,7 @@ public class OidcAuthController(
         return Redirect(authorizeUrl);
     }
 
-    // OAuth 2.1 mandates PKCE for every client, confidential or not — it closes the
-    // authorization-code-interception gap even when a client secret is also in play.
+    // OAuth 2.1 mandates PKCE for every client — closes the code-interception gap even with a client secret.
     private static string GeneratePkceCodeVerifier()
         => Base64UrlEncoder.Encode(RandomNumberGenerator.GetBytes(32));
 
@@ -180,9 +170,7 @@ public class OidcAuthController(
         var (claims, validationError) = await ValidateIdTokenAsync(configuration, settings, idToken, statePayload.Nonce);
         if (claims is null)
         {
-            // The cached ConfigurationManager (see GetProviderConfigurationAsync) can be
-            // serving a signing key set from before the IdP rotated its keys — force a refresh
-            // and retry once before giving up, same as OpenIdConnectHandler does internally.
+            // Cached signing keys may predate an IdP key rotation — refresh and retry once before giving up.
             RequestConfigurationRefresh(settings.Authority);
             configuration = await GetProviderConfigurationAsync(settings.Authority);
             (claims, validationError) = await ValidateIdTokenAsync(configuration, settings, idToken, statePayload.Nonce);
@@ -194,8 +182,7 @@ public class OidcAuthController(
         if (string.IsNullOrEmpty(rawSubject))
             return RedirectToWebUiWithError("ID token is missing a subject claim.");
 
-        // Prefix with the authority so switching Settings.Oidc.Authority can never make an
-        // identity minted by a different provider resolve to the same external auth ID.
+        // Prefixed with authority so identities from different providers never collide.
         var externalAuthID = $"{settings.Authority}::{rawSubject}";
 
         var (user, userError) = statePayload.LinkUserID is { } linkUserID
@@ -204,14 +191,10 @@ public class OidcAuthController(
         if (userError is not null)
             return RedirectToWebUiWithError(userError);
 
-        // Match the Shoko token's lifetime to the OIDC token's own expiry rather than a
-        // fixed value — a fresh login always mints a new token, so several can coexist
-        // with different expirations without any one of them ever being non-expiring.
+        // Token lifetime matches the OIDC token's own expiry rather than a fixed value.
         if (GetExpiration(claims) is not { } expiresAt || expiresAt <= DateTime.UtcNow.AddMinutes(1))
             return RedirectToWebUiWithError("ID token is missing a valid expiration.");
 
-        // Subject is part of the device name (not just externalAuthID) so a provider-scoped
-        // Unlink() can target exactly the tokens minted for this identity via prefix match.
         var apiToken = await userService.GenerateApiTokenForUser(user, $"OIDC — {settings.Authority} — {rawSubject}", expiresAt);
         return RedirectToWebUiWithToken(apiToken.Token, statePayload.ReturnUrl);
     }
@@ -242,17 +225,13 @@ public class OidcAuthController(
 
     private static async Task<(ClaimsIdentity? Claims, string? Error)> ValidateIdTokenAsync(OpenIdConnectConfiguration configuration, OidcSettings settings, string idToken, string expectedNonce)
     {
-        // Guaranteed non-null by GetEnabledConfigurationAsync's early-return check, but that
-        // guarantee doesn't cross the method boundary for the compiler's nullable analysis.
+        // Non-null guaranteed by GetEnabledConfigurationAsync's check, but that doesn't cross the method boundary.
         ArgumentException.ThrowIfNullOrWhiteSpace(settings.Authority);
 
         var handler = new JsonWebTokenHandler();
         var validationResult = await handler.ValidateTokenAsync(idToken, new TokenValidationParameters
         {
-            // Pinned to the configured Authority rather than configuration.Issuer — trusting
-            // whatever issuer the discovery document self-declares is circular; the document
-            // can only be believed once it's already been confirmed to describe our authority
-            // (checked in GetEnabledConfigurationAsync).
+            // Pinned to configured Authority, not the self-declared discovery-document issuer — see GetEnabledConfigurationAsync.
             ValidIssuer = settings.Authority.TrimEnd('/'),
             ValidAudience = settings.ClientID,
             IssuerSigningKeys = configuration.SigningKeys,
@@ -274,11 +253,7 @@ public class OidcAuthController(
             ? DateTimeOffset.FromUnixTimeSeconds(expSeconds).UtcDateTime
             : null;
 
-    // Sign-in only ever resolves a user that was already explicitly linked via Link() —
-    // never matches by username or email, which would let anyone controlling (or
-    // impersonating) the IdP take over a same-named local account. The one opt-in exception
-    // is AutoCreateUsers, which provisions a brand new account rather than linking an
-    // existing one, so it can't be used to take over anything.
+    // Never matches by username/email (account-takeover risk) — only an explicit prior Link(), or AutoCreateUsers provisioning a new account.
     private async Task<(JMMUser? User, string? Error)> ResolveUserAsync(string externalAuthID, string rawSubject, OidcSettings settings)
     {
         var user = userRepository.GetByExternalAuthID(externalAuthID);
@@ -343,10 +318,7 @@ public class OidcAuthController(
             return (settings, null, RedirectToWebUiWithError("Could not reach the OIDC provider. Please try again later."));
         }
 
-        // The discovery document is allowed to self-declare its issuer, but we only trust
-        // that declaration once it's confirmed to match the authority the admin configured
-        // — otherwise a compromised or misdirected discovery fetch could redefine its own
-        // trust anchor and ValidateIdTokenAsync's ValidIssuer check would be meaningless.
+        // Self-declared discovery-document issuer is only trusted once it matches the admin-configured authority.
         if (!string.Equals(configuration.Issuer?.TrimEnd('/'), settings.Authority.TrimEnd('/'), StringComparison.Ordinal))
         {
             logger.LogWarning("OIDC discovery document issuer {Issuer} does not match configured authority {Authority}", configuration.Issuer, settings.Authority);
@@ -358,9 +330,7 @@ public class OidcAuthController(
 
     private static Task<OpenIdConnectConfiguration> GetProviderConfigurationAsync(string authority)
     {
-        // ConfigurationManager caches and auto-refreshes internally — instantiating a new one
-        // per request would defeat that and re-fetch the discovery document (and JWKS) on
-        // every single login attempt. One long-lived instance per configured authority.
+        // One long-lived instance per authority — a new manager per request would re-fetch the discovery document every login.
         var manager = ConfigManagers.GetOrAdd(authority, static a => new ConfigurationManager<OpenIdConnectConfiguration>(
             a.TrimEnd('/') + "/.well-known/openid-configuration",
             new OpenIdConnectConfigurationRetriever()));
@@ -373,13 +343,10 @@ public class OidcAuthController(
             manager.RequestRefresh();
     }
 
-    // A fixed, admin-configured redirect_uri rather than one derived from the request's Host
-    // header — OIDC providers require the exact redirect_uri to be pre-registered anyway, so
-    // deriving it dynamically only adds a Host-header-trust surface for no benefit.
+    // Fixed, admin-configured redirect_uri instead of Host-header-derived — avoids a Host-header-trust surface for no benefit.
     private static string BuildRedirectUri(OidcSettings settings)
     {
-        // Guaranteed non-null by GetEnabledConfigurationAsync's early-return check, but that
-        // guarantee doesn't cross the method boundary for the compiler's nullable analysis.
+        // Non-null guaranteed by GetEnabledConfigurationAsync's check, but that doesn't cross the method boundary.
         ArgumentException.ThrowIfNullOrWhiteSpace(settings.PublicUrl);
         return $"{settings.PublicUrl.TrimEnd('/')}/api/v3/Auth/Oidc/Callback";
     }

--- a/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
+++ b/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -50,11 +51,19 @@ public class OidcAuthController(
     private const string ProtectorPurpose = "Shoko.Server.OidcAuth.State";
     private static readonly TimeSpan StateLifetime = TimeSpan.FromMinutes(10);
 
+    // Discovery documents are cached/auto-refreshed per authority by ConfigurationManager
+    // itself — creating a new one per request would re-fetch on every single login. Keyed
+    // by authority so a change to Settings.Oidc.Authority picks up a fresh manager instead
+    // of reusing a stale one.
+    private static readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> ConfigManagers = new();
+
     private OidcSettings Settings => settingsProvider.GetSettings().Oidc;
 
     // LinkUserID is only ever populated by the authenticated Link endpoint, never
     // attacker-controlled — the payload is signed/encrypted by IDataProtector.
-    private sealed record StatePayload(string Nonce, string? ReturnUrl, DateTime CreatedAt, int? LinkUserID = null);
+    // CodeVerifier is the PKCE verifier generated for this attempt; only ever compared
+    // against what we send back to the token endpoint under our own control.
+    private sealed record StatePayload(string Nonce, string CodeVerifier, string? ReturnUrl, DateTime CreatedAt, int? LinkUserID = null);
 
     /// <summary>
     /// Redirects the browser to the configured OIDC provider's authorization
@@ -62,10 +71,8 @@ public class OidcAuthController(
     /// </summary>
     [HttpGet("Challenge")]
     [AllowAnonymous]
-    public async Task<ActionResult> Challenge(
-        [FromQuery] string? returnUrl = null,
-        [FromHeader(Name = "X-Forwarded-Proto")] string? forwardedProto = null)
-        => await StartAuthorizeAsync(returnUrl, linkUserID: null, forwardedProto);
+    public async Task<ActionResult> Challenge([FromQuery] string? returnUrl = null)
+        => await StartAuthorizeAsync(returnUrl, linkUserID: null);
 
     /// <summary>
     /// Starts the OIDC flow to link the currently signed-in local account to
@@ -75,10 +82,8 @@ public class OidcAuthController(
     /// </summary>
     [HttpGet("Link")]
     [Authorize]
-    public async Task<ActionResult> Link(
-        [FromQuery] string? returnUrl = null,
-        [FromHeader(Name = "X-Forwarded-Proto")] string? forwardedProto = null)
-        => await StartAuthorizeAsync(returnUrl, linkUserID: User.JMMUserID, forwardedProto);
+    public async Task<ActionResult> Link([FromQuery] string? returnUrl = null)
+        => await StartAuthorizeAsync(returnUrl, linkUserID: User.JMMUserID);
 
     /// <summary>
     /// Removes the external identity link from the currently signed-in
@@ -106,7 +111,7 @@ public class OidcAuthController(
         authTokensRepository.DeleteWithUserIDAndDevicePrefix(userID, $"OIDC — {authority}");
     }
 
-    private async Task<ActionResult> StartAuthorizeAsync(string? returnUrl, int? linkUserID, string? forwardedProto)
+    private async Task<ActionResult> StartAuthorizeAsync(string? returnUrl, int? linkUserID)
     {
         var (settings, configuration, error) = await GetEnabledConfigurationAsync();
         if (error is not null)
@@ -117,20 +122,31 @@ public class OidcAuthController(
         var safeReturnUrl = returnUrl is not null && Url.IsLocalUrl(returnUrl) ? returnUrl : null;
 
         var nonce = Guid.NewGuid().ToString("N");
-        var state = ProtectState(new StatePayload(nonce, safeReturnUrl, DateTime.UtcNow, linkUserID));
+        var codeVerifier = GeneratePkceCodeVerifier();
+        var state = ProtectState(new StatePayload(nonce, codeVerifier, safeReturnUrl, DateTime.UtcNow, linkUserID));
 
         var authorizeUrl = QueryHelpers.AddQueryString(configuration.AuthorizationEndpoint, new Dictionary<string, string?>
         {
             ["client_id"] = settings.ClientID,
             ["response_type"] = "code",
             ["scope"] = "openid profile email",
-            ["redirect_uri"] = BuildRedirectUri(forwardedProto),
+            ["redirect_uri"] = BuildRedirectUri(settings),
             ["state"] = state,
             ["nonce"] = nonce,
+            ["code_challenge"] = ComputePkceCodeChallenge(codeVerifier),
+            ["code_challenge_method"] = "S256",
         });
 
         return Redirect(authorizeUrl);
     }
+
+    // OAuth 2.1 mandates PKCE for every client, confidential or not — it closes the
+    // authorization-code-interception gap even when a client secret is also in play.
+    private static string GeneratePkceCodeVerifier()
+        => Base64UrlEncoder.Encode(RandomNumberGenerator.GetBytes(32));
+
+    private static string ComputePkceCodeChallenge(string codeVerifier)
+        => Base64UrlEncoder.Encode(SHA256.HashData(Encoding.ASCII.GetBytes(codeVerifier)));
 
     /// <summary>
     /// Handles the redirect back from the OIDC provider, exchanges the code
@@ -142,8 +158,7 @@ public class OidcAuthController(
     public async Task<ActionResult> Callback(
         [FromQuery] string? code,
         [FromQuery] string? state,
-        [FromQuery] string? error,
-        [FromHeader(Name = "X-Forwarded-Proto")] string? forwardedProto = null)
+        [FromQuery] string? error)
     {
         if (!string.IsNullOrEmpty(error))
             return RedirectToWebUiWithError($"OIDC provider returned an error: {error}");
@@ -158,7 +173,7 @@ public class OidcAuthController(
         if (configError is not null)
             return configError;
 
-        var (idToken, exchangeError) = await ExchangeCodeForIdTokenAsync(configuration, settings, code, forwardedProto);
+        var (idToken, exchangeError) = await ExchangeCodeForIdTokenAsync(configuration, settings, code, statePayload.CodeVerifier);
         if (exchangeError is not null)
             return RedirectToWebUiWithError(exchangeError);
 
@@ -192,16 +207,17 @@ public class OidcAuthController(
         return RedirectToWebUiWithToken(apiToken.Token, statePayload.ReturnUrl);
     }
 
-    private async Task<(string? IdToken, string? Error)> ExchangeCodeForIdTokenAsync(OpenIdConnectConfiguration configuration, OidcSettings settings, string code, string? forwardedProto)
+    private async Task<(string? IdToken, string? Error)> ExchangeCodeForIdTokenAsync(OpenIdConnectConfiguration configuration, OidcSettings settings, string code, string codeVerifier)
     {
         var client = httpClientFactory.CreateClient("Default");
         using var tokenResponse = await client.PostAsync(configuration.TokenEndpoint, new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["grant_type"] = "authorization_code",
             ["code"] = code,
-            ["redirect_uri"] = BuildRedirectUri(forwardedProto),
+            ["redirect_uri"] = BuildRedirectUri(settings),
             ["client_id"] = settings.ClientID,
             ["client_secret"] = settings.ClientSecret ?? string.Empty,
+            ["code_verifier"] = codeVerifier,
         }));
 
         if (!tokenResponse.IsSuccessStatusCode)
@@ -220,7 +236,11 @@ public class OidcAuthController(
         var handler = new JsonWebTokenHandler();
         var validationResult = await handler.ValidateTokenAsync(idToken, new TokenValidationParameters
         {
-            ValidIssuer = configuration.Issuer,
+            // Pinned to the configured Authority rather than configuration.Issuer — trusting
+            // whatever issuer the discovery document self-declares is circular; the document
+            // can only be believed once it's already been confirmed to describe our authority
+            // (checked in GetEnabledConfigurationAsync).
+            ValidIssuer = settings.Authority!.TrimEnd('/'),
             ValidAudience = settings.ClientID,
             IssuerSigningKeys = configuration.SigningKeys,
         });
@@ -296,39 +316,49 @@ public class OidcAuthController(
     private async Task<(OidcSettings Settings, OpenIdConnectConfiguration Configuration, ActionResult? Error)> GetEnabledConfigurationAsync()
     {
         var settings = Settings;
-        if (!settings.Enabled || string.IsNullOrWhiteSpace(settings.Authority) || string.IsNullOrWhiteSpace(settings.ClientID))
+        if (!settings.Enabled || string.IsNullOrWhiteSpace(settings.Authority) || string.IsNullOrWhiteSpace(settings.ClientID) || string.IsNullOrWhiteSpace(settings.PublicUrl))
             return (settings, null, NotFound("OIDC sign-in is not enabled."));
 
+        OpenIdConnectConfiguration configuration;
         try
         {
-            return (settings, await GetProviderConfigurationAsync(settings.Authority), null);
+            configuration = await GetProviderConfigurationAsync(settings.Authority);
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Could not fetch OIDC discovery document from authority {Authority}", settings.Authority);
             return (settings, null, RedirectToWebUiWithError("Could not reach the OIDC provider. Please try again later."));
         }
+
+        // The discovery document is allowed to self-declare its issuer, but we only trust
+        // that declaration once it's confirmed to match the authority the admin configured
+        // — otherwise a compromised or misdirected discovery fetch could redefine its own
+        // trust anchor and ValidateIdTokenAsync's ValidIssuer check would be meaningless.
+        if (!string.Equals(configuration.Issuer?.TrimEnd('/'), settings.Authority.TrimEnd('/'), StringComparison.Ordinal))
+        {
+            logger.LogWarning("OIDC discovery document issuer {Issuer} does not match configured authority {Authority}", configuration.Issuer, settings.Authority);
+            return (settings, null, RedirectToWebUiWithError("OIDC provider configuration mismatch. Please contact your administrator."));
+        }
+
+        return (settings, configuration, null);
     }
 
-    private static async Task<OpenIdConnectConfiguration> GetProviderConfigurationAsync(string authority)
+    private static Task<OpenIdConnectConfiguration> GetProviderConfigurationAsync(string authority)
     {
-        var manager = new ConfigurationManager<OpenIdConnectConfiguration>(
-            authority.TrimEnd('/') + "/.well-known/openid-configuration",
-            new OpenIdConnectConfigurationRetriever());
-        return await manager.GetConfigurationAsync();
+        // ConfigurationManager caches and auto-refreshes internally — instantiating a new one
+        // per request would defeat that and re-fetch the discovery document (and JWKS) on
+        // every single login attempt. One long-lived instance per configured authority.
+        var manager = ConfigManagers.GetOrAdd(authority, static a => new ConfigurationManager<OpenIdConnectConfiguration>(
+            a.TrimEnd('/') + "/.well-known/openid-configuration",
+            new OpenIdConnectConfigurationRetriever()));
+        return manager.GetConfigurationAsync();
     }
 
-    private string BuildRedirectUri(string? forwardedProto)
-    {
-        // Request.Scheme reflects the connection Kestrel actually accepted, which is
-        // http when Shoko sits behind a TLS-terminating reverse proxy. Honor
-        // X-Forwarded-Proto so the redirect_uri we send matches what's registered
-        // with the OIDC provider.
-        var scheme = !string.IsNullOrWhiteSpace(forwardedProto)
-            ? forwardedProto.Split(',')[0].Trim()
-            : Request.Scheme;
-        return $"{scheme}://{Request.Host}/api/v3/Auth/Oidc/Callback";
-    }
+    // A fixed, admin-configured redirect_uri rather than one derived from the request's Host
+    // header — OIDC providers require the exact redirect_uri to be pre-registered anyway, so
+    // deriving it dynamically only adds a Host-header-trust surface for no benefit.
+    private static string BuildRedirectUri(OidcSettings settings)
+        => $"{settings.PublicUrl!.TrimEnd('/')}/api/v3/Auth/Oidc/Callback";
 
     private string ProtectState(StatePayload payload)
         => dataProtectionProvider.CreateProtector(ProtectorPurpose).Protect(JsonSerializer.Serialize(payload));

--- a/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
+++ b/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -37,6 +38,7 @@ namespace Shoko.Server.API.v3.Controllers;
 [Route("/api/v{version:apiVersion}/Auth/Oidc")]
 [ApiV3]
 public class OidcAuthController(
+    ILogger<OidcAuthController> logger,
     ISettingsProvider settingsProvider,
     JMMUserRepository userRepository,
     AuthTokensRepository authTokensRepository,
@@ -110,8 +112,12 @@ public class OidcAuthController(
         if (error is not null)
             return error;
 
+        // returnUrl must be a local path — otherwise a crafted Challenge/Link link could redirect
+        // the freshly minted API token (delivered via URL fragment) to an attacker-controlled origin.
+        var safeReturnUrl = returnUrl is not null && Url.IsLocalUrl(returnUrl) ? returnUrl : null;
+
         var nonce = Guid.NewGuid().ToString("N");
-        var state = ProtectState(new StatePayload(nonce, returnUrl, DateTime.UtcNow, linkUserID));
+        var state = ProtectState(new StatePayload(nonce, safeReturnUrl, DateTime.UtcNow, linkUserID));
 
         var authorizeUrl = QueryHelpers.AddQueryString(configuration.AuthorizationEndpoint, new Dictionary<string, string?>
         {
@@ -156,7 +162,7 @@ public class OidcAuthController(
         if (exchangeError is not null)
             return RedirectToWebUiWithError(exchangeError);
 
-        var (claims, validationError) = await ValidateIdTokenAsync(configuration, settings, idToken!, statePayload.Nonce);
+        var (claims, validationError) = await ValidateIdTokenAsync(configuration, settings, idToken, statePayload.Nonce);
         if (validationError is not null || claims is null)
             return RedirectToWebUiWithError(validationError ?? "ID token validation failed.");
 
@@ -182,7 +188,7 @@ public class OidcAuthController(
 
         // Subject is part of the device name (not just externalAuthID) so a provider-scoped
         // Unlink() can target exactly the tokens minted for this identity via prefix match.
-        var apiToken = await userService.GenerateApiTokenForUser(user!, $"OIDC — {settings.Authority} — {rawSubject}", expiresAt);
+        var apiToken = await userService.GenerateApiTokenForUser(user, $"OIDC — {settings.Authority} — {rawSubject}", expiresAt);
         return RedirectToWebUiWithToken(apiToken.Token, statePayload.ReturnUrl);
     }
 
@@ -194,7 +200,7 @@ public class OidcAuthController(
             ["grant_type"] = "authorization_code",
             ["code"] = code,
             ["redirect_uri"] = BuildRedirectUri(forwardedProto),
-            ["client_id"] = settings.ClientID!,
+            ["client_id"] = settings.ClientID,
             ["client_secret"] = settings.ClientSecret ?? string.Empty,
         }));
 
@@ -291,15 +297,16 @@ public class OidcAuthController(
     {
         var settings = Settings;
         if (!settings.Enabled || string.IsNullOrWhiteSpace(settings.Authority) || string.IsNullOrWhiteSpace(settings.ClientID))
-            return (settings, null!, NotFound("OIDC sign-in is not enabled."));
+            return (settings, null, NotFound("OIDC sign-in is not enabled."));
 
         try
         {
             return (settings, await GetProviderConfigurationAsync(settings.Authority), null);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            return (settings, null!, RedirectToWebUiWithError("Could not reach the OIDC provider. Please try again later."));
+            logger.LogWarning(ex, "Could not fetch OIDC discovery document from authority {Authority}", settings.Authority);
+            return (settings, null, RedirectToWebUiWithError("Could not reach the OIDC provider. Please try again later."));
         }
     }
 

--- a/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
+++ b/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
@@ -242,6 +242,10 @@ public class OidcAuthController(
 
     private static async Task<(ClaimsIdentity? Claims, string? Error)> ValidateIdTokenAsync(OpenIdConnectConfiguration configuration, OidcSettings settings, string idToken, string expectedNonce)
     {
+        // Guaranteed non-null by GetEnabledConfigurationAsync's early-return check, but that
+        // guarantee doesn't cross the method boundary for the compiler's nullable analysis.
+        ArgumentException.ThrowIfNullOrWhiteSpace(settings.Authority);
+
         var handler = new JsonWebTokenHandler();
         var validationResult = await handler.ValidateTokenAsync(idToken, new TokenValidationParameters
         {
@@ -249,7 +253,7 @@ public class OidcAuthController(
             // whatever issuer the discovery document self-declares is circular; the document
             // can only be believed once it's already been confirmed to describe our authority
             // (checked in GetEnabledConfigurationAsync).
-            ValidIssuer = settings.Authority!.TrimEnd('/'),
+            ValidIssuer = settings.Authority.TrimEnd('/'),
             ValidAudience = settings.ClientID,
             IssuerSigningKeys = configuration.SigningKeys,
         });
@@ -373,7 +377,12 @@ public class OidcAuthController(
     // header — OIDC providers require the exact redirect_uri to be pre-registered anyway, so
     // deriving it dynamically only adds a Host-header-trust surface for no benefit.
     private static string BuildRedirectUri(OidcSettings settings)
-        => $"{settings.PublicUrl!.TrimEnd('/')}/api/v3/Auth/Oidc/Callback";
+    {
+        // Guaranteed non-null by GetEnabledConfigurationAsync's early-return check, but that
+        // guarantee doesn't cross the method boundary for the compiler's nullable analysis.
+        ArgumentException.ThrowIfNullOrWhiteSpace(settings.PublicUrl);
+        return $"{settings.PublicUrl.TrimEnd('/')}/api/v3/Auth/Oidc/Callback";
+    }
 
     private string ProtectState(StatePayload payload)
         => dataProtectionProvider.CreateProtector(ProtectorPurpose).Protect(JsonSerializer.Serialize(payload));

--- a/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
+++ b/Shoko.Server/API/v3/Controllers/OidcAuthController.cs
@@ -178,8 +178,17 @@ public class OidcAuthController(
             return RedirectToWebUiWithError(exchangeError);
 
         var (claims, validationError) = await ValidateIdTokenAsync(configuration, settings, idToken, statePayload.Nonce);
-        if (validationError is not null || claims is null)
-            return RedirectToWebUiWithError(validationError ?? "ID token validation failed.");
+        if (claims is null)
+        {
+            // The cached ConfigurationManager (see GetProviderConfigurationAsync) can be
+            // serving a signing key set from before the IdP rotated its keys — force a refresh
+            // and retry once before giving up, same as OpenIdConnectHandler does internally.
+            RequestConfigurationRefresh(settings.Authority);
+            configuration = await GetProviderConfigurationAsync(settings.Authority);
+            (claims, validationError) = await ValidateIdTokenAsync(configuration, settings, idToken, statePayload.Nonce);
+            if (claims is null)
+                return RedirectToWebUiWithError(validationError ?? "ID token validation failed.");
+        }
 
         var rawSubject = claims.FindFirst("sub")?.Value;
         if (string.IsNullOrEmpty(rawSubject))
@@ -352,6 +361,12 @@ public class OidcAuthController(
             a.TrimEnd('/') + "/.well-known/openid-configuration",
             new OpenIdConnectConfigurationRetriever()));
         return manager.GetConfigurationAsync();
+    }
+
+    private static void RequestConfigurationRefresh(string authority)
+    {
+        if (ConfigManagers.TryGetValue(authority, out var manager))
+            manager.RequestRefresh();
     }
 
     // A fixed, admin-configured redirect_uri rather than one derived from the request's Host

--- a/Shoko.Server/API/v3/Models/Shoko/ServerStatus.cs
+++ b/Shoko.Server/API/v3/Models/Shoko/ServerStatus.cs
@@ -19,6 +19,13 @@ public class ServerStatus
     public string? StartupMessage { get; set; }
 
     /// <summary>
+    /// Whether OIDC single sign-on is configured and available as a login
+    /// option. Does not reveal the provider or any other details — just
+    /// whether the button should be shown.
+    /// </summary>
+    public bool OidcEnabled { get; set; }
+
+    /// <summary>
     /// Indicates that we can perform a controlled shutdown.
     /// </summary>
     /// <remarks>

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -1144,6 +1144,7 @@ public class MySQL(SystemService systemService) : BaseDatabase<MySqlConnection>(
                      )
                      WHERE sri.`CrossReferences` LIKE '%AnidbEpisodeID%'
                      """),
+        new(184,  1, "ALTER TABLE `JMMUser` ADD COLUMN `ExternalAuthID` VARCHAR(255) NULL DEFAULT NULL;"),
     ];
 
     #endregion

--- a/Shoko.Server/Databases/MySQL.cs
+++ b/Shoko.Server/Databases/MySQL.cs
@@ -1145,6 +1145,7 @@ public class MySQL(SystemService systemService) : BaseDatabase<MySqlConnection>(
                      WHERE sri.`CrossReferences` LIKE '%AnidbEpisodeID%'
                      """),
         new(184,  1, "ALTER TABLE `JMMUser` ADD COLUMN `ExternalAuthID` VARCHAR(255) NULL DEFAULT NULL;"),
+        new(184,  2, "ALTER TABLE `JMMUser` ADD UNIQUE INDEX `UIX_JMMUser_ExternalAuthID` (`ExternalAuthID` ASC);"),
     ];
 
     #endregion

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -1098,6 +1098,7 @@ public class SQLServer(SystemService systemService) : BaseDatabase<SqlConnection
         new(180, 37, "ALTER TABLE TMDB_Title ADD CONSTRAINT PK_TMDB_Title PRIMARY KEY CLUSTERED (TMDB_TitleID);"),
         new(180, 38, "ALTER TABLE VideoLocal_HashDigest ADD CONSTRAINT PK_VideoLocal_HashDigest PRIMARY KEY CLUSTERED (VideoLocal_HashDigestID);"),
         new(181,  1, "ALTER TABLE JMMUser ADD ExternalAuthID NVARCHAR(255) NULL DEFAULT NULL;"),
+        new(181,  2, "CREATE UNIQUE INDEX UIX_JMMUser_ExternalAuthID ON JMMUser(ExternalAuthID) WHERE ExternalAuthID IS NOT NULL;"),
     ];
 
     #endregion

--- a/Shoko.Server/Databases/SQLServer.cs
+++ b/Shoko.Server/Databases/SQLServer.cs
@@ -1097,6 +1097,7 @@ public class SQLServer(SystemService systemService) : BaseDatabase<SqlConnection
         new(180, 36, "ALTER TABLE TMDB_Show_Network ADD CONSTRAINT PK_TMDB_Show_Network PRIMARY KEY CLUSTERED (TMDB_Show_NetworkID);"),
         new(180, 37, "ALTER TABLE TMDB_Title ADD CONSTRAINT PK_TMDB_Title PRIMARY KEY CLUSTERED (TMDB_TitleID);"),
         new(180, 38, "ALTER TABLE VideoLocal_HashDigest ADD CONSTRAINT PK_VideoLocal_HashDigest PRIMARY KEY CLUSTERED (VideoLocal_HashDigestID);"),
+        new(181,  1, "ALTER TABLE JMMUser ADD ExternalAuthID NVARCHAR(255) NULL DEFAULT NULL;"),
     ];
 
     #endregion

--- a/Shoko.Server/Databases/SQLite.cs
+++ b/Shoko.Server/Databases/SQLite.cs
@@ -944,6 +944,7 @@ public class SQLite(SystemService systemService) : BaseDatabase<SqliteConnection
                      )
                      WHERE CrossReferences LIKE '%AnidbEpisodeID%'
                      """),
+        new(163,  1, "ALTER TABLE JMMUser ADD COLUMN ExternalAuthID TEXT NULL DEFAULT NULL;"),
     ];
 
     #endregion

--- a/Shoko.Server/Databases/SQLite.cs
+++ b/Shoko.Server/Databases/SQLite.cs
@@ -945,6 +945,7 @@ public class SQLite(SystemService systemService) : BaseDatabase<SqliteConnection
                      WHERE CrossReferences LIKE '%AnidbEpisodeID%'
                      """),
         new(163,  1, "ALTER TABLE JMMUser ADD COLUMN ExternalAuthID TEXT NULL DEFAULT NULL;"),
+        new(163,  2, "CREATE UNIQUE INDEX UIX_JMMUser_ExternalAuthID ON JMMUser(ExternalAuthID) WHERE ExternalAuthID IS NOT NULL;"),
     ];
 
     #endregion

--- a/Shoko.Server/Mappings/JMMUserMap.cs
+++ b/Shoko.Server/Mappings/JMMUserMap.cs
@@ -16,6 +16,7 @@ public class JMMUserMap : ClassMap<JMMUser>
         Map(x => x.IsAniDBUser).Not.Nullable();
         Map(x => x.IsAdmin).Not.Nullable();
         Map(x => x.Password);
+        Map(x => x.ExternalAuthID);
         Map(x => x.Username);
         Map(x => x.CanEditServerSettings);
         Map(x => x.PlexUsers);

--- a/Shoko.Server/Models/Shoko/JMMUser.cs
+++ b/Shoko.Server/Models/Shoko/JMMUser.cs
@@ -28,6 +28,13 @@ public class JMMUser : IIdentity, IUser
 
     public string Password { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The "sub" claim of the OIDC provider this user last signed in with via
+    /// SSO. Null for users who have never used SSO. A user can still sign in
+    /// with their local password even when this is set.
+    /// </summary>
+    public string? ExternalAuthID { get; set; }
+
     public int IsAdmin { get; set; }
 
     public int IsAniDBUser { get; set; }

--- a/Shoko.Server/Repositories/Cached/AuthTokensRepository.cs
+++ b/Shoko.Server/Repositories/Cached/AuthTokensRepository.cs
@@ -66,6 +66,13 @@ public class AuthTokensRepository(DatabaseFactory databaseFactory) : BaseCachedR
     public IReadOnlyList<AuthTokens> GetByUserID(int userID)
         => _userIDs!.GetMultiple(userID);
 
+    public bool DeleteWithUserIDAndDevicePrefix(int userID, string devicePrefix)
+    {
+        var tokens = _userIDs!.GetMultiple(userID).Where(a => a.DeviceName.StartsWith(devicePrefix, StringComparison.Ordinal)).ToList();
+        Delete(tokens);
+        return tokens.Count > 0;
+    }
+
     public AuthTokens CreateNewApiKey(JMMUser user, string device)
     {
         var allTokensForUser = _userIDs!.GetMultiple(user.JMMUserID);

--- a/Shoko.Server/Repositories/Cached/AuthTokensRepository.cs
+++ b/Shoko.Server/Repositories/Cached/AuthTokensRepository.cs
@@ -68,7 +68,7 @@ public class AuthTokensRepository(DatabaseFactory databaseFactory) : BaseCachedR
 
     public bool DeleteWithUserIDAndDevicePrefix(int userID, string devicePrefix)
     {
-        var tokens = _userIDs!.GetMultiple(userID).Where(a => a.DeviceName.StartsWith(devicePrefix, StringComparison.Ordinal)).ToList();
+        var tokens = _userIDs.GetMultiple(userID).Where(a => a.DeviceName.StartsWith(devicePrefix, StringComparison.Ordinal)).ToList();
         Delete(tokens);
         return tokens.Count > 0;
     }

--- a/Shoko.Server/Repositories/Cached/JMMUserRepository.cs
+++ b/Shoko.Server/Repositories/Cached/JMMUserRepository.cs
@@ -18,6 +18,11 @@ public class JMMUserRepository(DatabaseFactory databaseFactory) : BaseCachedRepo
     public JMMUser? GetAniDBUser()
         => Cache.GetAll().FirstOrDefault(a => a.IsAniDBUser == 1);
 
+    public JMMUser? GetByExternalAuthID(string? externalAuthID)
+        => !string.IsNullOrWhiteSpace(externalAuthID)
+            ? Cache.GetAll().FirstOrDefault(user => string.Equals(user.ExternalAuthID, externalAuthID, StringComparison.Ordinal))
+            : null;
+
     public JMMUser? AuthenticateUser(string userName, string? password)
     {
         password ??= string.Empty;

--- a/Shoko.Server/Settings/IServerSettings.cs
+++ b/Shoko.Server/Settings/IServerSettings.cs
@@ -123,6 +123,12 @@ public interface IServerSettings
     WebSettings Web { get; set; }
 
     /// <summary>
+    /// Configure optional OpenID Connect single sign-on, additive to local
+    /// username/password login.
+    /// </summary>
+    OidcSettings Oidc { get; set; }
+
+    /// <summary>
     /// The web UI settings, as a stringified JSON object.
     /// </summary>
     string WebUI_Settings { get; set; }

--- a/Shoko.Server/Settings/OidcSettings.cs
+++ b/Shoko.Server/Settings/OidcSettings.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using Shoko.Abstractions.Config.Attributes;
+
+namespace Shoko.Server.Settings;
+
+/// <summary>
+/// Optional OpenID Connect single sign-on. Disabled by default and fully
+/// independent of local username/password login — enabling this adds an
+/// additional sign-in option on top of local accounts, it never replaces
+/// them. SSO only ever links to a pre-existing local account matched by
+/// username/email; it never creates new accounts.
+/// </summary>
+public class OidcSettings
+{
+    /// <summary>
+    /// Enable the "Sign in with SSO" option on the login page.
+    /// </summary>
+    [Display(Name = "Enable OIDC Sign-In")]
+    [DefaultValue(false)]
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Label shown on the WebUI's SSO login button, e.g. "Sign in with Authentik".
+    /// </summary>
+    [Display(Name = "Display Name")]
+    [DefaultValue("SSO")]
+    public string DisplayName { get; set; } = "SSO";
+
+    /// <summary>
+    /// The OIDC provider's issuer URL, e.g. https://auth.example.com/application/o/shoko/.
+    /// Shoko fetches /.well-known/openid-configuration from this URL.
+    /// </summary>
+    [Display(Name = "Issuer/Authority URL")]
+    public string? Authority { get; set; }
+
+    /// <summary>
+    /// The OAuth2 client ID registered with the OIDC provider for Shoko.
+    /// </summary>
+    [Display(Name = "Client ID")]
+    public string? ClientID { get; set; }
+
+    /// <summary>
+    /// The OAuth2 client secret registered with the OIDC provider for Shoko.
+    /// </summary>
+    [Display(Name = "Client Secret")]
+    [DataType(DataType.Password)]
+    public string? ClientSecret { get; set; }
+}

--- a/Shoko.Server/Settings/OidcSettings.cs
+++ b/Shoko.Server/Settings/OidcSettings.cs
@@ -9,7 +9,7 @@ namespace Shoko.Server.Settings;
 /// independent of local username/password login — enabling this adds an
 /// additional sign-in option on top of local accounts, it never replaces
 /// them. SSO only ever links to a pre-existing local account matched by
-/// username/email; it never creates new accounts.
+/// username/email, unless <see cref="AutoCreateUsers"/> is enabled.
 /// </summary>
 public class OidcSettings
 {
@@ -46,4 +46,15 @@ public class OidcSettings
     [Display(Name = "Client Secret")]
     [DataType(DataType.Password)]
     public string? ClientSecret { get; set; }
+
+    /// <summary>
+    /// Automatically create a new local account for a subject that signs in
+    /// without having been explicitly linked first, using the subject claim
+    /// as the username and a randomly generated password. Disabled by
+    /// default — sign-in normally only succeeds for an already-linked
+    /// account.
+    /// </summary>
+    [Display(Name = "Auto-Create Users")]
+    [DefaultValue(false)]
+    public bool AutoCreateUsers { get; set; }
 }

--- a/Shoko.Server/Settings/OidcSettings.cs
+++ b/Shoko.Server/Settings/OidcSettings.cs
@@ -35,6 +35,17 @@ public class OidcSettings
     public string? Authority { get; set; }
 
     /// <summary>
+    /// The externally-reachable base URL of this Shoko instance, e.g.
+    /// https://shoko.example.com. Used to build the fixed OIDC
+    /// <c>redirect_uri</c> instead of trusting the incoming request's Host
+    /// header, which a misconfigured or permissive reverse proxy could
+    /// otherwise let a client influence. Must match the redirect URI
+    /// registered with the OIDC provider exactly.
+    /// </summary>
+    [Display(Name = "Public URL")]
+    public string? PublicUrl { get; set; }
+
+    /// <summary>
     /// The OAuth2 client ID registered with the OIDC provider for Shoko.
     /// </summary>
     [Display(Name = "Client ID")]

--- a/Shoko.Server/Settings/ServerSettings.cs
+++ b/Shoko.Server/Settings/ServerSettings.cs
@@ -179,6 +179,17 @@ public class ServerSettings : IServerSettings, INewtonsoftJsonConfiguration, IHi
     /// <inheritdoc />
     public WebSettings Web { get; set; } = new();
 
+    /// <summary>
+    /// Configure optional OpenID Connect single sign-on, additive to local
+    /// username/password login. Deliberately not exposed through the
+    /// settings UI/API — edit settings-server.json directly to configure
+    /// this, so enabling it is a conscious, hands-on-the-server action
+    /// rather than a checkbox someone stumbles into from a browser.
+    /// </summary>
+    [Display(Name = "Single Sign-On (OIDC)")]
+    [Visibility(DisplayVisibility.Hidden)]
+    public OidcSettings Oidc { get; set; } = new();
+
     /// <inheritdoc />
     [SectionName("Web UI")]
     [Display(Name = "Settings")]

--- a/Shoko.Server/Settings/ServerSettings.cs
+++ b/Shoko.Server/Settings/ServerSettings.cs
@@ -181,6 +181,17 @@ public class ServerSettings : IServerSettings, INewtonsoftJsonConfiguration, IHi
     /// <inheritdoc />
     public WebSettings Web { get; set; } = new();
 
+    /// <summary>
+    /// Configure optional OpenID Connect single sign-on, additive to local
+    /// username/password login. Deliberately not exposed through the
+    /// settings UI/API — edit settings-server.json directly to configure
+    /// this, so enabling it is a conscious, hands-on-the-server action
+    /// rather than a checkbox someone stumbles into from a browser.
+    /// </summary>
+    [Display(Name = "Single Sign-On (OIDC)")]
+    [Visibility(DisplayVisibility.Hidden)]
+    public OidcSettings Oidc { get; set; } = new();
+
     /// <inheritdoc />
     [SectionName("Web UI")]
     [Display(Name = "Settings")]

--- a/Shoko.Server/Shoko.Server.csproj
+++ b/Shoko.Server/Shoko.Server.csproj
@@ -70,6 +70,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" />
     <PackageReference Include="MySqlBackup.NET.MySqlConnector" Version="2.7.1" />
     <PackageReference Include="MySqlConnector" Version="2.6.1" />

--- a/docs/oidc-sso-setup.md
+++ b/docs/oidc-sso-setup.md
@@ -35,8 +35,83 @@ Create a new OAuth2/OIDC client/application for Shoko with:
 
 Copy the resulting **Client ID** and **Client Secret**, and note the
 provider's **issuer/authority URL** (the base URL that serves
-`/.well-known/openid-configuration`, e.g.
-`https://auth.example.com/application/o/shoko/` for Authentik).
+`/.well-known/openid-configuration`).
+
+Below are worked examples for three common self-hosted providers — the
+underlying steps are the same for any OIDC-compliant IdP not listed here
+(Zitadel, Pocket ID, Casdoor, an Entra ID / Google Workspace tenant, etc.):
+just create a confidential Authorization Code client with the redirect URI
+above and copy the resulting values into the same three settings fields.
+
+<details>
+<summary><strong>Authentik</strong></summary>
+
+1. **Applications → Providers → Create** → type **OAuth2/OpenID Provider**.
+2. **Authorization flow**: `default-provider-authorization-explicit-consent`
+   (or your own).
+3. **Client type**: `Confidential`.
+4. **Redirect URIs**: `https://<your-shoko-public-url>/api/v3/Auth/Oidc/Callback`.
+5. **Scopes**: include `openid`, `email`, `profile`.
+6. Save, then **Applications → Applications → Create** and attach the
+   provider you just made.
+7. `Authority` = `https://<authentik-host>/application/o/<slug>/` (the
+   provider's **OpenID Configuration Issuer** shown on its overview page).
+
+Reference: [Create an OAuth2 provider — authentik docs](https://docs.goauthentik.io/add-secure-apps/providers/oauth2/create-oauth2-provider/)
+
+</details>
+
+<details>
+<summary><strong>Keycloak</strong></summary>
+
+1. **Clients → Create client**, protocol `openid-connect`.
+2. **Client authentication**: `On` (this makes it confidential and generates
+   a client secret under the **Credentials** tab after saving).
+3. **Standard flow**: `On` (this is the Authorization Code flow). Leave
+   Direct access grants / Implicit flow off.
+4. **Valid redirect URIs**: `https://<your-shoko-public-url>/api/v3/Auth/Oidc/Callback`.
+5. `Authority` = `https://<keycloak-host>/realms/<realm-name>` — Keycloak
+   serves discovery at `<Authority>/.well-known/openid-configuration`.
+
+Reference: [Managing OpenID Connect and SAML Clients — Keycloak/Red Hat docs](https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/22.0/html/server_administration_guide/assembly-managing-clients_server_administration_guide)
+
+</details>
+
+<details>
+<summary><strong>Authelia</strong></summary>
+
+Authelia's OIDC provider is configured via YAML, not a web UI. Add a client
+under `identity_providers.oidc.clients` in your Authelia configuration:
+
+```yaml
+identity_providers:
+  oidc:
+    clients:
+      - client_id: shoko
+        client_name: Shoko
+        client_secret: '$pbkdf2-sha512$...'  # hash of your chosen secret, see docs below
+        public: false
+        authorization_policy: one_factor
+        redirect_uris:
+          - https://<your-shoko-public-url>/api/v3/Auth/Oidc/Callback
+        scopes:
+          - openid
+          - email
+          - profile
+        grant_types:
+          - authorization_code
+        response_types:
+          - code
+```
+
+`Authority` = the base URL of your Authelia instance (e.g.
+`https://auth.example.com`). `client_secret` in the YAML must be a *hashed*
+value generated with Authelia's crypto CLI — the plaintext secret you hash
+is what goes into Shoko's `ClientSecret`.
+
+Reference: [OpenID Connect 1.0 Clients — Authelia docs](https://www.authelia.com/configuration/identity-providers/openid-connect/clients/)
+
+</details>
 
 ## 2. Configure Shoko
 
@@ -108,3 +183,19 @@ invalidates every API token previously minted through that identity.
   proxy.
 - **Token lifetime**: the minted Shoko API token's expiry matches the OIDC
   ID token's own `exp` claim rather than a fixed window.
+
+## Further reading
+
+Background on the standards this implementation follows, if you want to
+understand what's actually happening under the hood:
+
+- [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) — the spec defining the Authorization Code flow, ID tokens, and discovery document used here.
+- [RFC 7636 — Proof Key for Code Exchange (PKCE)](https://datatracker.ietf.org/doc/html/rfc7636) — why every exchange includes a `code_challenge`/`code_verifier` pair.
+- [RFC 8414 — OAuth 2.0 Authorization Server Metadata](https://datatracker.ietf.org/doc/html/rfc8414) — the `/.well-known/openid-configuration` discovery document format.
+- [oauth.net PKCE explainer](https://oauth.net/2/pkce/) — a more approachable, less spec-dense description of PKCE than the RFC.
+
+Provider docs:
+
+- [authentik documentation](https://docs.goauthentik.io/)
+- [Keycloak documentation](https://www.keycloak.org/documentation)
+- [Authelia documentation](https://www.authelia.com/overview/prologue/introduction/)

--- a/docs/oidc-sso-setup.md
+++ b/docs/oidc-sso-setup.md
@@ -1,0 +1,110 @@
+# Optional OIDC / SSO Sign-In
+
+Shoko can optionally authenticate against an external OpenID Connect provider
+(Authentik, Keycloak, Authelia, or any spec-compliant IdP) as a second,
+opt-in way to sign in — alongside, never instead of, local username/password
+accounts.
+
+> **This is not a security boundary.** OIDC here is a convenience/deterrent
+> layer on top of Shoko's existing auth, not a hardened multi-tenant access
+> control system. Do **not** expose Shoko directly to the internet because
+> OIDC is enabled — put it behind a VPN or a reverse proxy you control either
+> way.
+
+## How it works
+
+- Local accounts and `Auth/SignIn` keep working exactly as before.
+- An already-authenticated local user explicitly **links** their account to
+  an external identity (`GET /api/v3/Auth/Oidc/Link`). Sign-in never
+  auto-matches an external identity to a local account by username or email —
+  only an explicit link can create that association.
+- Once linked, that user can sign in via `GET /api/v3/Auth/Oidc/Challenge`
+  instead of the password form.
+- Optionally, `AutoCreateUsers` lets an unlinked identity provision a brand
+  new local account on first sign-in (off by default) — this never links to
+  or takes over an *existing* account.
+
+## 1. Register Shoko with your IdP
+
+Create a new OAuth2/OIDC client/application for Shoko with:
+
+- **Grant type:** Authorization Code (with PKCE)
+- **Redirect URI:** `https://<your-shoko-public-url>/api/v3/Auth/Oidc/Callback`
+  — must match exactly what you put in `PublicUrl` below.
+- **Scopes:** `openid profile email`
+
+Copy the resulting **Client ID** and **Client Secret**, and note the
+provider's **issuer/authority URL** (the base URL that serves
+`/.well-known/openid-configuration`, e.g.
+`https://auth.example.com/application/o/shoko/` for Authentik).
+
+## 2. Configure Shoko
+
+OIDC settings are deliberately **not** exposed in the settings UI or API —
+enabling it means editing `settings-server.json` directly on the server, so
+turning it on is a conscious, hands-on-the-server action rather than a
+checkbox reachable from a browser. Stop Shoko, edit the file, then restart.
+
+```json
+{
+  "Oidc": {
+    "Enabled": true,
+    "DisplayName": "Authentik",
+    "Authority": "https://auth.example.com/application/o/shoko/",
+    "PublicUrl": "https://shoko.example.com",
+    "ClientID": "your-client-id",
+    "ClientSecret": "your-client-secret",
+    "AutoCreateUsers": false
+  }
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `Enabled` | yes | Master on/off switch. |
+| `Authority` | yes | Must exactly match the issuer your IdP's discovery document reports at `<Authority>/.well-known/openid-configuration` — Shoko rejects a mismatch rather than trusting whatever the document claims. |
+| `PublicUrl` | yes | The externally-reachable base URL of this Shoko instance, e.g. `https://shoko.example.com`. Used to build the fixed `redirect_uri` sent to the provider — must be the exact origin registered with the IdP in step 1. Shoko does **not** derive this from the incoming request's `Host` header, to avoid trusting a header a reverse proxy might not fully sanitize. |
+| `ClientID` / `ClientSecret` | yes | From step 1. |
+| `DisplayName` | no | Label for the WebUI's SSO button (e.g. "Sign in with Authentik"). Defaults to `SSO`. |
+| `AutoCreateUsers` | no | Off by default. When on, an unlinked identity gets a brand-new local account (random password) on first sign-in instead of being rejected. |
+
+The WebUI only shows the SSO option when `GET /api/v3/init/status` reports
+`OidcEnabled: true` — provider details are never exposed to unauthenticated
+clients.
+
+## 3. Link an account
+
+1. Sign in to Shoko normally with a local account.
+2. Visit `GET /api/v3/Auth/Oidc/Link` (authenticated) to start the linking
+   flow — this redirects to your IdP, then back to Shoko, and links the
+   external identity to whichever local account started the flow. It never
+   matches by username or email.
+3. From then on, that user can sign in via `Challenge` instead of the
+   password form.
+
+To remove the link, call `POST /api/v3/Auth/Oidc/Unlink` — this also
+invalidates every API token previously minted through that identity.
+
+## Design notes (why it's built this way)
+
+- **PKCE (`S256`)** is used on every authorization-code exchange, per current
+  OAuth 2.1 guidance — closes the code-interception gap even though a client
+  secret is also in play.
+- **`state`/nonce/PKCE verifier** travel in a single ASP.NET Data-Protection
+  signed-and-encrypted payload, never as a raw cookie or client-visible
+  value, and expire after 10 minutes.
+- **Discovery document caching**: Shoko keeps one long-lived
+  `ConfigurationManager` per configured authority (auto-refreshing per its
+  own internal cache policy) instead of re-fetching on every login.
+- **Issuer pinning**: the ID token's issuer is validated against your
+  configured `Authority`, not against whatever the discovery document
+  self-reports — the document's own `issuer` field is first checked to
+  match `Authority` before anything from it is trusted.
+- **Fixed `redirect_uri`** built from `PublicUrl`, never derived from the
+  request's `Host` header.
+- **Token delivery**: on success, Shoko redirects to the WebUI with the
+  minted API token in the URL **fragment** (`#oidcToken=...`), not a query
+  parameter — fragments are never sent to the server or logged by a reverse
+  proxy.
+- **Token lifetime**: the minted Shoko API token's expiry matches the OIDC
+  ID token's own `exp` claim rather than a fixed window.


### PR DESCRIPTION
## Summary

Example implementation of optional OIDC single sign-on, offered as a discussion starting point — not opinion-locked. See [ShokoAnime/ShokoServer#1386](https://github.com/ShokoAnime/ShokoServer/discussions/1386) for the broader SSO conversation. Opened as draft specifically to be picked apart before considering it mergeable.

- Adds `Settings.Oidc` (disabled by default, config-file only — not exposed in the settings UI/API)
- `OidcAuthController` — `/api/v3/Auth/Oidc/Challenge` and `/Callback`, authorization-code flow with PKCE against the provider's discovery document
- Sign-in requires an explicit prior link (`GET /Auth/Oidc/Link` / `POST /Auth/Oidc/Unlink`) — no auto-matching by username/email
- Optional `OidcSettings.AutoCreateUsers` (default off) provisions a new local account on first sign-in
- Minted token expiry matches the OIDC ID token's own `exp` claim; `Unlink` invalidates all tokens minted under that provider link
- `ServerStatus.OidcEnabled` lets the WebUI conditionally show an SSO button without revealing provider details
- `docs/oidc-sso-setup.md` walks through IdP registration and account linking

## Security notes

- PKCE (`S256`); issuer pinned to configured `Authority` rather than trusting the discovery document's self-declared issuer
- `redirect_uri` built from an explicit `OidcSettings.PublicUrl` setting, not derived from request headers
- `returnUrl` validated via `Url.IsLocalUrl` before being carried through signed state (closes an open-redirect path)
- Discovery document cached per-authority with refresh-and-retry on validation failure, so IdP key rotation doesn't cause a sign-in outage
- Unique index on `JMMUser.ExternalAuthID` (all DB backends) closes a concurrent-link race

## Test plan

- [x] `dotnet build Shoko.Server.sln` — 0 errors
- [x] `dotnet test Shoko.Tests/Shoko.Tests.csproj` — 517 passed, 0 failed
- [ ] Manual end-to-end test against a real OIDC provider (feedback on the flow itself would help shape this first)

## Rebase history
- 2026-08-16 16:41 UTC — rebased onto `master` @ `4f0e3c52b` (11 commits), now at `666a8063f`
- 2026-08-23 16:23 UTC — rebased onto `upstream/master` @ `b6fdba59b` (11 commits), now at `99d56cc1a`
