### PR TITLE
fix(db): make NHibernateDependencyInjector's type-info caches thread-safe

### DIFF
--- a/Shoko.Server/Databases/NHIbernate/NHibernateDependencyInjector.cs
+++ b/Shoko.Server/Databases/NHIbernate/NHibernateDependencyInjector.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,8 +13,12 @@ public class NHibernateDependencyInjector : EmptyInterceptor
     private readonly IServiceProvider _provider;
     private ISession _session;
     private static readonly Dictionary<Type, Func<object, (string name, object value)[], bool>> s_postInitializationCallbacks = new();
-    private static Dictionary<string, Type> s_allTypes;
-    private static readonly Dictionary<string, bool> s_typeHasValidConstructors = new();
+    // ConcurrentDictionary: Instantiate() runs concurrently across NHibernate sessions on different
+    // worker threads. A plain Dictionary here corrupts under concurrent first-time writes for the
+    // same not-yet-cached key, throwing "Operations that change non-concurrent collections must have
+    // exclusive access" and leaving the dictionary permanently broken for the rest of the process.
+    private static ConcurrentDictionary<string, Type> s_allTypes;
+    private static readonly ConcurrentDictionary<string, bool> s_typeHasValidConstructors = new();
 
     public NHibernateDependencyInjector(IServiceProvider provider)
     {
@@ -38,12 +43,13 @@ public class NHibernateDependencyInjector : EmptyInterceptor
     public override object Instantiate(string clazz, object id)
     {
         // return null -> use default NHibernate entity creation
-        s_allTypes ??= AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes()).DistinctBy(a => a.FullName).ToDictionary(a => a.FullName, a => a);
+        s_allTypes ??= new ConcurrentDictionary<string, Type>(
+            AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes()).DistinctBy(a => a.FullName).ToDictionary(a => a.FullName, a => a));
         if (!s_allTypes.TryGetValue(clazz, out var type)) return null;
         if (!s_typeHasValidConstructors.TryGetValue(clazz, out var hasParameters))
         {
             hasParameters = type.GetConstructors().Any(x => x.GetParameters().Any());
-            s_typeHasValidConstructors.Add(clazz, hasParameters);
+            s_typeHasValidConstructors.TryAdd(clazz, hasParameters);
         }
 
         if (!hasParameters) return null;

--- a/Shoko.Server/Databases/NHIbernate/NHibernateDependencyInjector.cs
+++ b/Shoko.Server/Databases/NHIbernate/NHibernateDependencyInjector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using NHibernate;
 using NHibernate.Type;
@@ -43,9 +44,12 @@ public class NHibernateDependencyInjector : EmptyInterceptor
     public override object Instantiate(string clazz, object id)
     {
         // return null -> use default NHibernate entity creation
-        s_allTypes ??= new ConcurrentDictionary<string, Type>(
-            AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes()).DistinctBy(a => a.FullName).ToDictionary(a => a.FullName, a => a));
-        if (!s_allTypes.TryGetValue(clazz, out var type)) return null;
+        // LazyInitializer, not `??=`, so concurrent first callers can't race to build/assign
+        // s_allTypes independently — a static field written from this instance method needs
+        // its own synchronization, same reasoning as the ConcurrentDictionary swap above.
+        var allTypes = LazyInitializer.EnsureInitialized(ref s_allTypes, static () => new ConcurrentDictionary<string, Type>(
+            AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes()).DistinctBy(a => a.FullName).ToDictionary(a => a.FullName, a => a)));
+        if (!allTypes.TryGetValue(clazz, out var type)) return null;
         if (!s_typeHasValidConstructors.TryGetValue(clazz, out var hasParameters))
         {
             hasParameters = type.GetConstructors().Any(x => x.GetParameters().Any());

--- a/Shoko.Tests/Databases/NHibernateDependencyInjectorTests.cs
+++ b/Shoko.Tests/Databases/NHibernateDependencyInjectorTests.cs
@@ -1,0 +1,33 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Shoko.Server.Databases.NHibernate;
+using Xunit;
+
+namespace Shoko.Tests.Databases;
+
+/// <summary>
+/// Guards against reverting <see cref="NHibernateDependencyInjector"/>'s static type-info caches
+/// back to plain <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>. <c>Instantiate</c>
+/// runs concurrently across NHibernate sessions on different worker threads; a plain Dictionary
+/// corrupts under concurrent first-time writes for the same not-yet-cached key, throwing
+/// "Operations that change non-concurrent collections must have exclusive access" and leaving the
+/// dictionary permanently broken (every subsequent lookup throws) for the rest of the process.
+/// </summary>
+public class NHibernateDependencyInjectorTests
+{
+    private static readonly BindingFlags StaticNonPublic = BindingFlags.NonPublic | BindingFlags.Static;
+
+    [Fact]
+    public void TypeHasValidConstructorsCache_IsConcurrentDictionary()
+    {
+        var field = typeof(NHibernateDependencyInjector).GetField("s_typeHasValidConstructors", StaticNonPublic)!;
+        Assert.Equal(typeof(ConcurrentDictionary<string, bool>), field.FieldType);
+    }
+
+    [Fact]
+    public void AllTypesCache_IsConcurrentDictionary()
+    {
+        var field = typeof(NHibernateDependencyInjector).GetField("s_allTypes", StaticNonPublic)!;
+        Assert.Equal(typeof(ConcurrentDictionary<string, System.Type>), field.FieldType);
+    }
+}


### PR DESCRIPTION
## Summary
- `NHibernateDependencyInjector.Instantiate()` runs concurrently across NHibernate sessions on different worker threads. Its two static type-info caches (`s_allTypes`, `s_typeHasValidConstructors`) were plain `Dictionary`s with an unsynchronized check-then-add pattern.
- Two threads racing on the same not-yet-cached `clazz` both miss the `TryGetValue` and both call `.Add()` concurrently, corrupting the dictionary's internal state: `InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state.`
- The corruption is **permanent for the process's lifetime** — every subsequent `Instantiate()` call touching that dictionary throws until the process restarts, cascading into any code path that instantiates an NHibernate entity (observed via TMDB metadata jobs and the Lua renamer's `Studios` access).
- The race window only opens right after a restart, before the caches warm up — it needs concurrent first-time access to the *same* entity type in that narrow window, which a startup job backlog (image downloads, renames, TMDB updates all firing at once) makes far more likely than steady-state traffic. This is why it went unnoticed since it was introduced in 2023 (`4e720796f`).
- Swapped both caches to `ConcurrentDictionary`, which removes the race entirely rather than serializing every `Instantiate()` call behind a lock.
- `s_allTypes` was still lazily built via `??=` on the static field from the instance method — a second, narrower race (concurrent first callers could each build/assign their own dictionary independently; harmless in practice, but flagged CRITICAL by SonarCloud as S2696 "static field updated from an instance method"). Switched to `LazyInitializer.EnsureInitialized` to guarantee single construction regardless of concurrent first access.

Reproduced and root-caused on a production instance: 76 occurrences over ~4 hours following a routine container restart, with the affected `UpdateTmdbShowJob` retrying and failing repeatedly (5/8 retries) since the corruption doesn't self-heal — restarting the container again should clear the corrupted dictionary and stop the cascade until the next cold-start race, but only this fix actually closes the window.

## Test plan
- [x] `dotnet build Shoko.Server.sln`
- [x] `dotnet test Shoko.Tests/Shoko.Tests.csproj --filter "FullyQualifiedName~NHibernateDependencyInjectorTests"` (2/2 passing — new tests guard against reverting the caches back to plain `Dictionary`)
- [x] SonarCloud Code Analysis passing (after the `LazyInitializer` fix for S2696)