### PR TITLE
chore(deps): update NuGet packages to latest versions

### DIFF
--- a/Shoko.BuildTools.Targets/Shoko.BuildTools.Targets.csproj
+++ b/Shoko.BuildTools.Targets/Shoko.BuildTools.Targets.csproj
@@ -20,9 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.13.9" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.13.9" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.8.2" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.8.2" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
   </ItemGroup>
 
 </Project>

--- a/Shoko.BuildTools/Shoko.BuildTools.csproj
+++ b/Shoko.BuildTools/Shoko.BuildTools.csproj
@@ -21,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.13.9" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageReference Include="Microsoft.Build" Version="18.8.2" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
   </ItemGroup>
 
 </Project>

--- a/Shoko.IntegrationTests/Shoko.IntegrationTests.csproj
+++ b/Shoko.IntegrationTests/Shoko.IntegrationTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Shoko.QueueProcessor.Tests/Shoko.QueueProcessor.Tests.csproj
+++ b/Shoko.QueueProcessor.Tests/Shoko.QueueProcessor.Tests.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>

--- a/Shoko.QueueProcessor/Shoko.QueueProcessor.csproj
+++ b/Shoko.QueueProcessor/Shoko.QueueProcessor.csproj
@@ -27,23 +27,23 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Pin fixed SQLitePCLRaw packages to avoid transitive vulnerability GHSA-2m69-gcr7-jv3q -->
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="SQLitePCLRaw.core" Version="3.0.3" />
-    <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
+    <PackageReference Include="SQLitePCLRaw.core" Version="3.0.5" />
+    <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microting.EntityFrameworkCore.MySql" Version="10.0.9" />
+    <PackageReference Include="Microting.EntityFrameworkCore.MySql" Version="10.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Shoko.Server/Shoko.Server.csproj
+++ b/Shoko.Server/Shoko.Server.csproj
@@ -59,36 +59,36 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
     <PackageReference Include="JsonDiffPatch.Net" Version="2.5.0" />
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.14.0" />
-    <PackageReference Include="MessagePack" Version="3.1.7" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.16.0" />
+    <PackageReference Include="MessagePack" Version="3.1.8" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.ResponseCaching" Version="2.3.11" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.11" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.9" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.10" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" />
     <PackageReference Include="MySqlBackup.NET.MySqlConnector" Version="2.7.1" />
     <PackageReference Include="MySqlConnector" Version="2.6.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="NHibernate" Version="5.6.1" />
+    <PackageReference Include="NHibernate" Version="5.7.0" />
     <PackageReference Include="NHibernate.Driver.MySqlConnector" Version="2.0.5" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="NJsonSchema" Version="11.6.1" />
     <PackageReference Include="NJsonSchema.Annotations" Version="11.6.1" />
     <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.6.1" />
-    <PackageReference Include="NLog" Version="6.1.3" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.3" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.3" />
+    <PackageReference Include="NLog" Version="6.1.4" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.4" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.4" />
     <PackageReference Include="Polly" Version="8.7.0" />
-    <PackageReference Include="Sentry" Version="6.6.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="6.6.0" />
-    <PackageReference Include="Sentry.Extensions.Logging" Version="6.6.0" />
-    <PackageReference Include="Sentry.NLog" Version="6.6.0" />
-    <PackageReference Include="SharpCompress" Version="0.49.1" />
+    <PackageReference Include="Sentry" Version="6.8.0" />
+    <PackageReference Include="Sentry.AspNetCore" Version="6.8.0" />
+    <PackageReference Include="Sentry.Extensions.Logging" Version="6.8.0" />
+    <PackageReference Include="Sentry.NLog" Version="6.8.0" />
+    <PackageReference Include="SharpCompress" Version="0.50.1" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.3" />
@@ -98,12 +98,12 @@
     <PackageReference Include="Trinet.Core.IO.Ntfs" Version="4.1.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" PrivateAssets="All" />
-    <PackageReference Include="MessagePackAnalyzer" Version="3.1.7">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" PrivateAssets="All" />
+    <PackageReference Include="MessagePackAnalyzer" Version="3.1.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Shoko.Tests/Shoko.Tests.csproj
+++ b/Shoko.Tests/Shoko.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Shoko.TrayService/Shoko.TrayService.csproj
+++ b/Shoko.TrayService/Shoko.TrayService.csproj
@@ -33,12 +33,12 @@
         <ProjectReference Include="..\Shoko.Server\Shoko.Server.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.0.5" />
-        <PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
+        <PackageReference Include="Avalonia" Version="12.1.0" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.1.0" />
         <!-- Needed for the windows' native tray system menu to function properly. -->
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.0" />
         <!-- Pin Tmds.DBus.Protocol to a non-vulnerable patch to address GHSA-xrw6-gwf8-vvr9 -->
-        <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
+        <PackageReference Include="Tmds.DBus.Protocol" Version="0.94.2" />
     </ItemGroup>
     <ItemGroup>
         <AvaloniaResource Include="..\Shoko.Server\db.ico">


### PR DESCRIPTION
## Summary
Bumps all outdated NuGet packages across the solution to their latest versions (Visual Studio-managed PackageReference updates only — no GitHub Actions/workflow changes).

## Packages updated

| Package | Current | New | Changelog |
|---|---|---|---|
| Magick.NET-Q8-AnyCPU ⚠️ | 14.14.0 | 14.16.0 | [releases](https://github.com/dlemstra/Magick.NET/releases) |
| MessagePack | 3.1.7 | 3.1.8 | [releases](https://github.com/MessagePack-CSharp/MessagePack-CSharp/releases) |
| MessagePackAnalyzer | 3.1.7 | 3.1.8 | [releases](https://github.com/MessagePack-CSharp/MessagePack-CSharp/releases) |
| Microsoft.AspNetCore.Mvc.NewtonsoftJson | 10.0.9 | 10.0.10 | [releases](https://github.com/dotnet/aspnetcore/releases) |
| Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson | 10.0.9 | 10.0.10 | [releases](https://github.com/dotnet/aspnetcore/releases) |
| Microsoft.CodeAnalysis.Analyzers | 5.3.0 | 5.6.0 | [releases](https://github.com/dotnet/roslyn-analyzers/releases) |
| Microsoft.CodeAnalysis.CSharp (Server) | 5.3.0 | 5.6.0 | [releases](https://github.com/dotnet/roslyn/releases) |
| Microsoft.CodeAnalysis.CSharp (BuildTools/Targets) 🔺 | 4.13.0 | 5.6.0 | [releases](https://github.com/dotnet/roslyn/releases) |
| Microsoft.CodeAnalysis.NetAnalyzers | 10.0.301 | 10.0.302 | [releases](https://github.com/dotnet/roslyn-analyzers/releases) |
| Microsoft.Data.SqlClient | 7.0.1 | 7.0.2 | [releases](https://github.com/dotnet/SqlClient/releases) |
| Microsoft.Data.Sqlite | 10.0.9 | 10.0.10 | [releases](https://github.com/dotnet/efcore/releases) |
| Microsoft.EntityFrameworkCore | 10.0.9 | 10.0.10 | [releases](https://github.com/dotnet/efcore/releases) |
| Microsoft.EntityFrameworkCore.Design | 10.0.9 | 10.0.10 | [releases](https://github.com/dotnet/efcore/releases) |
| Microsoft.EntityFrameworkCore.Sqlite | 10.0.9 | 10.0.10 | [releases](https://github.com/dotnet/efcore/releases) |
| Microsoft.EntityFrameworkCore.SqlServer | 10.0.9 | 10.0.10 | [releases](https://github.com/dotnet/efcore/releases) |
| Microsoft.Extensions.DependencyInjection.Abstractions | 10.0.9 | 10.0.10 | [releases](https://github.com/dotnet/runtime/releases) |
| Microsoft.Extensions.Hosting.Abstractions | 10.0.9 | 10.0.10 | [releases](https://github.com/dotnet/runtime/releases) |
| Microsoft.Extensions.Logging.Abstractions | 10.0.9 | 10.0.10 | [releases](https://github.com/dotnet/runtime/releases) |
| Microsoft.NET.Test.Sdk | 18.7.0 | 18.8.1 | [releases](https://github.com/microsoft/vstest/releases) |
| Microting.EntityFrameworkCore.MySql | 10.0.9 | 10.0.10 | [releases](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/releases) |
| NHibernate 🔺 | 5.6.1 | 5.7.0 | [releases](https://github.com/nhibernate/nhibernate-core/releases) |
| NLog | 6.1.3 | 6.1.4 | [releases](https://github.com/NLog/NLog/releases) |
| NLog.Extensions.Logging | 6.1.3 | 6.1.4 | [releases](https://github.com/NLog/NLog/releases) |
| NLog.Web.AspNetCore | 6.1.3 | 6.1.4 | [releases](https://github.com/NLog/NLog/releases) |
| Sentry | 6.6.0 | 6.8.0 | [changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md) |
| Sentry.AspNetCore | 6.6.0 | 6.8.0 | [changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md) |
| Sentry.Extensions.Logging | 6.6.0 | 6.8.0 | [changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md) |
| Sentry.NLog | 6.6.0 | 6.8.0 | [changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md) |
| SharpCompress | 0.49.1 | 0.50.1 | [releases](https://github.com/adamhathcock/sharpcompress/releases) |
| SQLitePCLRaw.bundle_e_sqlite3 | 3.0.3 | 3.0.5 | [releases](https://github.com/ericsink/SQLitePCL.raw/releases) |
| SQLitePCLRaw.core | 3.0.3 | 3.0.5 | [releases](https://github.com/ericsink/SQLitePCL.raw/releases) |
| SQLitePCLRaw.provider.e_sqlite3 | 3.0.3 | 3.0.5 | [releases](https://github.com/ericsink/SQLitePCL.raw/releases) |
| Avalonia | 12.0.5 | 12.1.0 | [releases](https://github.com/AvaloniaUI/Avalonia/releases) |
| Avalonia.Desktop | 12.0.5 | 12.1.0 | [releases](https://github.com/AvaloniaUI/Avalonia/releases) |
| Avalonia.Themes.Fluent | 12.0.5 | 12.1.0 | [releases](https://github.com/AvaloniaUI/Avalonia/releases) |
| Tmds.DBus.Protocol | 0.92.0 | 0.94.2 | [releases](https://github.com/tmds/Tmds.DBus/releases) |
| Microsoft.Build 🔺 | 17.13.9 | 18.8.2 | [releases](https://github.com/dotnet/msbuild/releases) |
| Microsoft.Build.Locator | 1.7.8 | 1.11.2 | [releases](https://github.com/microsoft/MSBuildLocator/releases) |
| Microsoft.Build.Framework 🔺 | 17.13.9 | 18.8.2 | [releases](https://github.com/dotnet/msbuild/releases) |
| Microsoft.Build.Utilities.Core 🔺 | 17.13.9 | 18.8.2 | [releases](https://github.com/dotnet/msbuild/releases) |

⚠️ = security fix · 🔺 = major-version bump, see notes below

## Security summary
Only **Magick.NET-Q8-AnyCPU** carried flagged vulnerabilities (5 low-severity GHSA advisories via NU1901 at 14.14.0) — all resolved by the 14.16.0 bump; `dotnet restore` now reports zero NU1901+ warnings.

## Breaking-change note
**NHibernate 5.6.1 → 5.7.0** — on .NET 10 targets, NHibernate now throws `SerializationException` for any feature relying on binary serialization, unless a custom `SerializationStrategy` is configured ([release notes](https://github.com/nhibernate/nhibernate-core/blob/master/releasenotes.txt)). This project uses no second-level cache provider, `ICacheProvider`, `DetachedCriteria` serialization, or `BinaryFormatter` — not applicable here, but flagging since it's the one genuine breaking change identified in this update set.

The two major-version tooling bumps (`Microsoft.Build*` 17→18, `Microsoft.CodeAnalysis.CSharp` 4.13/5.3→5.6) affect only `Shoko.BuildTools`/`Shoko.BuildTools.Targets` build-time tooling and are exercised directly by this repo's build (custom `ReadPluginIdentityFromSource` MSBuild task) — confirmed working via a full build + test run, not just compilation.

## Test plan
- [x] `dotnet build Shoko.Server.sln -c Release` — 0 errors
- [x] `dotnet test` — Shoko.Tests 514/514, Shoko.QueueProcessor.Tests 215/215, Shoko.IntegrationTests 1/1
- [x] `dotnet restore` — no NU1901+ vulnerability warnings remain


## Rebase history
- 2026-07-29 14:53 UTC — rebased onto `master` @ `342cb8d88` (1 commits), now at `c321b957d`
