### PR TITLE
fix(tmdb): add season-scoped nearest-air-date fallback for episode linking

### DIFF
--- a/Shoko.Abstractions/Metadata/Enums/MatchRating.cs
+++ b/Shoko.Abstractions/Metadata/Enums/MatchRating.cs
@@ -53,4 +53,9 @@ public enum MatchRating : byte
     ///   Date and Title are close, but not exact.
     /// </summary>
     DateAndTitleKindaMatches = 8,
+
+    /// <summary>
+    ///   No title or in-window date evidence; matched to the closest available air date as a last resort.
+    /// </summary>
+    NearestDateMatches = 9,
 }

--- a/Shoko.Abstractions/Metadata/Enums/MatchRating.cs
+++ b/Shoko.Abstractions/Metadata/Enums/MatchRating.cs
@@ -57,5 +57,5 @@ public enum MatchRating : byte
     /// <summary>
     ///   No title or in-window date evidence; matched to the closest available air date as a last resort.
     /// </summary>
-    NearestDateMatches = 9,
+    DateKindaMatches = 9,
 }

--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -472,6 +472,17 @@ public class TmdbLinkingService : ITmdbLinkingService
         var toSkip = new HashSet<int>();
         var toAdd = new List<CrossRef_AniDB_TMDB_Episode>();
         var crossReferences = new List<CrossRef_AniDB_TMDB_Episode>();
+        // Kept alongside crossReferences (not derived from it) so ResolveAnchorSeason can look up a
+        // neighbor's primary (Ordering == 0) link in O(1) instead of rescanning the whole list, which
+        // would otherwise get quadratically slower as crossReferences grows across passes.
+        var primaryLinkByAnidbEpisodeId = new Dictionary<int, CrossRef_AniDB_TMDB_Episode>();
+
+        void AddCrossReference(CrossRef_AniDB_TMDB_Episode xref)
+        {
+            crossReferences.Add(xref);
+            if (xref.TmdbEpisodeID != 0 && xref.Ordering == 0)
+                primaryLinkByAnidbEpisodeId[xref.AnidbEpisodeID] = xref;
+        }
         var secondPass = new List<AniDB_Episode>();
         var fourthPass = new List<AniDB_Episode>();
         var thirdPass = new List<AniDB_Episode>();
@@ -483,6 +494,7 @@ public class TmdbLinkingService : ITmdbLinkingService
             .OrderBy(episode => episode.EpisodeType)
             .ThenBy(episode => episode.EpisodeNumber)
             .ToDictionary(episode => episode.EpisodeID);
+        var anidbEpisodesByTypeNumber = anidbEpisodes.Values.ToDictionary(episode => (episode.EpisodeType, episode.EpisodeNumber));
         var tmdbEpisodeDict = _tmdbEpisodes.GetByTmdbShowID(tmdbShowId)
             .ToDictionary(episode => episode.TmdbEpisodeID);
         var tmdbEpisodes = tmdbEpisodeDict.Values
@@ -516,30 +528,80 @@ public class TmdbLinkingService : ITmdbLinkingService
 
         List<TMDB_Episode> GetEpisodeList(AniDB_Episode ep) => IsSpecialEpisode(ep) ? tmdbSpecialEpisodes : tmdbNormalEpisodes;
 
+        // Finds the TMDB season an episode's adjacent AniDB neighbor (previous and next) already linked
+        // to, so the nearest-air-date fallback in TryFindAnidbAndTmdbMatch can be scoped to that season
+        // instead of searching across all seasons. Without this, a back-to-back multi-cour release (e.g.
+        // season 1 ending in March, season 2 starting in June) can have less than the fallback's date
+        // tolerance between season boundaries, letting an unresolved season-1 episode get pulled onto a
+        // season-2 episode instead of staying unlinked. Returns null for OVAs, where there's only one pool.
+        // Looks up primaryLinkByAnidbEpisodeId (O(1), Ordering == 0 only) rather than crossReferences
+        // directly, so a multi-part neighbor's secondary/duplicate link can't be picked up by mistake.
+        int? ResolveAnchorSeason(AniDB_Episode episode)
+        {
+            if (isOVA)
+                return null;
+
+            (int Season, DateOnly? AiredAt)? SeasonOfNeighbor(int neighborEpisodeNumber)
+            {
+                if (!anidbEpisodesByTypeNumber.TryGetValue((episode.EpisodeType, neighborEpisodeNumber), out var neighbor))
+                    return null;
+                if (!primaryLinkByAnidbEpisodeId.TryGetValue(neighbor.EpisodeID, out var xref))
+                    return null;
+                if (!tmdbEpisodeDict.TryGetValue(xref.TmdbEpisodeID, out var tmdbEpisode))
+                    return null;
+
+                return (tmdbEpisode.SeasonNumber, tmdbEpisode.AiredAt);
+            }
+
+            var previous = SeasonOfNeighbor(episode.EpisodeNumber - 1);
+            var next = SeasonOfNeighbor(episode.EpisodeNumber + 1);
+            if (previous is null)
+                return next?.Season;
+            if (next is null || previous.Value.Season == next.Value.Season)
+                return previous.Value.Season;
+
+            // The neighbors disagree on season — a season boundary sits between them. Trust whichever
+            // neighbor's air date is actually closer to this episode's own, rather than always preferring
+            // the previous episode, so the first episode of a new season anchors to the new season
+            // instead of inheriting the one that just ended.
+            var anidbDate = episode.GetAirDateAsDate()?.ToDateOnly();
+            if (anidbDate is null)
+                return previous.Value.Season;
+
+            var previousDistance = CalculateAirDateDistance(anidbDate, previous.Value.AiredAt) ?? int.MaxValue;
+            var nextDistance = CalculateAirDateDistance(anidbDate, next.Value.AiredAt) ?? int.MaxValue;
+            return nextDistance < previousDistance ? next.Value.Season : previous.Value.Season;
+        }
+
         // Ranks episodes by their best candidate match without consuming it, so passes can process the
         // strongest matches first and let weaker duplicate claims fall back to their next-best candidate
         // instead of losing a shared TMDB episode purely by AniDB episode order. The match found here is
         // cached and handed back to the caller so the loop that actually consumes candidates doesn't have
         // to run the same title-search/air-date computation a second time for every episode.
-        List<(AniDB_Episode Episode, CrossRef_AniDB_TMDB_Episode CrossRef)> RankByConfidence(IEnumerable<AniDB_Episode> episodes) =>
+        List<(AniDB_Episode Episode, CrossRef_AniDB_TMDB_Episode CrossRef, int? AnchorSeasonNumber)> RankByConfidence(IEnumerable<AniDB_Episode> episodes) =>
             episodes
                 .Select(ep =>
                 {
-                    var crossRef = TryFindAnidbAndTmdbMatch(anime, ep, GetEpisodeList(ep), IsSpecialEpisode(ep) && !isOVA, show.OriginalLanguageCode, out var confidence);
-                    return (Episode: ep, CrossRef: crossRef, Confidence: confidence);
+                    var anchorSeasonNumber = ResolveAnchorSeason(ep);
+                    var crossRef = TryFindAnidbAndTmdbMatch(anime, ep, GetEpisodeList(ep), IsSpecialEpisode(ep) && !isOVA, show.OriginalLanguageCode, anchorSeasonNumber, out var confidence);
+                    return (Episode: ep, CrossRef: crossRef, Confidence: confidence, AnchorSeasonNumber: anchorSeasonNumber);
                 })
                 .OrderByDescending(ranked => ranked.Confidence)
-                .Select(ranked => (ranked.Episode, ranked.CrossRef))
+                .Select(ranked => (ranked.Episode, ranked.CrossRef, ranked.AnchorSeasonNumber))
                 .ToList();
 
         // Re-finds a match for an episode, reusing the cached match from RankByConfidence when its chosen
-        // TMDB candidate hasn't since been claimed by an earlier (stronger) episode in the same pass —
-        // in that case re-running the deterministic match against the unchanged remaining pool is
-        // guaranteed to produce the same result, so the recompute is skipped.
-        CrossRef_AniDB_TMDB_Episode ResolveRankedMatch(AniDB_Episode episode, CrossRef_AniDB_TMDB_Episode cached, List<TMDB_Episode> episodeList) =>
-            cached.TmdbEpisodeID != 0 && episodeList.Any(candidate => candidate.TmdbEpisodeID == cached.TmdbEpisodeID)
+        // TMDB candidate hasn't since been claimed by an earlier (stronger) episode in the same pass AND
+        // the episode's anchor season hasn't changed since — a same-pass neighbor getting linked earlier
+        // in this same loop can newly resolve an anchor that didn't exist when RankByConfidence ran, so
+        // pool-membership alone isn't enough to prove the cached match is still correct.
+        CrossRef_AniDB_TMDB_Episode ResolveRankedMatch(AniDB_Episode episode, CrossRef_AniDB_TMDB_Episode cached, int? cachedAnchorSeasonNumber, List<TMDB_Episode> episodeList)
+        {
+            var anchorSeasonNumber = ResolveAnchorSeason(episode);
+            return cached.TmdbEpisodeID != 0 && anchorSeasonNumber == cachedAnchorSeasonNumber && episodeList.Any(candidate => candidate.TmdbEpisodeID == cached.TmdbEpisodeID)
                 ? cached
-                : TryFindAnidbAndTmdbMatch(anime, episode, episodeList, IsSpecialEpisode(episode) && !isOVA, show.OriginalLanguageCode);
+                : TryFindAnidbAndTmdbMatch(anime, episode, episodeList, IsSpecialEpisode(episode) && !isOVA, show.OriginalLanguageCode, anchorSeasonNumber);
+        }
 
         // Narrows the TMDB candidate pool to seasons already established by an existing/new OV/DT
         // link, so later passes can't stray into an unrelated season once one has been established.
@@ -576,19 +638,19 @@ public class TmdbLinkingService : ITmdbLinkingService
             FilterToCurrentSeasons(passNumber);
 
             var passCurrent = 0;
-            foreach (var (episode, cachedCrossRef) in RankByConfidence(episodes))
+            foreach (var (episode, cachedCrossRef, cachedAnchorSeasonNumber) in RankByConfidence(episodes))
             {
                 passCurrent++;
                 _logger.LogTrace("Linking episode {EpisodeType} {EpisodeNumber}. (AniDB ID: {EpisodeID}, Progress: {Current}/{Total}, Pass: {PassNumber}/4)", episode.EpisodeType, episode.EpisodeNumber, episode.EpisodeID, passCurrent, episodes.Count, passNumber);
                 var episodeList = GetEpisodeList(episode);
-                var crossRef = ResolveRankedMatch(episode, cachedCrossRef, episodeList);
+                var crossRef = ResolveRankedMatch(episode, cachedCrossRef, cachedAnchorSeasonNumber, episodeList);
                 if (accepts(crossRef.MatchRating))
                 {
                     var index = episodeList.FindIndex(episode => episode.TmdbEpisodeID == crossRef.TmdbEpisodeID);
                     if (index != -1)
                         episodeList.RemoveAt(index);
 
-                    crossReferences.Add(crossRef);
+                    AddCrossReference(crossRef);
                     toAdd.Add(crossRef);
                     _logger.LogTrace("Adding new link for episode. (AniDB ID: {AnidbEpisodeID}, TMDB ID: {TMDbEpisodeID}, Rating: {MatchRating}, Pass: {PassNumber}/4)", episode.EpisodeID, crossRef.TmdbEpisodeID, crossRef.MatchRating, passNumber);
                 }
@@ -601,7 +663,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         }
 
         var current = 0;
-        foreach (var (episode, cachedCrossRef) in RankByConfidence(anidbEpisodes.Values))
+        foreach (var (episode, cachedCrossRef, cachedAnchorSeasonNumber) in RankByConfidence(anidbEpisodes.Values))
         {
             current++;
             _logger.LogTrace("Checking episode {EpisodeType} {EpisodeNumber}. (AniDB ID: {AnidbEpisodeID}, Progress: {Current}/{Total}, Pass: 1/4)", episode.EpisodeType, episode.EpisodeNumber, episode.EpisodeID, current, anidbEpisodes.Count);
@@ -628,12 +690,12 @@ public class TmdbLinkingService : ITmdbLinkingService
                     var link = existingLinks[0];
                     if (link.TmdbEpisodeID is 0 && link.TmdbShowID is 0)
                     {
-                        crossReferences.Add(link);
+                        AddCrossReference(link);
                         toSkip.Add(link.CrossRef_AniDB_TMDB_EpisodeID);
                     }
                     else
                     {
-                        crossReferences.Add(new(episode.EpisodeID, anidbAnimeId, 0, 0, MatchRating.None, 0));
+                        AddCrossReference(new(episode.EpisodeID, anidbAnimeId, 0, 0, MatchRating.None, 0));
                     }
                     continue;
                 }
@@ -642,7 +704,7 @@ public class TmdbLinkingService : ITmdbLinkingService
                 foreach (var link in existingLinks)
                 {
                     _logger.LogTrace("Skipping existing link for episode. (AniDB ID: {AnidbEpisodeID}, TMDB ID: {TmdbEpisodeID}, Rating: {MatchRating})", episode.EpisodeID, link.TmdbEpisodeID, link.MatchRating);
-                    crossReferences.Add(link);
+                    AddCrossReference(link);
                     toSkip.Add(link.CrossRef_AniDB_TMDB_EpisodeID);
 
                     // Exclude the linked episodes from the auto-match candidates.
@@ -665,21 +727,21 @@ public class TmdbLinkingService : ITmdbLinkingService
                 if (episode.AnimeEpisode?.IsHidden ?? false)
                 {
                     _logger.LogTrace("Skipping hidden episode. (AniDB ID: {AnidbEpisodeID})", episode.EpisodeID);
-                    crossReferences.Add(new(episode.EpisodeID, anidbAnimeId, 0, 0, MatchRating.None, 0));
+                    AddCrossReference(new(episode.EpisodeID, anidbAnimeId, 0, 0, MatchRating.None, 0));
                     continue;
                 }
 
                 // Else try find a match.
                 _logger.LogTrace("Linking episode. (AniDB ID: {AnidbEpisodeID}, Pass: 1/4)", episode.EpisodeID);
                 var episodeList = GetEpisodeList(episode);
-                var crossRef = ResolveRankedMatch(episode, cachedCrossRef, episodeList);
+                var crossRef = ResolveRankedMatch(episode, cachedCrossRef, cachedAnchorSeasonNumber, episodeList);
                 if (crossRef.MatchRating is MatchRating.DateAndTitleMatches)
                 {
                     var index = episodeList.FindIndex(episode => episode.TmdbEpisodeID == crossRef.TmdbEpisodeID);
                     if (index != -1)
                         episodeList.RemoveAt(index);
 
-                    crossReferences.Add(crossRef);
+                    AddCrossReference(crossRef);
                     toAdd.Add(crossRef);
                     _logger.LogTrace("Adding new link for episode. (AniDB ID: {AnidbEpisodeID}, TMDB ID: {TMDbEpisodeID}, Rating: {MatchRating}, Pass: 1/4)", episode.EpisodeID, crossRef.TmdbEpisodeID, crossRef.MatchRating);
                 }
@@ -742,13 +804,14 @@ public class TmdbLinkingService : ITmdbLinkingService
         int NormalEpisodeSeasonNumberSelector(CrossRef_AniDB_TMDB_Episode xref) => xref.TmdbEpisodeID is not 0 && (isOVA || anidbEpisodes[xref.AnidbEpisodeID].EpisodeType is EpisodeType.Episode) && tmdbEpisodeDict.TryGetValue(xref.TmdbEpisodeID, out var tmdbEpisode) ? tmdbEpisode.SeasonNumber : -1;
     }
 
-    private CrossRef_AniDB_TMDB_Episode TryFindAnidbAndTmdbMatch(AniDB_Anime anime, AniDB_Episode anidbEpisode, IReadOnlyList<TMDB_Episode> tmdbEpisodes, bool isSpecial, string originalLanguageCode) =>
-        TryFindAnidbAndTmdbMatch(anime, anidbEpisode, tmdbEpisodes, isSpecial, originalLanguageCode, out _);
+    private CrossRef_AniDB_TMDB_Episode TryFindAnidbAndTmdbMatch(AniDB_Anime anime, AniDB_Episode anidbEpisode, IReadOnlyList<TMDB_Episode> tmdbEpisodes, bool isSpecial, string originalLanguageCode, int? anchorSeasonNumber) =>
+        TryFindAnidbAndTmdbMatch(anime, anidbEpisode, tmdbEpisodes, isSpecial, originalLanguageCode, anchorSeasonNumber, out _);
 
     // The out confidence score lets callers rank multiple AniDB episodes contending for the same
     // TMDB episode within a pass, so the strongest match claims it instead of whichever AniDB
-    // episode happened to be processed first.
-    private CrossRef_AniDB_TMDB_Episode TryFindAnidbAndTmdbMatch(AniDB_Anime anime, AniDB_Episode anidbEpisode, IReadOnlyList<TMDB_Episode> tmdbEpisodes, bool isSpecial, string originalLanguageCode, out double confidence)
+    // episode happened to be processed first. anchorSeasonNumber scopes the nearest-air-date fallback
+    // to a season a neighboring episode already confirmed, so it can't cross a season boundary.
+    private CrossRef_AniDB_TMDB_Episode TryFindAnidbAndTmdbMatch(AniDB_Anime anime, AniDB_Episode anidbEpisode, IReadOnlyList<TMDB_Episode> tmdbEpisodes, bool isSpecial, string originalLanguageCode, int? anchorSeasonNumber, out double confidence)
     {
         confidence = 0;
 
@@ -771,12 +834,31 @@ public class TmdbLinkingService : ITmdbLinkingService
             .ThenBy(result => result.episode.SeasonNumber)
             .ThenBy(result => result.episode.EpisodeNumber)
             .ToList();
+        // No candidate within the strict ±2-day window (e.g. a delayed/compressed episode) — fall back to
+        // the closest air date available instead of dropping straight to a blind positional/title guess,
+        // which is what let e.g. AniDB episode 2 grab whatever TMDB episode happened to be next in the
+        // list (episode 5) instead of the episode actually nearest in air date. Scoped to anchorSeasonNumber
+        // (the season a neighboring episode already confirmed) when known, so a multi-cour show with less
+        // than the fallback's tolerance between season boundaries can't have this pull an episode across
+        // seasons — it can only widen within the season it already belongs to.
+        var nearestAirdate = airdateProbability.Count > 0 || anidbDate is null
+            ? new List<(TMDB_Episode episode, int distance)>()
+            : tmdbEpisodes
+                .Where(episode => anchorSeasonNumber is null || episode.SeasonNumber == anchorSeasonNumber.Value)
+                .Select(episode => (episode, distance: CalculateAirDateDistance(anidbDate, episode.AiredAt)))
+                .Where(result => result.distance is not null)
+                .Select(result => (result.episode, distance: result.distance!.Value))
+                .OrderBy(result => result.distance)
+                .ThenBy(result => result.episode.SeasonNumber == 0)
+                .ThenBy(result => result.episode.SeasonNumber)
+                .ThenBy(result => result.episode.EpisodeNumber)
+                .ToList();
         var titleSearchResults = !string.IsNullOrEmpty(anidbTitle) ? tmdbEpisodes
             .Search(anidbTitle, episode => GetEpisodeTitleCandidates(episode, originalLanguageCode), true)
             .OrderBy(result => result)
             .ToList() : [];
 
-        var crossRef = SelectBestEpisodeMatch(anidbEpisode, tmdbEpisodes, isSpecial, titleSearchResults, airdateProbability, out confidence);
+        var crossRef = SelectBestEpisodeMatch(anidbEpisode, tmdbEpisodes, isSpecial, titleSearchResults, airdateProbability, nearestAirdate, out confidence);
         return crossRef;
     }
 
@@ -831,6 +913,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         bool isSpecial,
         List<SeriesSearch.SearchResult<TMDB_Episode>> titleSearchResults,
         List<(TMDB_Episode episode, double probability)> airdateProbability,
+        List<(TMDB_Episode episode, int distance)> nearestAirdate,
         out double confidence)
     {
         if (TryExactTitleMatch(anidbEpisode, titleSearchResults, airdateProbability, out var crossRef, out confidence))
@@ -843,6 +926,9 @@ public class TmdbLinkingService : ITmdbLinkingService
             return crossRef;
 
         if (TryAnyTitleMatch(anidbEpisode, titleSearchResults, out crossRef, out confidence))
+            return crossRef;
+
+        if (TryNearestAirDateMatch(anidbEpisode, nearestAirdate, out crossRef, out confidence))
             return crossRef;
 
         confidence = 0;
@@ -939,20 +1025,55 @@ public class TmdbLinkingService : ITmdbLinkingService
         return true;
     }
 
+    // Last-resort tier: no title evidence and no candidate within the strict ±2-day window. Picks the
+    // closest remaining episode by air date instead of grabbing whatever's positionally next (the old
+    // FirstAvailable behavior), which is what mismatched delayed/compressed episodes onto the wrong slot.
+    // Confidence is kept low (and decays with distance) so a genuine close match elsewhere always outranks it.
+    // Bounded to MaxFallbackDifferenceInDays so an anime with a long hiatus (or a special dated months/years
+    // from anything on TMDB) doesn't get confidently linked to a wildly unrelated episode.
+    private const int MaxFallbackDifferenceInDays = 120;
+
+    private static bool TryNearestAirDateMatch(
+        AniDB_Episode anidbEpisode,
+        List<(TMDB_Episode episode, int distance)> nearestAirdate,
+        out CrossRef_AniDB_TMDB_Episode crossRef,
+        out double confidence)
+    {
+        crossRef = null!;
+        confidence = 0;
+        if (nearestAirdate.Count == 0)
+            return false;
+
+        var (tmdbEpisode, distance) = nearestAirdate[0];
+        if (distance > MaxFallbackDifferenceInDays)
+            return false;
+
+        confidence = 0.5 / (1 + distance);
+        crossRef = new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, MatchRating.NearestDateMatches);
+        return true;
+    }
+
     private static double CalculateAirDateProbability(DateOnly? firstDate, DateOnly? secondDate, int maxDifferenceInDays = 2)
     {
-        if (!firstDate.HasValue || !secondDate.HasValue)
+        var difference = CalculateAirDateDistance(firstDate, secondDate);
+        if (difference is null)
             return 0;
 
-        var difference = Math.Abs(secondDate.Value.DayNumber - firstDate.Value.DayNumber);
         if (difference == 0)
             return 1;
 
         if (difference <= maxDifferenceInDays)
-            return (maxDifferenceInDays - difference) / (double)maxDifferenceInDays;
+            return (maxDifferenceInDays - difference.Value) / (double)maxDifferenceInDays;
 
         return 0;
     }
+
+    // Unbounded companion to CalculateAirDateProbability, used only as a last-resort fallback once the
+    // strict ±2-day window finds nothing — e.g. a delayed or compressed episode whose TMDB entry aired
+    // weeks later. Returns the raw day distance so the caller can pick the closest candidate instead of
+    // falling through to a blind positional/title guess.
+    private static int? CalculateAirDateDistance(DateOnly? firstDate, DateOnly? secondDate) =>
+        !firstDate.HasValue || !secondDate.HasValue ? null : Math.Abs(secondDate.Value.DayNumber - firstDate.Value.DayNumber);
 
     private static IReadOnlyList<string> GetEpisodeTitleCandidates(TMDB_Episode episode, string originalLanguageCode) =>
         episode.GetAllTitles()
@@ -970,7 +1091,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         title.Trim().Equals($"Episode {episodeType.Prefix}{episodeNumber}", StringComparison.InvariantCultureIgnoreCase);
 
     // Ratings assigned with zero title evidence — the only ones a coincidental air-date mismatch can put out of order.
-    private static readonly HashSet<MatchRating> _weakOrderRatings = [MatchRating.DateMatches, MatchRating.FirstAvailable];
+    private static readonly HashSet<MatchRating> _weakOrderRatings = [MatchRating.DateMatches, MatchRating.NearestDateMatches, MatchRating.FirstAvailable];
 
     // Swaps adjacent weak TMDB matches into AniDB order; strong matches stay in the ordering (true adjacency) but are never swapped.
     internal static void ReconcileEpisodeOrderInversions(

--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -964,7 +964,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         AniDB_Episode anidbEpisode,
         List<SeriesSearch.SearchResult<TMDB_Episode>> titleSearchResults,
         List<(TMDB_Episode episode, double probability)> airdateProbability,
-        out CrossRef_AniDB_TMDB_Episode crossRef,
+        [NotNullWhen(true)] out CrossRef_AniDB_TMDB_Episode? crossRef,
         out double confidence) =>
         TryTitleMatch(anidbEpisode, titleSearchResults, airdateProbability,
             isCandidate: result => result.ExactMatch && result.LengthDifference < 3,
@@ -975,7 +975,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         AniDB_Episode anidbEpisode,
         List<SeriesSearch.SearchResult<TMDB_Episode>> titleSearchResults,
         List<(TMDB_Episode episode, double probability)> airdateProbability,
-        out CrossRef_AniDB_TMDB_Episode crossRef,
+        [NotNullWhen(true)] out CrossRef_AniDB_TMDB_Episode? crossRef,
         out double confidence) =>
         TryTitleMatch(anidbEpisode, titleSearchResults, airdateProbability,
             isCandidate: result => result.Distance < 0.2D && result.LengthDifference < 6,
@@ -991,7 +991,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         List<(TMDB_Episode episode, double probability)> airdateProbability,
         Func<SeriesSearch.SearchResult<TMDB_Episode>, bool> isCandidate,
         (MatchRating TitleOnly, MatchRating DateAndTitle) ratings,
-        out CrossRef_AniDB_TMDB_Episode crossRef,
+        [NotNullWhen(true)] out CrossRef_AniDB_TMDB_Episode? crossRef,
         out double confidence)
     {
         crossRef = null;
@@ -1055,7 +1055,7 @@ public class TmdbLinkingService : ITmdbLinkingService
     private static bool TryNearestAirDateMatch(
         AniDB_Episode anidbEpisode,
         List<(TMDB_Episode episode, int distance)> nearestAirdate,
-        out CrossRef_AniDB_TMDB_Episode crossRef,
+        [NotNullWhen(true)] out CrossRef_AniDB_TMDB_Episode? crossRef,
         out double confidence)
     {
         crossRef = null;

--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -495,7 +495,12 @@ public class TmdbLinkingService : ITmdbLinkingService
             .OrderBy(episode => episode.EpisodeType)
             .ThenBy(episode => episode.EpisodeNumber)
             .ToDictionary(episode => episode.EpisodeID);
-        var anidbEpisodesByTypeNumber = anidbEpisodes.Values.ToDictionary(episode => (episode.EpisodeType, episode.EpisodeNumber));
+        // GroupBy+First (not ToDictionary) — AniDB data can contain duplicate (EpisodeType, EpisodeNumber)
+        // pairs (e.g. a partial reimport), and this lookup is only used as a "does a neighboring episode
+        // exist" hint for anchor-season resolution, so silently keeping the first one is safe.
+        var anidbEpisodesByTypeNumber = anidbEpisodes.Values
+            .GroupBy(episode => (episode.EpisodeType, episode.EpisodeNumber))
+            .ToDictionary(group => group.Key, group => group.First());
         var tmdbEpisodeDict = _tmdbEpisodes.GetByTmdbShowID(tmdbShowId)
             .ToDictionary(episode => episode.TmdbEpisodeID);
         var tmdbEpisodes = tmdbEpisodeDict.Values
@@ -525,9 +530,7 @@ public class TmdbLinkingService : ITmdbLinkingService
             .Where(episode => episode.SeasonNumber == 0)
             .OrderBy(episode => episode.EpisodeNumber)
             .ToList();
-        bool IsSpecialEpisode(AniDB_Episode ep) => ep.EpisodeType is EpisodeType.Special || anime.AnimeType is not AnimeType.TV and not AnimeType.Web;
-
-        List<TMDB_Episode> GetEpisodeList(AniDB_Episode ep) => IsSpecialEpisode(ep) ? tmdbSpecialEpisodes : tmdbNormalEpisodes;
+        List<TMDB_Episode> GetEpisodeList(AniDB_Episode ep) => IsSpecialEpisode(ep.EpisodeType, anime.AnimeType) ? tmdbSpecialEpisodes : tmdbNormalEpisodes;
 
         var matchContext = new EpisodeMatchContext(anime, show, isOVA, GetEpisodeList, anidbEpisodesByTypeNumber, primaryLinkByAnidbEpisodeId, tmdbEpisodeDict);
 
@@ -793,13 +796,17 @@ public class TmdbLinkingService : ITmdbLinkingService
     // instead of losing a shared TMDB episode purely by AniDB episode order. The match found here is
     // cached and handed back to the caller so the loop that actually consumes candidates doesn't have
     // to run the same title-search/air-date computation a second time for every episode.
-    private List<(AniDB_Episode Episode, CrossRef_AniDB_TMDB_Episode CrossRef, int? AnchorSeasonNumber)> RankByConfidence(IEnumerable<AniDB_Episode> episodes, EpisodeMatchContext context) =>
+    private List<(AniDB_Episode Episode, CrossRef_AniDB_TMDB_Episode CrossRef, int? AnchorSeasonNumber)> RankByConfidence(
+        IEnumerable<AniDB_Episode> episodes,
+        EpisodeMatchContext context) =>
         episodes
             .Select(ep =>
             {
                 var anchorSeasonNumber = ResolveAnchorSeason(ep, context);
                 var isSpecial = IsSpecialEpisode(ep, context);
-                var crossRef = TryFindAnidbAndTmdbMatch(context.Anime, ep, context.GetEpisodeList(ep), isSpecial && !context.IsOVA, context.Show.OriginalLanguageCode, anchorSeasonNumber, out var confidence);
+                var crossRef = TryFindAnidbAndTmdbMatch(
+                    context.Anime, ep, context.GetEpisodeList(ep), isSpecial && !context.IsOVA, context.Show.OriginalLanguageCode,
+                    anchorSeasonNumber, out var confidence);
                 return (Episode: ep, CrossRef: crossRef, Confidence: confidence, AnchorSeasonNumber: anchorSeasonNumber);
             })
             .OrderByDescending(ranked => ranked.Confidence)
@@ -811,26 +818,49 @@ public class TmdbLinkingService : ITmdbLinkingService
     // the episode's anchor season hasn't changed since — a same-pass neighbor getting linked earlier
     // in this same loop can newly resolve an anchor that didn't exist when RankByConfidence ran, so
     // pool-membership alone isn't enough to prove the cached match is still correct.
-    private CrossRef_AniDB_TMDB_Episode ResolveRankedMatch(AniDB_Episode episode, CrossRef_AniDB_TMDB_Episode cached, int? cachedAnchorSeasonNumber, List<TMDB_Episode> episodeList, EpisodeMatchContext context)
+    private CrossRef_AniDB_TMDB_Episode ResolveRankedMatch(
+        AniDB_Episode episode,
+        CrossRef_AniDB_TMDB_Episode cached,
+        int? cachedAnchorSeasonNumber,
+        List<TMDB_Episode> episodeList,
+        EpisodeMatchContext context)
     {
         var anchorSeasonNumber = ResolveAnchorSeason(episode, context);
         var isSpecial = IsSpecialEpisode(episode, context);
-        return cached.TmdbEpisodeID != 0 && anchorSeasonNumber == cachedAnchorSeasonNumber && episodeList.Any(candidate => candidate.TmdbEpisodeID == cached.TmdbEpisodeID)
+        return cached.TmdbEpisodeID != 0
+            && anchorSeasonNumber == cachedAnchorSeasonNumber
+            && episodeList.Any(candidate => candidate.TmdbEpisodeID == cached.TmdbEpisodeID)
             ? cached
             : TryFindAnidbAndTmdbMatch(context.Anime, episode, episodeList, isSpecial && !context.IsOVA, context.Show.OriginalLanguageCode, anchorSeasonNumber);
     }
 
     private static bool IsSpecialEpisode(AniDB_Episode episode, EpisodeMatchContext context) =>
-        episode.EpisodeType is EpisodeType.Special || context.Anime.AnimeType is not AnimeType.TV and not AnimeType.Web;
+        IsSpecialEpisode(episode.EpisodeType, context.Anime.AnimeType);
 
-    private CrossRef_AniDB_TMDB_Episode TryFindAnidbAndTmdbMatch(AniDB_Anime anime, AniDB_Episode anidbEpisode, IReadOnlyList<TMDB_Episode> tmdbEpisodes, bool isSpecial, string originalLanguageCode, int? anchorSeasonNumber) =>
+    private static bool IsSpecialEpisode(EpisodeType episodeType, AnimeType animeType) =>
+        episodeType is EpisodeType.Special || animeType is not AnimeType.TV and not AnimeType.Web;
+
+    private CrossRef_AniDB_TMDB_Episode TryFindAnidbAndTmdbMatch(
+        AniDB_Anime anime,
+        AniDB_Episode anidbEpisode,
+        IReadOnlyList<TMDB_Episode> tmdbEpisodes,
+        bool isSpecial,
+        string originalLanguageCode,
+        int? anchorSeasonNumber) =>
         TryFindAnidbAndTmdbMatch(anime, anidbEpisode, tmdbEpisodes, isSpecial, originalLanguageCode, anchorSeasonNumber, out _);
 
     // The out confidence score lets callers rank multiple AniDB episodes contending for the same
     // TMDB episode within a pass, so the strongest match claims it instead of whichever AniDB
     // episode happened to be processed first. anchorSeasonNumber scopes the nearest-air-date fallback
     // to a season a neighboring episode already confirmed, so it can't cross a season boundary.
-    private CrossRef_AniDB_TMDB_Episode TryFindAnidbAndTmdbMatch(AniDB_Anime anime, AniDB_Episode anidbEpisode, IReadOnlyList<TMDB_Episode> tmdbEpisodes, bool isSpecial, string originalLanguageCode, int? anchorSeasonNumber, out double confidence)
+    private CrossRef_AniDB_TMDB_Episode TryFindAnidbAndTmdbMatch(
+        AniDB_Anime anime,
+        AniDB_Episode anidbEpisode,
+        IReadOnlyList<TMDB_Episode> tmdbEpisodes,
+        bool isSpecial,
+        string originalLanguageCode,
+        int? anchorSeasonNumber,
+        out double confidence)
     {
         confidence = 0;
 
@@ -862,11 +892,11 @@ public class TmdbLinkingService : ITmdbLinkingService
         // seasons — it can only widen within the season it already belongs to.
         var nearestAirdate = airdateProbability.Count > 0 || anidbDate is null
             ? new List<(TMDB_Episode episode, int distance)>()
-            : tmdbEpisodes
-                .Where(episode => anchorSeasonNumber is null || episode.SeasonNumber == anchorSeasonNumber.Value)
-                .Select(episode => (episode, distance: CalculateAirDateDistance(anidbDate, episode.AiredAt)))
-                .Where(result => result.distance is not null)
-                .Select(result => (result.episode, distance: result.distance.Value))
+            : (from episode in tmdbEpisodes
+               where anchorSeasonNumber is null || episode.SeasonNumber == anchorSeasonNumber.Value
+               let distance = CalculateAirDateDistance(anidbDate, episode.AiredAt)
+               where distance is not null
+               select (episode, distance: distance.Value))
                 .OrderBy(result => result.distance)
                 .ThenBy(result => result.episode.SeasonNumber == 0)
                 .ThenBy(result => result.episode.SeasonNumber)
@@ -947,7 +977,11 @@ public class TmdbLinkingService : ITmdbLinkingService
         if (TryAnyTitleMatch(anidbEpisode, titleSearchResults, out crossRef, out confidence))
             return crossRef;
 
-        if (TryNearestAirDateMatch(anidbEpisode, nearestAirdate, out crossRef, out confidence))
+        // Unlike the strict ±2-day airdateProbability match above, this fallback widens to 120 days —
+        // for a special with no title match, that's little more than a coin flip against whatever TMDB
+        // episode happens to be nearest, so it's gated the same way the positional FirstAvailable
+        // fallback below is.
+        if (!isSpecial && TryNearestAirDateMatch(anidbEpisode, nearestAirdate, out crossRef, out confidence))
             return crossRef;
 
         confidence = 0;

--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -847,7 +847,7 @@ public class TmdbLinkingService : ITmdbLinkingService
                 .Where(episode => anchorSeasonNumber is null || episode.SeasonNumber == anchorSeasonNumber.Value)
                 .Select(episode => (episode, distance: CalculateAirDateDistance(anidbDate, episode.AiredAt)))
                 .Where(result => result.distance is not null)
-                .Select(result => (result.episode, distance: result.distance!.Value))
+                .Select(result => (result.episode, distance: result.distance.Value))
                 .OrderBy(result => result.distance)
                 .ThenBy(result => result.episode.SeasonNumber == 0)
                 .ThenBy(result => result.episode.SeasonNumber)
@@ -975,7 +975,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         out CrossRef_AniDB_TMDB_Episode crossRef,
         out double confidence)
     {
-        crossRef = null!;
+        crossRef = null;
         confidence = 0;
         if (titleSearchResults.Count == 0 || titleSearchResults[0] is not { } titleMatch || !isCandidate(titleMatch))
             return false;
@@ -995,7 +995,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         out CrossRef_AniDB_TMDB_Episode crossRef,
         out double confidence)
     {
-        crossRef = null!;
+        crossRef = null;
         confidence = 0;
         if (airdateProbability.Count == 0)
             return false;
@@ -1014,13 +1014,13 @@ public class TmdbLinkingService : ITmdbLinkingService
         out CrossRef_AniDB_TMDB_Episode crossRef,
         out double confidence)
     {
-        crossRef = null!;
+        crossRef = null;
         confidence = 0;
         if (titleSearchResults.Count == 0)
             return false;
 
-        var tmdbEpisode = titleSearchResults[0]!.Result;
-        confidence = 1 - titleSearchResults[0]!.Distance;
+        var tmdbEpisode = titleSearchResults[0].Result;
+        confidence = 1 - titleSearchResults[0].Distance;
         crossRef = new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, MatchRating.TitleKindaMatches);
         return true;
     }
@@ -1039,7 +1039,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         out CrossRef_AniDB_TMDB_Episode crossRef,
         out double confidence)
     {
-        crossRef = null!;
+        crossRef = null;
         confidence = 0;
         if (nearestAirdate.Count == 0)
             return false;

--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -1068,7 +1068,7 @@ public class TmdbLinkingService : ITmdbLinkingService
             return false;
 
         confidence = 0.5 / (1 + distance);
-        crossRef = new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, MatchRating.NearestDateMatches);
+        crossRef = new(anidbEpisode.EpisodeID, anidbEpisode.AnimeID, tmdbEpisode.TmdbEpisodeID, tmdbEpisode.TmdbShowID, MatchRating.DateKindaMatches);
         return true;
     }
 
@@ -1110,7 +1110,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         title.Trim().Equals($"Episode {episodeType.Prefix}{episodeNumber}", StringComparison.InvariantCultureIgnoreCase);
 
     // Ratings assigned with zero title evidence — the only ones a coincidental air-date mismatch can put out of order.
-    private static readonly HashSet<MatchRating> _weakOrderRatings = [MatchRating.DateMatches, MatchRating.NearestDateMatches, MatchRating.FirstAvailable];
+    private static readonly HashSet<MatchRating> _weakOrderRatings = [MatchRating.DateMatches, MatchRating.DateKindaMatches, MatchRating.FirstAvailable];
 
     // Swaps adjacent weak TMDB matches into AniDB order; strong matches stay in the ordering (true adjacency) but are never swapped.
     internal static void ReconcileEpisodeOrderInversions(

--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -992,7 +993,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         AniDB_Episode anidbEpisode,
         List<SeriesSearch.SearchResult<TMDB_Episode>> titleSearchResults,
         List<(TMDB_Episode episode, double probability)> airdateProbability,
-        out CrossRef_AniDB_TMDB_Episode crossRef,
+        [NotNullWhen(true)] out CrossRef_AniDB_TMDB_Episode? crossRef,
         out double confidence)
     {
         crossRef = null;
@@ -1011,7 +1012,7 @@ public class TmdbLinkingService : ITmdbLinkingService
     private static bool TryAnyTitleMatch(
         AniDB_Episode anidbEpisode,
         List<SeriesSearch.SearchResult<TMDB_Episode>> titleSearchResults,
-        out CrossRef_AniDB_TMDB_Episode crossRef,
+        [NotNullWhen(true)] out CrossRef_AniDB_TMDB_Episode? crossRef,
         out double confidence)
     {
         crossRef = null;

--- a/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
+++ b/Shoko.Server/Providers/TMDB/TmdbLinkingService.cs
@@ -529,80 +529,7 @@ public class TmdbLinkingService : ITmdbLinkingService
 
         List<TMDB_Episode> GetEpisodeList(AniDB_Episode ep) => IsSpecialEpisode(ep) ? tmdbSpecialEpisodes : tmdbNormalEpisodes;
 
-        // Finds the TMDB season an episode's adjacent AniDB neighbor (previous and next) already linked
-        // to, so the nearest-air-date fallback in TryFindAnidbAndTmdbMatch can be scoped to that season
-        // instead of searching across all seasons. Without this, a back-to-back multi-cour release (e.g.
-        // season 1 ending in March, season 2 starting in June) can have less than the fallback's date
-        // tolerance between season boundaries, letting an unresolved season-1 episode get pulled onto a
-        // season-2 episode instead of staying unlinked. Returns null for OVAs, where there's only one pool.
-        // Looks up primaryLinkByAnidbEpisodeId (O(1), Ordering == 0 only) rather than crossReferences
-        // directly, so a multi-part neighbor's secondary/duplicate link can't be picked up by mistake.
-        int? ResolveAnchorSeason(AniDB_Episode episode)
-        {
-            if (isOVA)
-                return null;
-
-            (int Season, DateOnly? AiredAt)? SeasonOfNeighbor(int neighborEpisodeNumber)
-            {
-                if (!anidbEpisodesByTypeNumber.TryGetValue((episode.EpisodeType, neighborEpisodeNumber), out var neighbor))
-                    return null;
-                if (!primaryLinkByAnidbEpisodeId.TryGetValue(neighbor.EpisodeID, out var xref))
-                    return null;
-                if (!tmdbEpisodeDict.TryGetValue(xref.TmdbEpisodeID, out var tmdbEpisode))
-                    return null;
-
-                return (tmdbEpisode.SeasonNumber, tmdbEpisode.AiredAt);
-            }
-
-            var previous = SeasonOfNeighbor(episode.EpisodeNumber - 1);
-            var next = SeasonOfNeighbor(episode.EpisodeNumber + 1);
-            if (previous is null)
-                return next?.Season;
-            if (next is null || previous.Value.Season == next.Value.Season)
-                return previous.Value.Season;
-
-            // The neighbors disagree on season — a season boundary sits between them. Trust whichever
-            // neighbor's air date is actually closer to this episode's own, rather than always preferring
-            // the previous episode, so the first episode of a new season anchors to the new season
-            // instead of inheriting the one that just ended.
-            var anidbDate = episode.GetAirDateAsDate()?.ToDateOnly();
-            if (anidbDate is null)
-                return previous.Value.Season;
-
-            var previousDistance = CalculateAirDateDistance(anidbDate, previous.Value.AiredAt) ?? int.MaxValue;
-            var nextDistance = CalculateAirDateDistance(anidbDate, next.Value.AiredAt) ?? int.MaxValue;
-            return nextDistance < previousDistance ? next.Value.Season : previous.Value.Season;
-        }
-
-        // Ranks episodes by their best candidate match without consuming it, so passes can process the
-        // strongest matches first and let weaker duplicate claims fall back to their next-best candidate
-        // instead of losing a shared TMDB episode purely by AniDB episode order. The match found here is
-        // cached and handed back to the caller so the loop that actually consumes candidates doesn't have
-        // to run the same title-search/air-date computation a second time for every episode.
-        List<(AniDB_Episode Episode, CrossRef_AniDB_TMDB_Episode CrossRef, int? AnchorSeasonNumber)> RankByConfidence(IEnumerable<AniDB_Episode> episodes) =>
-            episodes
-                .Select(ep =>
-                {
-                    var anchorSeasonNumber = ResolveAnchorSeason(ep);
-                    var crossRef = TryFindAnidbAndTmdbMatch(anime, ep, GetEpisodeList(ep), IsSpecialEpisode(ep) && !isOVA, show.OriginalLanguageCode, anchorSeasonNumber, out var confidence);
-                    return (Episode: ep, CrossRef: crossRef, Confidence: confidence, AnchorSeasonNumber: anchorSeasonNumber);
-                })
-                .OrderByDescending(ranked => ranked.Confidence)
-                .Select(ranked => (ranked.Episode, ranked.CrossRef, ranked.AnchorSeasonNumber))
-                .ToList();
-
-        // Re-finds a match for an episode, reusing the cached match from RankByConfidence when its chosen
-        // TMDB candidate hasn't since been claimed by an earlier (stronger) episode in the same pass AND
-        // the episode's anchor season hasn't changed since — a same-pass neighbor getting linked earlier
-        // in this same loop can newly resolve an anchor that didn't exist when RankByConfidence ran, so
-        // pool-membership alone isn't enough to prove the cached match is still correct.
-        CrossRef_AniDB_TMDB_Episode ResolveRankedMatch(AniDB_Episode episode, CrossRef_AniDB_TMDB_Episode cached, int? cachedAnchorSeasonNumber, List<TMDB_Episode> episodeList)
-        {
-            var anchorSeasonNumber = ResolveAnchorSeason(episode);
-            return cached.TmdbEpisodeID != 0 && anchorSeasonNumber == cachedAnchorSeasonNumber && episodeList.Any(candidate => candidate.TmdbEpisodeID == cached.TmdbEpisodeID)
-                ? cached
-                : TryFindAnidbAndTmdbMatch(anime, episode, episodeList, IsSpecialEpisode(episode) && !isOVA, show.OriginalLanguageCode, anchorSeasonNumber);
-        }
+        var matchContext = new EpisodeMatchContext(anime, show, isOVA, GetEpisodeList, anidbEpisodesByTypeNumber, primaryLinkByAnidbEpisodeId, tmdbEpisodeDict);
 
         // Narrows the TMDB candidate pool to seasons already established by an existing/new OV/DT
         // link, so later passes can't stray into an unrelated season once one has been established.
@@ -639,12 +566,12 @@ public class TmdbLinkingService : ITmdbLinkingService
             FilterToCurrentSeasons(passNumber);
 
             var passCurrent = 0;
-            foreach (var (episode, cachedCrossRef, cachedAnchorSeasonNumber) in RankByConfidence(episodes))
+            foreach (var (episode, cachedCrossRef, cachedAnchorSeasonNumber) in RankByConfidence(episodes, matchContext))
             {
                 passCurrent++;
                 _logger.LogTrace("Linking episode {EpisodeType} {EpisodeNumber}. (AniDB ID: {EpisodeID}, Progress: {Current}/{Total}, Pass: {PassNumber}/4)", episode.EpisodeType, episode.EpisodeNumber, episode.EpisodeID, passCurrent, episodes.Count, passNumber);
                 var episodeList = GetEpisodeList(episode);
-                var crossRef = ResolveRankedMatch(episode, cachedCrossRef, cachedAnchorSeasonNumber, episodeList);
+                var crossRef = ResolveRankedMatch(episode, cachedCrossRef, cachedAnchorSeasonNumber, episodeList, matchContext);
                 if (accepts(crossRef.MatchRating))
                 {
                     var index = episodeList.FindIndex(episode => episode.TmdbEpisodeID == crossRef.TmdbEpisodeID);
@@ -664,7 +591,7 @@ public class TmdbLinkingService : ITmdbLinkingService
         }
 
         var current = 0;
-        foreach (var (episode, cachedCrossRef, cachedAnchorSeasonNumber) in RankByConfidence(anidbEpisodes.Values))
+        foreach (var (episode, cachedCrossRef, cachedAnchorSeasonNumber) in RankByConfidence(anidbEpisodes.Values, matchContext))
         {
             current++;
             _logger.LogTrace("Checking episode {EpisodeType} {EpisodeNumber}. (AniDB ID: {AnidbEpisodeID}, Progress: {Current}/{Total}, Pass: 1/4)", episode.EpisodeType, episode.EpisodeNumber, episode.EpisodeID, current, anidbEpisodes.Count);
@@ -735,7 +662,7 @@ public class TmdbLinkingService : ITmdbLinkingService
                 // Else try find a match.
                 _logger.LogTrace("Linking episode. (AniDB ID: {AnidbEpisodeID}, Pass: 1/4)", episode.EpisodeID);
                 var episodeList = GetEpisodeList(episode);
-                var crossRef = ResolveRankedMatch(episode, cachedCrossRef, cachedAnchorSeasonNumber, episodeList);
+                var crossRef = ResolveRankedMatch(episode, cachedCrossRef, cachedAnchorSeasonNumber, episodeList, matchContext);
                 if (crossRef.MatchRating is MatchRating.DateAndTitleMatches)
                 {
                     var index = episodeList.FindIndex(episode => episode.TmdbEpisodeID == crossRef.TmdbEpisodeID);
@@ -804,6 +731,97 @@ public class TmdbLinkingService : ITmdbLinkingService
 
         int NormalEpisodeSeasonNumberSelector(CrossRef_AniDB_TMDB_Episode xref) => xref.TmdbEpisodeID is not 0 && (isOVA || anidbEpisodes[xref.AnidbEpisodeID].EpisodeType is EpisodeType.Episode) && tmdbEpisodeDict.TryGetValue(xref.TmdbEpisodeID, out var tmdbEpisode) ? tmdbEpisode.SeasonNumber : -1;
     }
+
+    // Shared state for ResolveAnchorSeason/RankByConfidence/ResolveRankedMatch. GetEpisodeList is a
+    // delegate, not a snapshot, since FilterToCurrentSeasons mutates the episode lists between passes.
+    private readonly record struct EpisodeMatchContext(
+        AniDB_Anime Anime,
+        TMDB_Show Show,
+        bool IsOVA,
+        Func<AniDB_Episode, List<TMDB_Episode>> GetEpisodeList,
+        IReadOnlyDictionary<(EpisodeType, int), AniDB_Episode> AnidbEpisodesByTypeNumber,
+        IReadOnlyDictionary<int, CrossRef_AniDB_TMDB_Episode> PrimaryLinkByAnidbEpisodeId,
+        IReadOnlyDictionary<int, TMDB_Episode> TmdbEpisodeDict);
+
+    // Finds the TMDB season an episode's adjacent AniDB neighbor (previous and next) already linked
+    // to, so the nearest-air-date fallback in TryFindAnidbAndTmdbMatch can be scoped to that season
+    // instead of searching across all seasons. Without this, a back-to-back multi-cour release (e.g.
+    // season 1 ending in March, season 2 starting in June) can have less than the fallback's date
+    // tolerance between season boundaries, letting an unresolved season-1 episode get pulled onto a
+    // season-2 episode instead of staying unlinked. Returns null for OVAs, where there's only one pool.
+    // Looks up PrimaryLinkByAnidbEpisodeId (O(1), Ordering == 0 only) rather than crossReferences
+    // directly, so a multi-part neighbor's secondary/duplicate link can't be picked up by mistake.
+    private static int? ResolveAnchorSeason(AniDB_Episode episode, EpisodeMatchContext context)
+    {
+        if (context.IsOVA)
+            return null;
+
+        (int Season, DateOnly? AiredAt)? SeasonOfNeighbor(int neighborEpisodeNumber)
+        {
+            if (!context.AnidbEpisodesByTypeNumber.TryGetValue((episode.EpisodeType, neighborEpisodeNumber), out var neighbor))
+                return null;
+            if (!context.PrimaryLinkByAnidbEpisodeId.TryGetValue(neighbor.EpisodeID, out var xref))
+                return null;
+            if (!context.TmdbEpisodeDict.TryGetValue(xref.TmdbEpisodeID, out var tmdbEpisode))
+                return null;
+
+            return (tmdbEpisode.SeasonNumber, tmdbEpisode.AiredAt);
+        }
+
+        var previous = SeasonOfNeighbor(episode.EpisodeNumber - 1);
+        var next = SeasonOfNeighbor(episode.EpisodeNumber + 1);
+        if (previous is null)
+            return next?.Season;
+        if (next is null || previous.Value.Season == next.Value.Season)
+            return previous.Value.Season;
+
+        // The neighbors disagree on season — a season boundary sits between them. Trust whichever
+        // neighbor's air date is actually closer to this episode's own, rather than always preferring
+        // the previous episode, so the first episode of a new season anchors to the new season
+        // instead of inheriting the one that just ended.
+        var anidbDate = episode.GetAirDateAsDate()?.ToDateOnly();
+        if (anidbDate is null)
+            return previous.Value.Season;
+
+        var previousDistance = CalculateAirDateDistance(anidbDate, previous.Value.AiredAt) ?? int.MaxValue;
+        var nextDistance = CalculateAirDateDistance(anidbDate, next.Value.AiredAt) ?? int.MaxValue;
+        return nextDistance < previousDistance ? next.Value.Season : previous.Value.Season;
+    }
+
+    // Ranks episodes by their best candidate match without consuming it, so passes can process the
+    // strongest matches first and let weaker duplicate claims fall back to their next-best candidate
+    // instead of losing a shared TMDB episode purely by AniDB episode order. The match found here is
+    // cached and handed back to the caller so the loop that actually consumes candidates doesn't have
+    // to run the same title-search/air-date computation a second time for every episode.
+    private List<(AniDB_Episode Episode, CrossRef_AniDB_TMDB_Episode CrossRef, int? AnchorSeasonNumber)> RankByConfidence(IEnumerable<AniDB_Episode> episodes, EpisodeMatchContext context) =>
+        episodes
+            .Select(ep =>
+            {
+                var anchorSeasonNumber = ResolveAnchorSeason(ep, context);
+                var isSpecial = IsSpecialEpisode(ep, context);
+                var crossRef = TryFindAnidbAndTmdbMatch(context.Anime, ep, context.GetEpisodeList(ep), isSpecial && !context.IsOVA, context.Show.OriginalLanguageCode, anchorSeasonNumber, out var confidence);
+                return (Episode: ep, CrossRef: crossRef, Confidence: confidence, AnchorSeasonNumber: anchorSeasonNumber);
+            })
+            .OrderByDescending(ranked => ranked.Confidence)
+            .Select(ranked => (ranked.Episode, ranked.CrossRef, ranked.AnchorSeasonNumber))
+            .ToList();
+
+    // Re-finds a match for an episode, reusing the cached match from RankByConfidence when its chosen
+    // TMDB candidate hasn't since been claimed by an earlier (stronger) episode in the same pass AND
+    // the episode's anchor season hasn't changed since — a same-pass neighbor getting linked earlier
+    // in this same loop can newly resolve an anchor that didn't exist when RankByConfidence ran, so
+    // pool-membership alone isn't enough to prove the cached match is still correct.
+    private CrossRef_AniDB_TMDB_Episode ResolveRankedMatch(AniDB_Episode episode, CrossRef_AniDB_TMDB_Episode cached, int? cachedAnchorSeasonNumber, List<TMDB_Episode> episodeList, EpisodeMatchContext context)
+    {
+        var anchorSeasonNumber = ResolveAnchorSeason(episode, context);
+        var isSpecial = IsSpecialEpisode(episode, context);
+        return cached.TmdbEpisodeID != 0 && anchorSeasonNumber == cachedAnchorSeasonNumber && episodeList.Any(candidate => candidate.TmdbEpisodeID == cached.TmdbEpisodeID)
+            ? cached
+            : TryFindAnidbAndTmdbMatch(context.Anime, episode, episodeList, isSpecial && !context.IsOVA, context.Show.OriginalLanguageCode, anchorSeasonNumber);
+    }
+
+    private static bool IsSpecialEpisode(AniDB_Episode episode, EpisodeMatchContext context) =>
+        episode.EpisodeType is EpisodeType.Special || context.Anime.AnimeType is not AnimeType.TV and not AnimeType.Web;
 
     private CrossRef_AniDB_TMDB_Episode TryFindAnidbAndTmdbMatch(AniDB_Anime anime, AniDB_Episode anidbEpisode, IReadOnlyList<TMDB_Episode> tmdbEpisodes, bool isSpecial, string originalLanguageCode, int? anchorSeasonNumber) =>
         TryFindAnidbAndTmdbMatch(anime, anidbEpisode, tmdbEpisodes, isSpecial, originalLanguageCode, anchorSeasonNumber, out _);

--- a/Shoko.Tests/Providers/TMDB/TmdbLinkingServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbLinkingServiceTests.cs
@@ -194,4 +194,47 @@ public class TmdbLinkingServiceTests
 
         Assert.Empty(candidates);
     }
+
+    private static bool TryNearestAirDateMatch(AniDB_Episode anidbEpisode, List<(TMDB_Episode episode, int distance)> nearestAirdate, out CrossRef_AniDB_TMDB_Episode crossRef, out double confidence)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static;
+        var method = typeof(TmdbLinkingService).GetMethod("TryNearestAirDateMatch", flags)!;
+        var args = new object?[] { anidbEpisode, nearestAirdate, null, 0d };
+        var result = (bool)method.Invoke(null, args)!;
+        crossRef = (CrossRef_AniDB_TMDB_Episode)args[2]!;
+        confidence = (double)args[3]!;
+        return result;
+    }
+
+    // Reproduces "The Elusive Samurai" S2: AniDB episode 2 has no TMDB entry within ±2 days (TMDB
+    // simply hasn't listed it yet), so the strict air-date pass finds nothing. Previously this fell
+    // straight to a blind positional "first available" guess (grabbing whatever TMDB episode was next
+    // in the list, e.g. episode 5's slot); the nearest-date fallback should instead pick the episode
+    // whose air date is actually closest, even though it's outside the strict window.
+    [Fact]
+    public void TryNearestAirDateMatch_PicksClosestCandidate_OutsideStrictWindow()
+    {
+        var anidbEpisode = new AniDB_Episode { EpisodeID = 2, EpisodeNumber = 2, EpisodeType = EpisodeType.Episode };
+        var farEpisode = new TMDB_Episode { TmdbEpisodeID = 201, TmdbShowID = 1, SeasonNumber = 2, EpisodeNumber = 2 };
+        var nearEpisode = new TMDB_Episode { TmdbEpisodeID = 202, TmdbShowID = 1, SeasonNumber = 2, EpisodeNumber = 3 };
+        var nearestAirdate = new List<(TMDB_Episode episode, int distance)> { (nearEpisode, 5), (farEpisode, 20) };
+
+        var found = TryNearestAirDateMatch(anidbEpisode, nearestAirdate, out var crossRef, out var confidence);
+
+        Assert.True(found);
+        Assert.Equal(nearEpisode.TmdbEpisodeID, crossRef.TmdbEpisodeID);
+        Assert.Equal(MatchRating.NearestDateMatches, crossRef.MatchRating);
+        Assert.True(confidence > 0);
+    }
+
+    [Fact]
+    public void TryNearestAirDateMatch_ReturnsFalse_WhenNoCandidates()
+    {
+        var anidbEpisode = new AniDB_Episode { EpisodeID = 2, EpisodeNumber = 2, EpisodeType = EpisodeType.Episode };
+
+        var found = TryNearestAirDateMatch(anidbEpisode, [], out _, out var confidence);
+
+        Assert.False(found);
+        Assert.Equal(0, confidence);
+    }
 }

--- a/Shoko.Tests/Providers/TMDB/TmdbLinkingServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbLinkingServiceTests.cs
@@ -237,4 +237,57 @@ public class TmdbLinkingServiceTests
         Assert.False(found);
         Assert.Equal(0, confidence);
     }
+
+    private static CrossRef_AniDB_TMDB_Episode SelectBestEpisodeMatch(
+        AniDB_Episode anidbEpisode,
+        IReadOnlyList<TMDB_Episode> tmdbEpisodes,
+        bool isSpecial,
+        List<(TMDB_Episode episode, int distance)> nearestAirdate,
+        out double confidence)
+    {
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static;
+        var method = typeof(TmdbLinkingService).GetMethod("SelectBestEpisodeMatch", flags)!;
+        var args = new object?[]
+        {
+            anidbEpisode, tmdbEpisodes, isSpecial, new List<Shoko.Server.Utilities.SeriesSearch.SearchResult<TMDB_Episode>>(),
+            new List<(TMDB_Episode episode, double probability)>(), nearestAirdate, 0d,
+        };
+        var result = (CrossRef_AniDB_TMDB_Episode)method.Invoke(null, args)!;
+        confidence = (double)args[6]!;
+        return result;
+    }
+
+    // Guards the fix for specials being auto-linked purely on loose (up to 120-day) air-date
+    // proximity with zero title corroboration — unlike a normal episode, a special with no strict
+    // date/title match should fall all the way through to an empty (unmatched) link rather than
+    // grabbing whatever TMDB episode happens to be nearest in air date.
+    [Fact]
+    public void SelectBestEpisodeMatch_DoesNotUseLooseAirDateFallback_ForSpecials()
+    {
+        var anidbEpisode = new AniDB_Episode { EpisodeID = 2, EpisodeNumber = 1, EpisodeType = EpisodeType.Special };
+        var nearEpisode = new TMDB_Episode { TmdbEpisodeID = 202, TmdbShowID = 1, SeasonNumber = 0, EpisodeNumber = 1 };
+        var nearestAirdate = new List<(TMDB_Episode episode, int distance)> { (nearEpisode, 5) };
+
+        var crossRef = SelectBestEpisodeMatch(anidbEpisode, [nearEpisode], isSpecial: true, nearestAirdate, out var confidence);
+
+        Assert.Equal(0, crossRef.TmdbEpisodeID);
+        Assert.Equal(MatchRating.None, crossRef.MatchRating);
+        Assert.Equal(0, confidence);
+    }
+
+    // Same setup as above but for a normal episode, where the loose air-date fallback should still
+    // apply — confirms the isSpecial gate doesn't accidentally suppress it for non-specials too.
+    [Fact]
+    public void SelectBestEpisodeMatch_UsesLooseAirDateFallback_ForNonSpecials()
+    {
+        var anidbEpisode = new AniDB_Episode { EpisodeID = 2, EpisodeNumber = 2, EpisodeType = EpisodeType.Episode };
+        var nearEpisode = new TMDB_Episode { TmdbEpisodeID = 202, TmdbShowID = 1, SeasonNumber = 2, EpisodeNumber = 3 };
+        var nearestAirdate = new List<(TMDB_Episode episode, int distance)> { (nearEpisode, 5) };
+
+        var crossRef = SelectBestEpisodeMatch(anidbEpisode, [nearEpisode], isSpecial: false, nearestAirdate, out var confidence);
+
+        Assert.Equal(nearEpisode.TmdbEpisodeID, crossRef.TmdbEpisodeID);
+        Assert.Equal(MatchRating.DateKindaMatches, crossRef.MatchRating);
+        Assert.True(confidence > 0);
+    }
 }

--- a/Shoko.Tests/Providers/TMDB/TmdbLinkingServiceTests.cs
+++ b/Shoko.Tests/Providers/TMDB/TmdbLinkingServiceTests.cs
@@ -223,7 +223,7 @@ public class TmdbLinkingServiceTests
 
         Assert.True(found);
         Assert.Equal(nearEpisode.TmdbEpisodeID, crossRef.TmdbEpisodeID);
-        Assert.Equal(MatchRating.NearestDateMatches, crossRef.MatchRating);
+        Assert.Equal(MatchRating.DateKindaMatches, crossRef.MatchRating);
         Assert.True(confidence > 0);
     }
 


### PR DESCRIPTION
## Summary
- `TryFindAnidbAndTmdbMatch` previously fell straight from the strict ±2-day `TryAirDateMatch` window to a blind positional `FirstAvailable` guess, which mismatched delayed/compressed episodes onto the wrong TMDB slot (e.g. AniDB episode 2 grabbing episode 5's TMDB entry).
- Added `TryNearestAirDateMatch`, tagged with a new `MatchRating.DateKindaMatches`, using the unbounded `CalculateAirDateDistance` to pick the closest remaining candidate by air date instead of by list position, bounded by `MaxFallbackDifferenceInDays` (120) so it can't confidently link episodes separated by an unrelated multi-month gap.
- Scoped the fallback candidate pool to `anchorSeasonNumber`, resolved from whichever neighboring AniDB episode already has a confirmed TMDB link, so a back-to-back multi-cour release (e.g. season 1 ending in March, season 2 starting in June) can't have this pull an unresolved episode across the season boundary. When neighbors disagree on season, the closer one by air date wins instead of always preferring the previous episode.
- `ResolveRankedMatch`'s cache-reuse now also invalidates when a same-pass neighbor resolves a new anchor mid-pass, not just when the cached TMDB candidate gets claimed.
- Renamed `MatchRating.NearestDateMatches` to `DateKindaMatches` to match the existing `*KindaMatches` naming convention (`TitleKindaMatches`, `DateAndTitleKindaMatches`), per harshithmohan's review.

## Follow-up fixes (post-review)
- `anidbEpisodesByTypeNumber` is now built with `GroupBy`+`First` instead of `ToDictionary`, which threw on any duplicate `(EpisodeType, EpisodeNumber)` pair.
- The loose (±120 day) `TryNearestAirDateMatch` fallback is now gated by `isSpecial`, matching the positional `FirstAvailable` fallback beside it — a special with no title match could previously auto-link to whatever TMDB episode was nearest in air date up to four months away, with zero corroborating evidence. Covered by two new tests.
- Collapsed two duplicate copies of the special-episode predicate (a closure and a static method reimplementing the same check) into one shared `IsSpecialEpisode(EpisodeType, AnimeType)` helper.
- Rewrote the `nearestAirdate` LINQ chain as a query expression so the null-check is visible to nullable analysis across the following `select`, clearing a CS8629 warning.
- Wrapped new method signatures that exceeded the repo's 160-character line limit.

## Test plan
- [x] `dotnet build Shoko.Server.sln`
- [x] `dotnet test Shoko.Tests/Shoko.Tests.csproj --filter "FullyQualifiedName~TmdbLinkingServiceTests"` (11/11 passing, including 4 gap-handling tests)
- [x] `dotnet test Shoko.Tests/Shoko.Tests.csproj` (521/521 passing)

## Rebase history
- 2026-08-10 00:53 UTC — rebased onto `master` @ `7b1523c88` (6 commits), now at `9aeae1017`
- 2026-08-13 17:22 UTC — rebased onto `master` @ `d4dff0c4d` (8 commits), now at `a84f981e6`
