### PR TITLE
fix(relocation): normalize relocated event path

### DIFF
--- a/Shoko.Abstractions/Video/Events/VideoFileRelocatedEventArgs.cs
+++ b/Shoko.Abstractions/Video/Events/VideoFileRelocatedEventArgs.cs
@@ -34,7 +34,7 @@ public class VideoFileRelocatedEventArgs : VideoFileEventArgs
     /// <summary>
     /// The absolute path leading to the previous location of the file. Uses an OS dependent directory separator.
     /// </summary>
-    public string PreviousPath => Path.Join(PreviousManagedFolder.Path, PreviousRelativePath);
+    public string PreviousPath => Path.Join(PreviousManagedFolder.Path, PreviousRelativePath.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
 
     /// <summary>
     /// Initializes a new instance of the <see cref="VideoFileRelocatedEventArgs"/> class.

--- a/Shoko.Tests/Video/VideoFileRelocatedEventArgsTests.cs
+++ b/Shoko.Tests/Video/VideoFileRelocatedEventArgsTests.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using Moq;
+using Shoko.Abstractions.Video;
+using Shoko.Abstractions.Video.Events;
+using Xunit;
+
+namespace Shoko.Tests.Video;
+
+public class VideoFileRelocatedEventArgsTests
+{
+    [Fact]
+    public void PreviousPath_DoesNotDuplicateSeparatorAtManagedFolderBoundary()
+    {
+        var folderPath = Path.Join("library", "anime") + Path.DirectorySeparatorChar;
+        var folder = new Mock<IManagedFolder>();
+        folder.SetupGet(a => a.Path).Returns(folderPath);
+
+        var eventArgs = new VideoFileRelocatedEventArgs(
+            "new-file.mkv", folder.Object, "series/old-file.mkv", folder.Object,
+            Mock.Of<IVideoFile>(), Mock.Of<IVideo>(), [], [], []);
+
+        Assert.Equal(Path.Join(folderPath, "series", "old-file.mkv"), eventArgs.PreviousPath);
+    }
+}


### PR DESCRIPTION
## Summary

Normalizes the absolute `PreviousPath` exposed by relocation events so a managed-folder path ending in a separator and an event-relative path beginning with one do not produce a doubled separator.

## Root cause

Managed-folder paths intentionally retain a trailing separator, while relocation event paths intentionally retain a leading separator. `Path.Join` preserves both at that boundary.

## Impact

The duplicated separator is cosmetic on Linux, where it resolves to the same location, but it made relocation logs and event consumers see a malformed-looking path. The fix preserves the existing relative-path event contract and normalizes only the composed absolute path.

## Validation

- `dotnet test Shoko.Tests/Shoko.Tests.csproj --filter "FullyQualifiedName~VideoFileRelocatedEventArgsTests"`
