### PR TITLE
feat(images): add paginated type-filtered images endpoint for entities

### DIFF
--- a/Shoko.Server/API/v3/Controllers/EpisodeController.cs
+++ b/Shoko.Server/API/v3/Controllers/EpisodeController.cs
@@ -771,6 +771,49 @@ public class EpisodeController : BaseController
             .ToDto(showLinkedIDs: showLinkedIDs);
     }
 
+    /// <summary>
+    /// Get a paginated list of images of the given <paramref name="imageType"/> for the episode.
+    /// </summary>
+    /// <param name="episodeID">Episode ID</param>
+    /// <param name="imageType">Primary, Backdrop, Banner, Logo, Disc</param>
+    /// <param name="showLinkedIDs">Include linked image IDs in the response.</param>
+    /// <param name="includeDisabled">Include disabled images.</param>
+    /// <param name="includeUndesired">Include undesired images.</param>
+    /// <param name="pageSize">Number of results per page (0-100, default 50).</param>
+    /// <param name="page">Page number (default 1).</param>
+    /// <returns>A paginated list of images.</returns>
+    [HttpGet("{episodeID}/Images/{imageType}")]
+    public ActionResult<ListResult<Image>> GetEpisodeImagesForType(
+        [FromRoute, Range(1, int.MaxValue)] int episodeID,
+        [FromRoute] ImageEntityType imageType,
+        [FromQuery] bool showLinkedIDs = false,
+        [FromQuery] bool includeDisabled = false,
+        [FromQuery] bool includeUndesired = false,
+        [FromQuery, Range(0, 100)] int pageSize = 50,
+        [FromQuery, Range(1, int.MaxValue)] int page = 1
+    )
+    {
+        var episode = _animeEpisodes.GetByID(episodeID);
+        if (episode == null)
+            return NotFound(EpisodeNotFoundWithEpisodeID);
+
+        var series = episode.AnimeSeries;
+        if (series is null)
+            return InternalError(EpisodeNoSeriesForEpisodeID);
+
+        if (!User.AllowedSeries(series))
+            return Forbid(EpisodeForbiddenForUser);
+
+        return ((IWithImages)episode)
+            .GetImages(new() { ImageType = imageType, IsEnabled = includeDisabled ? null : true, IsDesired = includeUndesired ? null : true })
+            .OrderBy(a => a.Source)
+            .ThenByDescending(a => a.LanguageCode is null)
+            .ThenBy(a => a.LanguageCode)
+            .ThenByDescending(a => a.CountryCode is null)
+            .ThenBy(a => a.CountryCode)
+            .ToListResult(image => new Image(image, showLinkedIDs), page, pageSize);
+    }
+
     #endregion
 
     #region Default image
@@ -835,7 +878,7 @@ public class EpisodeController : BaseController
     /// <param name="episodeID">Episode ID</param>
     /// <param name="imageType">Primary, Backdrop, Banner, Logo, Disc</param>
     /// <returns></returns>
-    [HttpGet("{episodeID}/Images/{imageType}")]
+    [HttpGet("{episodeID}/Images/{imageType}/Default")]
     public ActionResult<Image> GetEpisodeDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int episodeID,
         [FromRoute] ImageEntityType imageType)
     {
@@ -878,7 +921,7 @@ public class EpisodeController : BaseController
     /// <param name="body">The body containing the source and id used to set.</param>
     /// <returns></returns>
     [Authorize("admin")]
-    [HttpPut("{episodeID}/Images/{imageType}")]
+    [HttpPut("{episodeID}/Images/{imageType}/Default")]
     public ActionResult<Image> SetEpisodeDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int episodeID,
         [FromRoute] ImageEntityType imageType, [FromBody] Image.Input.DefaultImageBody body)
     {
@@ -908,7 +951,7 @@ public class EpisodeController : BaseController
     /// <param name="imageType">Poster, Banner, Fanart</param>
     /// <returns></returns>
     [Authorize("admin")]
-    [HttpDelete("{episodeID}/Images/{imageType}")]
+    [HttpDelete("{episodeID}/Images/{imageType}/Default")]
     public ActionResult DeleteEpisodeDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int episodeID, [FromRoute] ImageEntityType imageType)
     {
         var episode = _animeEpisodes.GetByID(episodeID);

--- a/Shoko.Server/API/v3/Controllers/GroupController.cs
+++ b/Shoko.Server/API/v3/Controllers/GroupController.cs
@@ -315,6 +315,45 @@ public class GroupController(ISettingsProvider settingsProvider, IImageManager _
             .ToDto(showLinkedIDs: showLinkedIDs);
     }
 
+    /// <summary>
+    /// Get a paginated list of images of the given <paramref name="imageType"/> for the group.
+    /// </summary>
+    /// <param name="groupID">Shoko Group ID</param>
+    /// <param name="imageType">Primary, Backdrop, Banner, Logo, Disc</param>
+    /// <param name="showLinkedIDs">Include linked image IDs in the response.</param>
+    /// <param name="includeDisabled">Include disabled images.</param>
+    /// <param name="includeUndesired">Include undesired images.</param>
+    /// <param name="pageSize">Number of results per page (0-100, default 50).</param>
+    /// <param name="page">Page number (default 1).</param>
+    /// <returns>A paginated list of images.</returns>
+    [HttpGet("{groupID}/Images/{imageType}")]
+    public ActionResult<ListResult<Image>> GetGroupImagesForType(
+        [FromRoute, Range(1, int.MaxValue)] int groupID,
+        [FromRoute] ImageEntityType imageType,
+        [FromQuery] bool showLinkedIDs = false,
+        [FromQuery] bool includeDisabled = false,
+        [FromQuery] bool includeUndesired = false,
+        [FromQuery, Range(0, 100)] int pageSize = 50,
+        [FromQuery, Range(1, int.MaxValue)] int page = 1
+    )
+    {
+        if (_animeGroups.GetByID(groupID) is not { } group)
+            return NotFound(GroupNotFound);
+
+        var user = User;
+        if (!user.AllowedGroup(group))
+            return Forbid(GroupForbiddenForUser);
+
+        return ((IWithImages)group)
+            .GetImages(new() { ImageType = imageType, IsEnabled = includeDisabled ? null : true, IsDesired = includeUndesired ? null : true })
+            .OrderBy(a => a.Source)
+            .ThenByDescending(a => a.LanguageCode is null)
+            .ThenBy(a => a.LanguageCode)
+            .ThenByDescending(a => a.CountryCode is null)
+            .ThenBy(a => a.CountryCode)
+            .ToListResult(image => new Image(image, showLinkedIDs), page, pageSize);
+    }
+
     #endregion
 
     #region Default image
@@ -374,7 +413,7 @@ public class GroupController(ISettingsProvider settingsProvider, IImageManager _
     /// <param name="groupID">Shoko Group ID</param>
     /// <param name="imageType">Primary, Backdrop, Banner, Logo, Disc</param>
     /// <returns></returns>
-    [HttpGet("{groupID}/Images/{imageType}")]
+    [HttpGet("{groupID}/Images/{imageType}/Default")]
     public ActionResult<Image> GetSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int groupID,
         [FromRoute] ImageEntityType imageType)
     {
@@ -414,7 +453,7 @@ public class GroupController(ISettingsProvider settingsProvider, IImageManager _
     /// <param name="body">The body containing the source and id used to set.</param>
     /// <returns></returns>
     [Authorize("admin")]
-    [HttpPut("{groupID}/Images/{imageType}")]
+    [HttpPut("{groupID}/Images/{imageType}/Default")]
     public ActionResult<Image> SetSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int groupID,
         [FromRoute] ImageEntityType imageType, [FromBody] Image.Input.DefaultImageBody body)
     {
@@ -440,7 +479,7 @@ public class GroupController(ISettingsProvider settingsProvider, IImageManager _
     /// <param name="imageType">Poster, Banner, Fanart</param>
     /// <returns></returns>
     [Authorize("admin")]
-    [HttpDelete("{groupID}/Images/{imageType}")]
+    [HttpDelete("{groupID}/Images/{imageType}/Default")]
     public ActionResult DeleteSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int groupID, [FromRoute] ImageEntityType imageType)
     {
         if (_animeGroups.GetByID(groupID) is not { } group)

--- a/Shoko.Server/API/v3/Controllers/SeriesController.cs
+++ b/Shoko.Server/API/v3/Controllers/SeriesController.cs
@@ -2636,6 +2636,45 @@ public class SeriesController : BaseController
             .ToDto(showLinkedIDs: showLinkedIDs);
     }
 
+    /// <summary>
+    /// Get a paginated list of images of the given <paramref name="imageType"/> for the series.
+    /// </summary>
+    /// <param name="seriesID">Shoko ID</param>
+    /// <param name="imageType">Primary, Backdrop, Banner, Logo, Disc</param>
+    /// <param name="showLinkedIDs">Include linked image IDs in the response.</param>
+    /// <param name="includeDisabled">Include disabled images.</param>
+    /// <param name="includeUndesired">Include undesired images.</param>
+    /// <param name="pageSize">Number of results per page (0-100, default 50).</param>
+    /// <param name="page">Page number (default 1).</param>
+    /// <returns>A paginated list of images.</returns>
+    [HttpGet("{seriesID}/Images/{imageType}")]
+    public ActionResult<ListResult<Image>> GetSeriesImagesForType(
+        [FromRoute, Range(1, int.MaxValue)] int seriesID,
+        [FromRoute] ImageEntityType imageType,
+        [FromQuery] bool showLinkedIDs = false,
+        [FromQuery] bool includeDisabled = false,
+        [FromQuery] bool includeUndesired = false,
+        [FromQuery, Range(0, 100)] int pageSize = 50,
+        [FromQuery, Range(1, int.MaxValue)] int page = 1
+    )
+    {
+        var series = _animeSeries.GetByID(seriesID);
+        if (series == null)
+            return NotFound(SeriesNotFoundWithSeriesID);
+
+        if (!User.AllowedSeries(series))
+            return Forbid(SeriesForbiddenForUser);
+
+        return ((IWithImages)series)
+            .GetImages(new() { ImageType = imageType, IsEnabled = includeDisabled ? null : true, IsDesired = includeUndesired ? null : true })
+            .OrderBy(a => a.Source)
+            .ThenByDescending(a => a.LanguageCode is null)
+            .ThenBy(a => a.LanguageCode)
+            .ThenByDescending(a => a.CountryCode is null)
+            .ThenBy(a => a.CountryCode)
+            .ToListResult(image => new Image(image, showLinkedIDs), page, pageSize);
+    }
+
     #endregion
 
     #region Default image
@@ -2696,7 +2735,7 @@ public class SeriesController : BaseController
     /// <param name="seriesID">Series ID</param>
     /// <param name="imageType">Primary, Backdrop, Banner, Logo, Disc</param>
     /// <returns></returns>
-    [HttpGet("{seriesID}/Images/{imageType}")]
+    [HttpGet("{seriesID}/Images/{imageType}/Default")]
     public ActionResult<Image> GetSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromRoute] ImageEntityType imageType)
     {
@@ -2736,7 +2775,7 @@ public class SeriesController : BaseController
     /// <param name="body">The body containing the source and id used to set.</param>
     /// <returns></returns>
     [Authorize("admin")]
-    [HttpPut("{seriesID}/Images/{imageType}")]
+    [HttpPut("{seriesID}/Images/{imageType}/Default")]
     public ActionResult<Image> SetSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int seriesID,
         [FromRoute] ImageEntityType imageType, [FromBody] Image.Input.DefaultImageBody body)
     {
@@ -2762,7 +2801,7 @@ public class SeriesController : BaseController
     /// <param name="imageType">Poster, Banner, Fanart</param>
     /// <returns></returns>
     [Authorize("admin")]
-    [HttpDelete("{seriesID}/Images/{imageType}")]
+    [HttpDelete("{seriesID}/Images/{imageType}/Default")]
     public ActionResult DeleteSeriesDefaultImageForType([FromRoute, Range(1, int.MaxValue)] int seriesID, [FromRoute] ImageEntityType imageType)
     {
         // Check if the series exists and if the user can access the series.


### PR DESCRIPTION
## Problem

The Web UI lists a series' images using `GET /Image/Management/CrossReference/Entity/Shoko/Series/{id}`. Because `linkedEntityImages` defaults to `true` for series, that endpoint returns cross-references for the series **and** its linked TMDB shows, seasons, and movies — so the same physical image can appear more than once as separate rows.

When a user pins one of those *linked* images as the default via `PUT /Series/{id}/Images/{imageType}`, `SetPreferredImageForEntity` creates a **new** direct cross-reference for the series (because no direct xref existed for that image ID). The UI then shows the same image twice: once as the linked xref and once as the new direct xref.

There was no endpoint that returned the *deduplicated images* for a series with pagination and a type filter:

- `GET /Series/{id}/Images` returns deduplicated images grouped into an `Images` DTO, but has no type filter and no pagination.
- `GET /Image/Management/CrossReference/Entity/...` has pagination and a type filter, but returns raw cross-references (no dedup) and includes linked entities by default.

## Change

Add `GET /{id}/Images/{imageType}` for series, groups, and episodes. It returns a paginated, deduplicated `ListResult<Image>` for a single image type, reusing `GetImagesForEntity`'s existing `DistinctBy((image.ID, imageType))` dedup — so a pinned linked image collapses to a single direct entry instead of a duplicate.

The new endpoint mirrors the existing `GET /{id}/Images` filtering (`includeDisabled`, `includeUndesired`) and ordering, and adds `page`/`pageSize` pagination.

To free up the `/{imageType}` route segment, the default-image endpoints were relocated to a `/Default` suffix:

| Verb | Before | After |
|------|--------|-------|
| GET  | `/{id}/Images/{imageType}` | `/{id}/Images/{imageType}/Default` |
| PUT  | `/{id}/Images/{imageType}` | `/{id}/Images/{imageType}/Default` |
| DELETE | `/{id}/Images/{imageType}` | `/{id}/Images/{imageType}/Default` |

## Breaking change

The default-image routes moved. Any client that gets, sets, or unsets a default image must switch from `/{id}/Images/{imageType}` to `/{id}/Images/{imageType}/Default`.

## Scope

- `SeriesController` — added `GetSeriesImagesForType`, relocated 3 default-image routes
- `GroupController` — added `GetGroupImagesForType`, relocated 3 default-image routes
- `EpisodeController` — added `GetEpisodeImagesForType`, relocated 3 default-image routes
