### PR TITLE
refactor(images)!: migrate v3 image endpoints to the new image system

### DIFF
--- a/Shoko.Server/API/v3/Controllers/EpisodeController.cs
+++ b/Shoko.Server/API/v3/Controllers/EpisodeController.cs
@@ -730,7 +730,7 @@ public class EpisodeController : BaseController
 
     #region Images
 
-    private const string InvalidIDForSource = "Invalid image id for selected source.";
+    private const string ImageNotFound = "The requested image does not exist.";
 
     #region All images
 
@@ -881,7 +881,7 @@ public class EpisodeController : BaseController
     [Authorize("admin")]
     [HttpPut("{episodeID}/Images/{imageType}")]
     public ActionResult<Image> SetEpisodeDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int episodeID,
-        [FromRoute] Image.LegacyImageType imageType, [FromBody] Image.Input.DefaultImageBody body)
+        [FromRoute] ImageEntityType imageType, [FromBody] Image.Input.DefaultImageBody body)
     {
         var episode = _animeEpisodes.GetByID(episodeID);
         if (episode == null)
@@ -894,18 +894,11 @@ public class EpisodeController : BaseController
         if (!User.AllowedSeries(series))
             return Forbid(EpisodeForbiddenForUser);
 
-        // Check if the id is valid for the given type and source.
-        var dataSource = body.Source;
-        var imageEntityType = imageType.ToServer();
-        var image = Guid.TryParse(body.ID, out var imageID)
-            ? _imageManager.GetImageByID(imageID)
-            : int.TryParse(body.ID, out var legacyImageID)
-                ? _imageManager.GetImageByID(legacyImageID)
-                : null;
-        if (image is null || (dataSource is not DataSource.None && dataSource != image.Source))
-            return ValidationProblem(InvalidIDForSource);
+        var image = _imageManager.GetImageByID(body.ID);
+        if (image is null)
+            return NotFound(ImageNotFound);
 
-        var xref = _imageManager.SetPreferredImageForEntity(episode, imageEntityType, image);
+        var xref = _imageManager.SetPreferredImageForEntity(episode, imageType, image);
         return new Image(ImageStub.Wrap(image, xref));
     }
 
@@ -917,7 +910,7 @@ public class EpisodeController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpDelete("{episodeID}/Images/{imageType}")]
-    public ActionResult DeleteEpisodeDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int episodeID, [FromRoute] Image.LegacyImageType imageType)
+    public ActionResult DeleteEpisodeDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int episodeID, [FromRoute] ImageEntityType imageType)
     {
         var episode = _animeEpisodes.GetByID(episodeID);
         if (episode == null)
@@ -931,9 +924,8 @@ public class EpisodeController : BaseController
             return Forbid(EpisodeForbiddenForUser);
 
         // Check if a default image is set.
-        var imageEntityType = imageType.ToServer();
         var xref = _imageManager
-            .GetImageCrossReferencesForEntity(episode, new() { ImageType = imageEntityType, IsPreferred = true }).FirstOrDefault();
+            .GetImageCrossReferencesForEntity(episode, new() { ImageType = imageType, IsPreferred = true }).FirstOrDefault();
         if (xref is null)
             return ValidationProblem("No default image for the selected type.");
 

--- a/Shoko.Server/API/v3/Controllers/EpisodeController.cs
+++ b/Shoko.Server/API/v3/Controllers/EpisodeController.cs
@@ -833,11 +833,11 @@ public class EpisodeController : BaseController
     /// Get the default <see cref="Image"/> for the given <paramref name="imageType"/> for the <see cref="Episode"/>.
     /// </summary>
     /// <param name="episodeID">Episode ID</param>
-    /// <param name="imageType">Poster, Banner, Fanart</param>
+    /// <param name="imageType">Primary, Backdrop, Banner, Logo, Disc</param>
     /// <returns></returns>
     [HttpGet("{episodeID}/Images/{imageType}")]
     public ActionResult<Image> GetEpisodeDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int episodeID,
-        [FromRoute] Image.LegacyImageType imageType)
+        [FromRoute] ImageEntityType imageType)
     {
         var episode = _animeEpisodes.GetByID(episodeID);
         if (episode == null)
@@ -850,13 +850,12 @@ public class EpisodeController : BaseController
         if (!User.AllowedSeries(series))
             return Forbid(EpisodeForbiddenForUser);
 
-        var imageEntityType = imageType.ToServer();
-        var preferredImage = ((IWithImages)episode).GetPreferredImageForType(imageEntityType);
+        var preferredImage = ((IWithImages)episode).GetPreferredImageForType(imageType);
         if (preferredImage is not null)
             return new Image(preferredImage);
 
-        var images = ((IWithImages)episode).GetImages(new() { ImageType = imageEntityType }).ToDto();
-        var image = imageEntityType switch
+        var images = ((IWithImages)episode).GetImages(new() { ImageType = imageType }).ToDto();
+        var image = imageType switch
         {
             ImageEntityType.Primary => images.Posters.FirstOrDefault(),
             ImageEntityType.Banner => images.Banners.FirstOrDefault(),

--- a/Shoko.Server/API/v3/Controllers/GroupController.cs
+++ b/Shoko.Server/API/v3/Controllers/GroupController.cs
@@ -276,7 +276,7 @@ public class GroupController(ISettingsProvider settingsProvider, IImageManager _
 
     #region Images
 
-    private const string InvalidIDForSource = "Invalid image id for selected source.";
+    private const string ImageNotFound = "The requested image does not exist.";
 
     private const string NoDefaultImageForType = "No default image for type.";
 
@@ -417,7 +417,7 @@ public class GroupController(ISettingsProvider settingsProvider, IImageManager _
     [Authorize("admin")]
     [HttpPut("{groupID}/Images/{imageType}")]
     public ActionResult<Image> SetSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int groupID,
-        [FromRoute] Image.LegacyImageType imageType, [FromBody] Image.Input.DefaultImageBody body)
+        [FromRoute] ImageEntityType imageType, [FromBody] Image.Input.DefaultImageBody body)
     {
         if (_animeGroups.GetByID(groupID) is not { } group)
             return NotFound(GroupNotFound);
@@ -426,18 +426,11 @@ public class GroupController(ISettingsProvider settingsProvider, IImageManager _
         if (!user.AllowedGroup(group))
             return Forbid(GroupForbiddenForUser);
 
-        // Check if the id is valid for the given type and source.
-        var dataSource = body.Source;
-        var imageEntityType = imageType.ToServer();
-        var image = Guid.TryParse(body.ID, out var imageID)
-            ? _imageManager.GetImageByID(imageID)
-            : int.TryParse(body.ID, out var legacyImageID)
-                ? _imageManager.GetImageByID(legacyImageID)
-                : null;
-        if (image is null || (dataSource is not DataSource.None && dataSource != image.Source))
-            return ValidationProblem(InvalidIDForSource);
+        var image = _imageManager.GetImageByID(body.ID);
+        if (image is null)
+            return NotFound(ImageNotFound);
 
-        var xref = _imageManager.SetPreferredImageForEntity(group, imageEntityType, image);
+        var xref = _imageManager.SetPreferredImageForEntity(group, imageType, image);
         return new Image(ImageStub.Wrap(image, xref));
     }
 
@@ -449,7 +442,7 @@ public class GroupController(ISettingsProvider settingsProvider, IImageManager _
     /// <returns></returns>
     [Authorize("admin")]
     [HttpDelete("{groupID}/Images/{imageType}")]
-    public ActionResult DeleteSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int groupID, [FromRoute] Image.LegacyImageType imageType)
+    public ActionResult DeleteSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int groupID, [FromRoute] ImageEntityType imageType)
     {
         if (_animeGroups.GetByID(groupID) is not { } group)
             return NotFound(GroupNotFound);
@@ -459,9 +452,8 @@ public class GroupController(ISettingsProvider settingsProvider, IImageManager _
             return Forbid(GroupForbiddenForUser);
 
         // Check if a default image is set.
-        var imageEntityType = imageType.ToServer();
         var xref = _imageManager
-            .GetImageCrossReferencesForEntity(group, new() { ImageType = imageEntityType, IsPreferred = true }).FirstOrDefault();
+            .GetImageCrossReferencesForEntity(group, new() { ImageType = imageType, IsPreferred = true }).FirstOrDefault();
         if (xref is null)
             return ValidationProblem("No default image for the selected type.");
 

--- a/Shoko.Server/API/v3/Controllers/GroupController.cs
+++ b/Shoko.Server/API/v3/Controllers/GroupController.cs
@@ -372,11 +372,11 @@ public class GroupController(ISettingsProvider settingsProvider, IImageManager _
     /// Get the default <see cref="Image"/> for the given <paramref name="imageType"/> for the <see cref="Series"/>.
     /// </summary>
     /// <param name="groupID">Shoko Group ID</param>
-    /// <param name="imageType">Poster, Banner, Fanart</param>
+    /// <param name="imageType">Primary, Backdrop, Banner, Logo, Disc</param>
     /// <returns></returns>
     [HttpGet("{groupID}/Images/{imageType}")]
     public ActionResult<Image> GetSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int groupID,
-        [FromRoute] Image.LegacyImageType imageType)
+        [FromRoute] ImageEntityType imageType)
     {
         if (_animeGroups.GetByID(groupID) is not { } group)
             return NotFound(GroupNotFound);
@@ -385,13 +385,12 @@ public class GroupController(ISettingsProvider settingsProvider, IImageManager _
         if (!user.AllowedGroup(group))
             return Forbid(GroupForbiddenForUser);
 
-        var imageEntityType = imageType.ToServer();
-        var preferredImage = ((IWithImages)group).GetPreferredImageForType(imageEntityType);
+        var preferredImage = ((IWithImages)group).GetPreferredImageForType(imageType);
         if (preferredImage is not null)
             return new Image(preferredImage);
 
-        var images = ((IWithImages)group).GetImages(new() { ImageType = imageEntityType }).ToDto();
-        var image = imageEntityType switch
+        var images = ((IWithImages)group).GetImages(new() { ImageType = imageType }).ToDto();
+        var image = imageType switch
         {
             ImageEntityType.Primary => images.Posters.FirstOrDefault(),
             ImageEntityType.Banner => images.Banners.FirstOrDefault(),

--- a/Shoko.Server/API/v3/Controllers/ImageController.cs
+++ b/Shoko.Server/API/v3/Controllers/ImageController.cs
@@ -16,7 +16,7 @@ namespace Shoko.Server.API.v3.Controllers;
 [ApiV3]
 public class ImageController(IImageManager imageManager, ISettingsProvider settingsProvider) : BaseController(settingsProvider)
 {
-    private const string ImageNotFound = "The requested resource does not exist.";
+    private const string ImageNotFound = "The requested image does not exist.";
 
     /// <summary>
     /// Returns the image for the given <paramref name="imageID"/>.

--- a/Shoko.Server/API/v3/Controllers/ImageController.cs
+++ b/Shoko.Server/API/v3/Controllers/ImageController.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Shoko.Abstractions.Metadata.Enums;
 using Shoko.Abstractions.Metadata.Services;
 using Shoko.Server.API.Annotations;
@@ -83,66 +80,26 @@ public class ImageController(IImageManager imageManager, ISettingsProvider setti
     }
 
     /// <summary>
-    /// Enable or disable an image. Disabled images are hidden unless explicitly
-    /// asked for.
-    /// </summary>
-    /// <remarks>
-    /// <b>Deprecated:</b> Use the management controller's enabled endpoint for
-    /// the image or cross-reference, preferably the cross-reference.
-    /// </remarks>
-    /// <param name="source">AniDB, TMDB, Shoko, etc.</param>
-    /// <param name="type">Poster, Backdrop, Banner, Thumbnail, etc.</param>
-    /// <param name="value">The image ID.</param>
-    /// <param name="body"></param>
-    /// <returns></returns>
-    [Authorize("admin")]
-    [HttpPost("{source}/{type}/{value}/Enabled")]
-    [Obsolete("Use the management controller's enabled endpoint for the image or cross-reference, preferably the cross-reference.")]
-    public async Task<ActionResult> EnableOrDisableLegacyImage(
-        [FromRoute] DataSource source,
-        [FromRoute] Image.LegacyImageType type,
-        [FromRoute, Range(1, int.MaxValue)] int value,
-        [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Disallow)] Image.Input.EnableImageBody body
-    )
-    {
-        var metadata = imageManager.GetImageByID(value);
-        if (metadata is null)
-            return NotFound(ImageNotFound);
-
-        // Enabled state is now tied to cross-references.
-        if (metadata.GetCrossReferences() is { Count: 0 })
-            return ValidationProblem($"Unable to enable or disable {source} {type} with id {value}!");
-
-        imageManager.EnableImage(metadata, body.Enabled);
-
-        return NoContent();
-    }
-
-    /// <summary>
     /// Returns a random image for the <paramref name="imageType"/>.
     /// </summary>
-    /// <param name="imageType">Poster, Backdrop, Banner, Thumb, Static</param>
-    /// <returns>200 on found, 400/404 if the type or source are invalid, and 404 if the id is not found</returns>
+    /// <param name="imageType">Primary, Backdrop, Banner</param>
+    /// <returns>200 on found, 400 if the type is unsupported, and 404 if no image could be found</returns>
     [HttpGet("Random/{imageType}")]
     [ProducesResponseType(typeof(FileStreamResult), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(404)]
-    [ProducesResponseType(500)]
-    public ActionResult GetRandomImageForType([FromRoute] Image.LegacyImageType imageType)
+    public ActionResult GetRandomImageForType([FromRoute] ImageEntityType imageType)
     {
-        if (imageType == Image.LegacyImageType.Avatar)
-            return ValidationProblem("Unsupported image type for random image.", "imageType");
+        if (imageType is ImageEntityType.None or ImageEntityType.Logo or ImageEntityType.Disc)
+            return ValidationProblem("Unsupported image type for random image.", nameof(imageType));
 
         var dataSource = Image.GetRandomImageSource(imageType);
-        var imageEntityType = imageType.ToServer();
-        if (imageEntityType == ImageEntityType.None)
-            return InternalError("Could not generate a valid image type to fetch.");
 
         // Try 5 times to get a valid image.
         var tries = 0;
         do
         {
-            var metadata = imageManager.GetRandomImageCrossReference(dataSource, imageEntityType, new() { IsAvailable = true })?.GetImage();
+            var metadata = imageManager.GetRandomImageCrossReference(dataSource, imageType, new() { IsAvailable = true })?.GetImage();
             if (metadata is null)
                 continue;
 
@@ -156,41 +113,38 @@ public class ImageController(IImageManager imageManager, ISettingsProvider setti
             return File(stream, metadata.ContentType);
         } while (tries++ < 5);
 
-        return InternalError("Unable to find a random image to send.");
+        return NotFound("Unable to find a random image to send.");
     }
 
     /// <summary>
     /// Returns the metadata for a random image for the <paramref name="imageType"/>.
     /// </summary>
-    /// <param name="imageType">Poster, Backdrop, Banner, Thumb</param>
+    /// <param name="imageType">Primary, Backdrop, Banner</param>
     /// <param name="includeRestricted">Include or exclude restricted images</param>
     /// <param name="seriesType">Series types to include in the search</param>
     /// <param name="maxAttempts">Maximum number of attempts to find a valid image</param>
-    /// <returns>200 on found, 400 if the type or source are invalid</returns>
+    /// <returns>200 on found, 400 if the type is unsupported, and 404 if no image could be found</returns>
     [HttpGet("Random/{imageType}/Metadata")]
     [ProducesResponseType(typeof(Image), 200)]
     [ProducesResponseType(400)]
-    [ProducesResponseType(500)]
+    [ProducesResponseType(404)]
     public ActionResult<Image> GetRandomImageMetadataForType(
-        [FromRoute] Image.LegacyImageType imageType,
+        [FromRoute] ImageEntityType imageType,
         [FromQuery] IncludeOnlyFilter includeRestricted = IncludeOnlyFilter.False,
         [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] HashSet<AnimeType>? seriesType = null,
         [FromQuery, Range(0, 100)] int maxAttempts = 5
     )
     {
-        if (imageType == Image.LegacyImageType.Avatar)
-            return ValidationProblem("Unsupported image type for random image.", "imageType");
+        if (imageType is ImageEntityType.None or ImageEntityType.Logo or ImageEntityType.Disc)
+            return ValidationProblem("Unsupported image type for random image.", nameof(imageType));
 
         var dataSource = Image.GetRandomImageSource(imageType);
-        var imageEntityType = imageType.ToServer();
-        if (imageEntityType == ImageEntityType.None)
-            return InternalError("Could not generate a valid image type to fetch.");
 
         // Try 5 times to get a valid image.
         var tries = 0;
         do
         {
-            var metadata = imageManager.GetRandomImageCrossReference(dataSource, imageEntityType, new() { IsAvailable = true })?.GetImage();
+            var metadata = imageManager.GetRandomImageCrossReference(dataSource, imageType, new() { IsAvailable = true })?.GetImage();
             if (metadata is null)
                 continue;
 
@@ -214,6 +168,6 @@ public class ImageController(IImageManager imageManager, ISettingsProvider setti
             return image;
         } while (tries++ < maxAttempts);
 
-        return InternalError("Unable to find a random image to send.");
+        return NotFound("Unable to find a random image to send.");
     }
 }

--- a/Shoko.Server/API/v3/Controllers/SeriesController.cs
+++ b/Shoko.Server/API/v3/Controllers/SeriesController.cs
@@ -2593,7 +2593,7 @@ public class SeriesController : BaseController
 
     #region Images
 
-    private const string InvalidIDForSource = "Invalid image id for selected source.";
+    private const string ImageNotFound = "The requested image does not exist.";
 
     private const string NoDefaultImageForType = "No default image for type.";
 
@@ -2739,7 +2739,7 @@ public class SeriesController : BaseController
     [Authorize("admin")]
     [HttpPut("{seriesID}/Images/{imageType}")]
     public ActionResult<Image> SetSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int seriesID,
-        [FromRoute] Image.LegacyImageType imageType, [FromBody] Image.Input.DefaultImageBody body)
+        [FromRoute] ImageEntityType imageType, [FromBody] Image.Input.DefaultImageBody body)
     {
         var series = _animeSeries.GetByID(seriesID);
         if (series == null)
@@ -2748,18 +2748,11 @@ public class SeriesController : BaseController
         if (!User.AllowedSeries(series))
             return Forbid(SeriesForbiddenForUser);
 
-        // Check if the id is valid for the given type and source.
-        var dataSource = body.Source;
-        var imageEntityType = imageType.ToServer();
-        var image = Guid.TryParse(body.ID, out var imageID)
-            ? _imageManager.GetImageByID(imageID)
-            : int.TryParse(body.ID, out var legacyImageID)
-                ? _imageManager.GetImageByID(legacyImageID)
-                : null;
-        if (image is null || (dataSource is not DataSource.None && dataSource != image.Source))
-            return ValidationProblem(InvalidIDForSource);
+        var image = _imageManager.GetImageByID(body.ID);
+        if (image is null)
+            return NotFound(ImageNotFound);
 
-        var xref = _imageManager.SetPreferredImageForEntity(series, imageEntityType, image);
+        var xref = _imageManager.SetPreferredImageForEntity(series, imageType, image);
         return new Image(ImageStub.Wrap(image, xref));
     }
 
@@ -2771,7 +2764,7 @@ public class SeriesController : BaseController
     /// <returns></returns>
     [Authorize("admin")]
     [HttpDelete("{seriesID}/Images/{imageType}")]
-    public ActionResult DeleteSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromRoute] Image.LegacyImageType imageType)
+    public ActionResult DeleteSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromRoute] ImageEntityType imageType)
     {
         // Check if the series exists and if the user can access the series.
         var series = _animeSeries.GetByID(seriesID);
@@ -2782,9 +2775,8 @@ public class SeriesController : BaseController
             return Forbid(SeriesForbiddenForUser);
 
         // Check if a default image is set.
-        var imageEntityType = imageType.ToServer();
         var xref = _imageManager
-            .GetImageCrossReferencesForEntity(series, new() { ImageType = imageEntityType, IsPreferred = true }).FirstOrDefault();
+            .GetImageCrossReferencesForEntity(series, new() { ImageType = imageType, IsPreferred = true }).FirstOrDefault();
         if (xref is null)
             return ValidationProblem("No default image for the selected type.");
 

--- a/Shoko.Server/API/v3/Controllers/SeriesController.cs
+++ b/Shoko.Server/API/v3/Controllers/SeriesController.cs
@@ -2694,11 +2694,11 @@ public class SeriesController : BaseController
     /// Get the default <see cref="Image"/> for the given <paramref name="imageType"/> for the <see cref="Series"/>.
     /// </summary>
     /// <param name="seriesID">Series ID</param>
-    /// <param name="imageType">Poster, Banner, Fanart</param>
+    /// <param name="imageType">Primary, Backdrop, Banner, Logo, Disc</param>
     /// <returns></returns>
     [HttpGet("{seriesID}/Images/{imageType}")]
     public ActionResult<Image> GetSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int seriesID,
-        [FromRoute] Image.LegacyImageType imageType)
+        [FromRoute] ImageEntityType imageType)
     {
         var series = _animeSeries.GetByID(seriesID);
         if (series == null)
@@ -2707,13 +2707,12 @@ public class SeriesController : BaseController
         if (!User.AllowedSeries(series))
             return Forbid(SeriesForbiddenForUser);
 
-        var imageEntityType = imageType.ToServer();
-        var preferredImage = ((IWithImages)series).GetPreferredImageForType(imageEntityType);
+        var preferredImage = ((IWithImages)series).GetPreferredImageForType(imageType);
         if (preferredImage is not null)
             return new Image(preferredImage);
 
-        var images = ((IWithImages)series).GetImages(new() { ImageType = imageEntityType }).ToDto();
-        var image = imageEntityType switch
+        var images = ((IWithImages)series).GetImages(new() { ImageType = imageType }).ToDto();
+        var image = imageType switch
         {
             ImageEntityType.Primary => images.Posters.FirstOrDefault(),
             ImageEntityType.Banner => images.Banners.FirstOrDefault(),

--- a/Shoko.Server/API/v3/Models/Common/Image.cs
+++ b/Shoko.Server/API/v3/Models/Common/Image.cs
@@ -5,7 +5,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Shoko.Abstractions.Metadata.Enums;
 using Shoko.Abstractions.Metadata.Image;
-using Shoko.Server.API.Converters;
 using Shoko.Server.Extensions;
 
 #pragma warning disable CS0618
@@ -296,21 +295,10 @@ public class Image
         public class DefaultImageBody
         {
             /// <summary>
-            /// The ID. A stringified int since we send the ID as a string
-            /// from the API. Also see <seealso cref="Image.ID"/>.
+            /// The image's universally/globally unique identifier (UUID/GUID).
+            /// Also see <seealso cref="Image.UID"/>.
             /// </summary>
-            /// <value></value>
-            [Required]
-            [JsonConverter(typeof(AutoStringConverter))]
-            public string ID { get; set; } = string.Empty;
-
-            /// <summary>
-            /// The image source.
-            /// </summary>
-            /// <value></value>
-            [Obsolete("No longer necessary now that image IDs are universal.")]
-            [JsonConverter(typeof(StringEnumConverter))]
-            public DataSource Source { get; set; } = DataSource.None;
+            public Guid ID { get; set; }
         }
 
         public class EnableImageBody

--- a/Shoko.Server/API/v3/Models/Common/Image.cs
+++ b/Shoko.Server/API/v3/Models/Common/Image.cs
@@ -180,13 +180,13 @@ public class Image
         DataSource.TMDB,
     ];
 
-    internal static DataSource GetRandomImageSource(LegacyImageType imageType)
+    internal static DataSource GetRandomImageSource(ImageEntityType imageType)
     {
         var sourceList = imageType switch
         {
-            LegacyImageType.Poster => _posterImageSources,
-            LegacyImageType.Banner => _bannerImageSources,
-            LegacyImageType.Backdrop => _backdropImageSources,
+            ImageEntityType.Primary => _posterImageSources,
+            ImageEntityType.Banner => _bannerImageSources,
+            ImageEntityType.Backdrop => _backdropImageSources,
             _ => [],
         };
 

--- a/Shoko.Server/API/v3/Models/Common/Image.cs
+++ b/Shoko.Server/API/v3/Models/Common/Image.cs
@@ -314,25 +314,6 @@ public class Image
 
 public static class ImageExtensions
 {
-    public static ImageEntityType ToServer(this Image.LegacyImageType type)
-        => type switch
-        {
-            Image.LegacyImageType.Primary => ImageEntityType.Primary,
-            Image.LegacyImageType.Poster => ImageEntityType.Primary,
-            Image.LegacyImageType.Character => ImageEntityType.Primary,
-            Image.LegacyImageType.Creator => ImageEntityType.Primary,
-            Image.LegacyImageType.Staff => ImageEntityType.Primary,
-            Image.LegacyImageType.Avatar => ImageEntityType.Primary,
-            Image.LegacyImageType.Banner => ImageEntityType.Banner,
-            Image.LegacyImageType.Backdrop => ImageEntityType.Backdrop,
-            Image.LegacyImageType.Thumbnail => ImageEntityType.Backdrop,
-            Image.LegacyImageType.Thumb => ImageEntityType.Backdrop,
-            Image.LegacyImageType.Fanart => ImageEntityType.Backdrop,
-            Image.LegacyImageType.Logo => ImageEntityType.Logo,
-            Image.LegacyImageType.Disc => ImageEntityType.Disc,
-            _ => ImageEntityType.None,
-        };
-
     public static Image.LegacyImageType ToLegacyDto(this ImageEntityType type)
         => type switch
         {


### PR DESCRIPTION
## Summary

Migrates the v3 image endpoints from the legacy image system (`Image.LegacyImageType`, int image IDs) to the new image system (`ImageEntityType`, GUIDs).

## Migrated endpoints

- **`SeriesController`**
  - `GET /api/v3/Series/{seriesID}/Images/{imageType}`
  - `PUT /api/v3/Series/{seriesID}/Images/{imageType}`
  - `DELETE /api/v3/Series/{seriesID}/Images/{imageType}`
- **`EpisodeController`**
  - `GET /api/v3/Episode/{episodeID}/Images/{imageType}`
  - `PUT /api/v3/Episode/{episodeID}/Images/{imageType}`
  - `DELETE /api/v3/Episode/{episodeID}/Images/{imageType}`
- **`GroupController`**
  - `GET /api/v3/Group/{groupID}/Images/{imageType}`
  - `PUT /api/v3/Group/{groupID}/Images/{imageType}`
  - `DELETE /api/v3/Group/{groupID}/Images/{imageType}`

  (route param `LegacyImageType` → `ImageEntityType`)

- **`ImageController`**
  - `GET /api/v3/Image/Random/{imageType}` and `GET /api/v3/Image/Random/{imageType}/Metadata` — `LegacyImageType` → `ImageEntityType`; now return `404` (was `500`) when no image is found
- **`Image.Input.DefaultImageBody`** — `ID` changed from `string` to `Guid`; `Source` removed (unused)

## Removed

- `POST /api/v3/Image/{source}/{type}/{value}/Enabled` (`EnableOrDisableLegacyImage`) — superseded by the image-management controller's cross-reference enable endpoint
- `ImageExtensions.ToServer()` — became dead code once the migrated endpoints stopped calling it

## Intentionally NOT migrated / removed

Kept for backwards compatibility because **Shokofin** (and the legacy **ShokoRelay.bundle** Plex plugin) still depend on them:

- `GET /api/v3/Image/{source}/{type}/{value}` (`GetLegacyImage`) — Shokofin builds image URLs as `/api/v3/Image/{Source}/{Type}/{ID}` and proxies them through its host controller
- The `Image` response DTO's legacy fields — `ID` (`int`) and `Type` (`LegacyImageType`) — Shokofin deserializes these from the `.../Images` responses

These should be removed only after Shokofin migrates to `UID` (GUID) and `ImageEntityType`.

## Breaking changes

- Legacy image type synonyms (`Poster`, `Fanart`, `Thumbnail`, `Thumb`, `Character`, `Creator`, `Staff`, `Avatar`) no longer bind as route values; only `Primary`, `Backdrop`, `Banner`, `Logo`, `Disc` remain
- `DefaultImageBody.Source` is no longer accepted
