### PR TITLE
docs(api): correct DELETE File/{fileID} parameter documentation

### DIFF
--- a/Shoko.Server/API/v3/Controllers/FileController.cs
+++ b/Shoko.Server/API/v3/Controllers/FileController.cs
@@ -337,7 +337,8 @@ public class FileController(
     /// <summary>
     /// Delete a file.
     /// </summary>
-    /// <param name="fileID">The VideoLocal_Place ID. This cares about which location we are deleting from.</param>
+    /// <param name="fileID">The Shoko VideoLocalID. This deletes the file across all its locations.
+    /// To delete a single location, use DELETE /File/Location/{locationID} instead.</param>
     /// <param name="removeFiles">Remove all physical file locations.</param>
     /// <param name="removeFolder">This causes the empty folder removal to skipped if set to false.
     /// This significantly speeds up batch deleting if you are deleting many files in the same folder.


### PR DESCRIPTION
`DELETE /api/v3/File/{fileID}` is currently documented as accepting a `VideoLocal_Place` ID:

> The VideoLocal_Place ID. This cares about which location we are deleting from.

However, the implementation resolves the parameter as a `VideoLocalID`:

```csharp
var file = _videoLocals.GetByID(fileID);
await _videoService.DeleteVideo(file, removeFiles, removeFolder);
```

This means passing a location ID can delete an unrelated file if that location ID happens to match a different `VideoLocalID`.

I see two possible fixes:

1. Treat the current implementation as intended and update the API docs/schema to say `{fileID}` is a `VideoLocalID`. The docs could also point users to the location-specific endpoint:

   `DELETE /api/v3/File/Location/{locationID}`

2. Treat the current docs as intended and change the implementation to resolve `{fileID}` via `_videoLocalPlaces.GetByID(...)` and call the location-specific deletion path.

Given the existing route name (`{fileID}`), method name (`DeleteFile`), and separate location endpoint, option 1 seems less risky to me. This PR implements option 1 by correcting the API documentation to match current behavior.
