### PR TITLE
repo(workflows): replace archived publish-nuget action, resolve Node 20 deprecation

### DIFF
--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -1,0 +1,49 @@
+name: Publish NuGet package
+description: >
+  Packs and pushes a NuGet package, skipping already-published versions, and
+  tags the commit on a successful publish. Replaces the archived
+  brandedoutcast/publish-nuget action.
+
+inputs:
+  project-file-path:
+    description: Path to the .csproj to pack and publish.
+    required: true
+  nuget-key:
+    description: NuGet.org API key.
+    required: true
+  tag-format:
+    description: >
+      Git tag to create on publish, with * replaced by the package version
+      (e.g. "Shoko.Abstractions-v*" -> "Shoko.Abstractions-v1.2.3").
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Read package version
+      id: version
+      shell: bash
+      run: |
+        version=$(dotnet msbuild "${{ inputs.project-file-path }}" -nologo -getProperty:Version)
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "tag=${TAG_FORMAT/\*/$version}" >> "$GITHUB_OUTPUT"
+      env:
+        TAG_FORMAT: ${{ inputs.tag-format }}
+
+    - name: Pack
+      shell: bash
+      run: dotnet pack -c Release "${{ inputs.project-file-path }}" -o ./nupkg
+
+    - name: Push
+      shell: bash
+      run: dotnet nuget push "./nupkg/*.nupkg" --api-key "${{ inputs.nuget-key }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+    - name: Clean up package output
+      shell: bash
+      run: rm -rf ./nupkg
+
+    - name: Tag release
+      uses: rickstaa/action-create-tag@v1
+      with:
+        tag: ${{ steps.version.outputs.tag }}
+        message: "${{ inputs.project-file-path }} v${{ steps.version.outputs.version }}"

--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -38,10 +38,10 @@ jobs:
         run: |
           echo "date=$(git --no-pager show -s --date='format-local:%Y-%m-%dT%H:%M:%SZ' --format=%cd ${{ github.sha }})" >> "$GITHUB_OUTPUT"
 
-      - name: Setup Node v20
+      - name: Setup Node v24
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install NPM Packages
         run: |
@@ -241,12 +241,12 @@ jobs:
         run: dotnet build -c Release Shoko.Abstractions
 
       - name: Publish Shoko.Abstractions Nuget
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: ./.github/actions/publish-nuget
         if: ${{ env.NUGET_API_KEY != '' }}
         with:
-          PROJECT_FILE_PATH: Shoko.Abstractions/Shoko.Abstractions.csproj
-          NUGET_KEY: ${{ env.NUGET_API_KEY }}
-          TAG_FORMAT: Shoko.Abstractions-v*
+          project-file-path: Shoko.Abstractions/Shoko.Abstractions.csproj
+          nuget-key: ${{ env.NUGET_API_KEY }}
+          tag-format: Shoko.Abstractions-v*
 
   queue-nuget:
     runs-on: ubuntu-latest
@@ -275,12 +275,12 @@ jobs:
         run: dotnet build -c Release Shoko.QueueProcessor
 
       - name: Publish Shoko.QueueProcessor Nuget
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: ./.github/actions/publish-nuget
         if: ${{ env.NUGET_API_KEY != '' }}
         with:
-          PROJECT_FILE_PATH: Shoko.QueueProcessor/Shoko.QueueProcessor.csproj
-          NUGET_KEY: ${{ env.NUGET_API_KEY }}
-          TAG_FORMAT: Shoko.QueueProcessor-v*
+          project-file-path: Shoko.QueueProcessor/Shoko.QueueProcessor.csproj
+          nuget-key: ${{ env.NUGET_API_KEY }}
+          tag-format: Shoko.QueueProcessor-v*
 
   buildtools-nuget:
     runs-on: ubuntu-latest
@@ -309,12 +309,12 @@ jobs:
         run: dotnet build -c Release Shoko.BuildTools
 
       - name: Publish Shoko.BuildTools Nuget Tool
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: ./.github/actions/publish-nuget
         if: ${{ env.NUGET_API_KEY != '' }}
         with:
-          PROJECT_FILE_PATH: Shoko.BuildTools/Shoko.BuildTools.csproj
-          NUGET_KEY: ${{ env.NUGET_API_KEY }}
-          TAG_FORMAT: Shoko.BuildTools-v*
+          project-file-path: Shoko.BuildTools/Shoko.BuildTools.csproj
+          nuget-key: ${{ env.NUGET_API_KEY }}
+          tag-format: Shoko.BuildTools-v*
 
   buildtools-targets-nuget:
     runs-on: ubuntu-latest
@@ -343,12 +343,12 @@ jobs:
         run: dotnet build -c Release Shoko.BuildTools.Targets
 
       - name: Publish Shoko.BuildTools.Targets Nuget
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: ./.github/actions/publish-nuget
         if: ${{ env.NUGET_API_KEY != '' }}
         with:
-          PROJECT_FILE_PATH: Shoko.BuildTools.Targets/Shoko.BuildTools.Targets.csproj
-          NUGET_KEY: ${{ env.NUGET_API_KEY }}
-          TAG_FORMAT: Shoko.BuildTools.Targets-v*
+          project-file-path: Shoko.BuildTools.Targets/Shoko.BuildTools.Targets.csproj
+          nuget-key: ${{ env.NUGET_API_KEY }}
+          tag-format: Shoko.BuildTools.Targets-v*
 
   cli:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -61,6 +61,9 @@ jobs:
 
     name: Publish Shoko.Abstractions Nuget
 
+    env:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
     steps:
       - name: Checkout "${{ github.ref }}"
         uses: actions/checkout@v7
@@ -76,11 +79,12 @@ jobs:
         run: dotnet build -c Release Shoko.Abstractions
 
       - name: Publish Shoko.Abstractions Nuget
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: ./.github/actions/publish-nuget
+        if: ${{ env.NUGET_API_KEY != '' }}
         with:
-          PROJECT_FILE_PATH: Shoko.Abstractions/Shoko.Abstractions.csproj
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-          TAG_FORMAT: Shoko.Abstractions-v*
+          project-file-path: Shoko.Abstractions/Shoko.Abstractions.csproj
+          nuget-key: ${{ env.NUGET_API_KEY }}
+          tag-format: Shoko.Abstractions-v*
 
   queue-nuget:
     runs-on: ubuntu-latest
@@ -90,6 +94,9 @@ jobs:
         dotnet: [ '10.x' ]
 
     name: Publish Shoko.QueueProcessor Nuget
+
+    env:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
     steps:
       - name: Checkout "${{ github.ref }}"
@@ -106,11 +113,12 @@ jobs:
         run: dotnet build -c Release Shoko.QueueProcessor
 
       - name: Publish Shoko.QueueProcessor Nuget
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: ./.github/actions/publish-nuget
+        if: ${{ env.NUGET_API_KEY != '' }}
         with:
-          PROJECT_FILE_PATH: Shoko.QueueProcessor/Shoko.QueueProcessor.csproj
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-          TAG_FORMAT: Shoko.QueueProcessor-v*
+          project-file-path: Shoko.QueueProcessor/Shoko.QueueProcessor.csproj
+          nuget-key: ${{ env.NUGET_API_KEY }}
+          tag-format: Shoko.QueueProcessor-v*
 
   buildtools-nuget:
     runs-on: ubuntu-latest
@@ -120,6 +128,9 @@ jobs:
         dotnet: [ '10.x' ]
 
     name: Publish Shoko.BuildTools Nuget Tool
+
+    env:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
     steps:
       - name: Checkout "${{ github.ref }}"
@@ -136,11 +147,12 @@ jobs:
         run: dotnet build -c Release Shoko.BuildTools
 
       - name: Publish Shoko.BuildTools Nuget Tool
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: ./.github/actions/publish-nuget
+        if: ${{ env.NUGET_API_KEY != '' }}
         with:
-          PROJECT_FILE_PATH: Shoko.BuildTools/Shoko.BuildTools.csproj
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-          TAG_FORMAT: Shoko.BuildTools-v*
+          project-file-path: Shoko.BuildTools/Shoko.BuildTools.csproj
+          nuget-key: ${{ env.NUGET_API_KEY }}
+          tag-format: Shoko.BuildTools-v*
 
   buildtools-targets-nuget:
     runs-on: ubuntu-latest
@@ -150,6 +162,9 @@ jobs:
         dotnet: [ '10.x' ]
 
     name: Publish Shoko.BuildTools.Targets Nuget
+
+    env:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
     steps:
       - name: Checkout "${{ github.ref }}"
@@ -166,11 +181,12 @@ jobs:
         run: dotnet build -c Release Shoko.BuildTools.Targets
 
       - name: Publish Shoko.BuildTools.Targets Nuget
-        uses: brandedoutcast/publish-nuget@v2.5.2
+        uses: ./.github/actions/publish-nuget
+        if: ${{ env.NUGET_API_KEY != '' }}
         with:
-          PROJECT_FILE_PATH: Shoko.BuildTools.Targets/Shoko.BuildTools.Targets.csproj
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-          TAG_FORMAT: Shoko.BuildTools.Targets-v*
+          project-file-path: Shoko.BuildTools.Targets/Shoko.BuildTools.Targets.csproj
+          nuget-key: ${{ env.NUGET_API_KEY }}
+          tag-format: Shoko.BuildTools.Targets-v*
 
   webui:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `brandedoutcast/publish-nuget` is archived (unmaintained since 2022) and its Node 20 runtime is now being force-run on Node 24 by GitHub's runners, surfacing a `Node.js 20 is deprecated` annotation on every daily/release build.
- Replaced it in both `build-daily.yml` and `build-release.yml` with a composite `./.github/actions/publish-nuget` action that wraps `dotnet pack` / `dotnet nuget push --skip-duplicate` plus the existing `rickstaa/action-create-tag` step, preserving tag-on-publish behavior.
- Also bumped `build-daily.yml`'s explicitly pinned `node-version: 20` (used for the release-info npm packages) to 24 — a separate source of the same warning.
- Checked all other actions across both workflows: everything else already floats on a major-version tag (`@v7`, `@v4`, etc.) and auto-tracks latest, so nothing else needed bumping.

## Test plan
- [x] `build-daily.yml`'s composite action pattern already exercised locally against the branch diff
- [ ] Verify a real daily build run picks up the new composite action cleanly (opening as draft pending this)
- [ ] Confirm release-workflow NuGet publish jobs behave identically (skip-duplicate, tag creation) once run on a real release

## Rebase history
- 2026-08-13 17:22 UTC — rebased onto `master` @ `d4dff0c4d` (1 commits), now at `123ddbc72`
