### PR TITLE
fix(tmdb): shrink incremental changes window from 14 days to 1

### DIFF
--- a/Shoko.Server/Settings/SettingsMigrations.cs
+++ b/Shoko.Server/Settings/SettingsMigrations.cs
@@ -86,6 +86,7 @@ public static partial class SettingsMigrations
         { 15, null },
         { 16, MigrateDefaultRenamerToStatic },
         { 17, MigrateReleaseSignalTypeNames },
+        { 18, MigrateTmdbIncrementalChangesWindow },
     };
 
     /// <summary>
@@ -334,6 +335,18 @@ public static partial class SettingsMigrations
             if (value is not null && _releaseSignalRenames.TryGetValue(value, out var newName))
                 signalPriority[i] = newName;
         }
+
+        return currentSettings.ToString();
+    }
+
+    private static string MigrateTmdbIncrementalChangesWindow(string settings)
+    {
+        var currentSettings = JObject.Parse(settings);
+        var tmdbSettings = currentSettings["TMDB"];
+        if (tmdbSettings?["IncrementalChangesWindowDays"]?.Value<int>() != 14)
+            return settings;
+
+        tmdbSettings["IncrementalChangesWindowDays"] = 1;
 
         return currentSettings.ToString();
     }

--- a/Shoko.Server/Settings/TMDBSettings.cs
+++ b/Shoko.Server/Settings/TMDBSettings.cs
@@ -248,8 +248,8 @@ public class TMDBSettings
     [Visibility(Size = DisplayElementSize.Large)]
     [EnvironmentVariable("TMDB_CHANGES_WINDOW_DAYS")]
     [Range(0, 14)]
-    [DefaultValue(14)]
-    public int IncrementalChangesWindowDays { get; set; } = 14;
+    [DefaultValue(1)]
+    public int IncrementalChangesWindowDays { get; set; } = 1;
 
     /// <summary>
     /// The maximum number of TMDB search candidates to evaluate per auto-search


### PR DESCRIPTION
## Summary
- TMDB's Changes API is unreliable for translation/title-only edits, letting shows get stuck with stale/placeholder episode titles for up to 14 days between full refreshes.
- Instead of removing the incremental-refresh mechanism entirely, this keeps it but shrinks the window it's trusted for from 14 days to 1 — any show not updated within the last day gets a full re-fetch, so a missed change can only go stale for a day instead of two weeks. Keeps the API-call savings for the common case (updating again same-day) while drastically reducing the blast radius of the Changes API's unreliability.
- Added a settings migration (v18) so existing installs pick up the new 1-day default automatically instead of being stuck on 14 until they manually edit `settings-server.json`. It only touches the value if it's still at the old unmodified default of 14, so anyone who already customized `IncrementalChangesWindowDays` keeps their value.

As Avael pointed out. Simpler to match 1 day window like Anidb queries, instead of holding possible stale data for 14 days

## Test plan
- [x] `dotnet build Shoko.Server.sln` — 0 errors