### PR TITLE
feat: add plugin-registrable action system (RFC #1380)

### DIFF
--- a/Shoko.Abstractions/Actions/ActionCategory.cs
+++ b/Shoko.Abstractions/Actions/ActionCategory.cs
@@ -1,0 +1,68 @@
+using System.Text.Json.Serialization;
+using Newtonsoft.Json.Converters;
+
+namespace Shoko.Abstractions.Actions;
+
+/// <summary>
+///   The category of an executable action. Categories group related actions
+///   together in the UI and can be used to filter the action list.
+/// </summary>
+/// <remarks>
+///   This is a closed, core-owned enum — a plugin cannot invent a new
+///   core-owned category at runtime; adding one requires a PR against core.
+///   <see cref="Miscellaneous"/> is the shared fallback for any action that
+///   declares no category. <see cref="PluginInferred"/> is an explicit opt-in
+///   a plugin uses to request its own dedicated group; its display label is
+///   always the owning plugin's own name.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+[Newtonsoft.Json.JsonConverter(typeof(StringEnumConverter))]
+public enum ActionCategory : byte
+{
+    /// <summary>
+    ///   File import and scanning actions.
+    /// </summary>
+    Import = 0x01,
+
+    /// <summary>
+    ///   AniDB metadata and synchronization actions.
+    /// </summary>
+    AniDB = 0x21,
+
+    /// <summary>
+    ///   TMDB metadata and synchronization actions.
+    /// </summary>
+    TMDB = 0x22,
+
+    /// <summary>
+    ///   Data synchronization actions across providers.
+    /// </summary>
+    Sync = 0x31,
+
+    /// <summary>
+    ///   Image download and management actions.
+    /// </summary>
+    Images = 0x71,
+
+    /// <summary>
+    ///   System maintenance actions.
+    /// </summary>
+    Maintenance = 0xF1,
+
+    /// <summary>
+    ///   The shared fallback category for any action — core or plugin — that
+    ///   declares no category.
+    /// </summary>
+    Miscellaneous = 0xF2,
+
+    /// <summary>
+    ///   Destructive operations such as purging data.
+    /// </summary>
+    Destructive = 0xFE,
+
+    /// <summary>
+    ///   An explicit opt-in a plugin uses to request its own dedicated group.
+    ///   The display label is always the owning plugin's own name.
+    /// </summary>
+    PluginInferred = 0xFF,
+}

--- a/Shoko.Abstractions/Actions/ActionPermission.cs
+++ b/Shoko.Abstractions/Actions/ActionPermission.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+using Newtonsoft.Json.Converters;
+
+namespace Shoko.Abstractions.Actions;
+
+/// <summary>
+///   The permission required to invoke an executable action. Orthogonal to
+///   <see cref="ActionScope"/> — an action of any scope may require either
+///   permission level.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+[Newtonsoft.Json.JsonConverter(typeof(StringEnumConverter))]
+public enum ActionPermission
+{
+    /// <summary>
+    ///   Only administrators may invoke the action.
+    /// </summary>
+    Admin,
+
+    /// <summary>
+    ///   Any authenticated user may invoke the action.
+    /// </summary>
+    User,
+}

--- a/Shoko.Abstractions/Actions/ActionScope.cs
+++ b/Shoko.Abstractions/Actions/ActionScope.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+using Newtonsoft.Json.Converters;
+
+namespace Shoko.Abstractions.Actions;
+
+/// <summary>
+///   The entity level an executable action is bound to.
+/// </summary>
+/// <remarks>
+///   <para>
+///     Global actions implement <see cref="IExecutableAction"/> directly.
+///     Scoped actions derive from one of the three base classes
+///     (<see cref="SeriesAction"/>, <see cref="GroupAction"/>,
+///     <see cref="EpisodeAction"/>), which fix the scope at compile time.
+///   </para>
+///   <para>
+///     Actions available for a given scope do not vary by <em>which</em>
+///     series/group/episode is being viewed, only by which entity type it is,
+///     so listings are scope-filtered, not entity-filtered.
+///   </para>
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+[Newtonsoft.Json.JsonConverter(typeof(StringEnumConverter))]
+public enum ActionScope
+{
+    /// <summary>
+    ///   The action is not tied to a particular entity.
+    /// </summary>
+    Global,
+
+    /// <summary>
+    ///   The action operates on a group.
+    /// </summary>
+    Group,
+
+    /// <summary>
+    ///   The action operates on a series.
+    /// </summary>
+    Series,
+
+    /// <summary>
+    ///   The action operates on an episode.
+    /// </summary>
+    Episode,
+}

--- a/Shoko.Abstractions/Actions/ActionValidationResult.cs
+++ b/Shoko.Abstractions/Actions/ActionValidationResult.cs
@@ -1,0 +1,11 @@
+namespace Shoko.Abstractions.Actions;
+
+/// <summary>
+///   The result of a failed <see cref="IExecutableAction.Validate"/> call.
+///   Returned by actions to reject an invocation before it is enqueued; the
+///   API maps it to a 400 response with <see cref="Reason"/> as the message.
+/// </summary>
+/// <param name="Reason">
+///   The reason the invocation was rejected.
+/// </param>
+public sealed record ActionValidationResult(string Reason);

--- a/Shoko.Abstractions/Actions/EpisodeAction.cs
+++ b/Shoko.Abstractions/Actions/EpisodeAction.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Metadata.Shoko;
+
+namespace Shoko.Abstractions.Actions;
+
+/// <summary>
+///   Base class for episode-scoped executable actions. Derive from this
+///   (rather than implementing <see cref="IExecutableAction"/> directly) to
+///   register an <see cref="ActionScope.Episode"/> action; the framework
+///   populates <see cref="Episode"/> before <see cref="Execute"/> runs.
+/// </summary>
+public abstract class EpisodeAction : IExecutableAction, IScopedAction
+{
+    /// <summary>
+    ///   The scope of the action.
+    /// </summary>
+    public ActionScope Scope => ActionScope.Episode;
+
+    /// <summary>
+    ///   The episode the action operates on. Non-null by the time
+    ///   <see cref="Execute"/> runs — populated by the framework via
+    ///   <see cref="IScopedAction.SetContext"/>.
+    /// </summary>
+    protected IShokoEpisode Episode { get; private set; } = null!;
+
+    void IScopedAction.SetContext(object context)
+        => Episode = (IShokoEpisode)context;
+
+    /// <inheritdoc cref="IExecutableAction.Name"/>
+    public abstract string Name { get; }
+
+    /// <inheritdoc cref="IExecutableAction.Permission"/>
+    public abstract ActionPermission Permission { get; }
+
+    /// <inheritdoc cref="IExecutableAction.Execute"/>
+    public abstract Task Execute(CancellationToken token = default);
+}

--- a/Shoko.Abstractions/Actions/ExecutableActionInfo.cs
+++ b/Shoko.Abstractions/Actions/ExecutableActionInfo.cs
@@ -1,25 +1,15 @@
 using System;
-using Shoko.Abstractions.Actions;
 
-namespace Shoko.Server.Services;
+namespace Shoko.Abstractions.Actions;
 
 /// <summary>
-///   Metadata for a registered executable action, cached at registration time
-///   in <see cref="ActionService.AddParts"/> so listings never need to
-///   resolve an instance.
+///   Metadata for a registered executable action, as exposed to plugins for
+///   listing and invocation. The concrete action type stays internal to the
+///   server; plugins work with this metadata and the action's ID only.
 /// </summary>
 /// <param name="Id">
 ///   The action's stable UUIDv5 identifier, derived from the action type's
 ///   fully-qualified name namespaced by the owning plugin's ID.
-/// </param>
-/// <param name="ActionType">
-///   The concrete action type, resolved transiently from DI per execution.
-/// </param>
-/// <param name="Scope">
-///   The entity level the action is bound to.
-/// </param>
-/// <param name="PluginId">
-///   The ID of the plugin that owns the action.
 /// </param>
 /// <param name="Name">
 ///   The action's display name.
@@ -35,21 +25,26 @@ namespace Shoko.Server.Services;
 ///   for <see cref="ActionCategory.PluginInferred"/>, otherwise the
 ///   category's own name.
 /// </param>
+/// <param name="Scope">
+///   The entity level the action is bound to.
+/// </param>
 /// <param name="Permission">
 ///   The permission required to invoke the action.
 /// </param>
 /// <param name="RequiresConfirmation">
 ///   UI hint for destructive actions.
 /// </param>
-public record ExecutableActionInfo(
+/// <param name="PluginId">
+///   The ID of the plugin that owns the action.
+/// </param>
+public sealed record ExecutableActionInfo(
     Guid Id,
-    Type ActionType,
-    ActionScope Scope,
-    Guid PluginId,
     string Name,
     string? Description,
     ActionCategory Category,
     string CategoryName,
+    ActionScope Scope,
     ActionPermission Permission,
-    bool RequiresConfirmation
+    bool RequiresConfirmation,
+    Guid PluginId
 );

--- a/Shoko.Abstractions/Actions/GroupAction.cs
+++ b/Shoko.Abstractions/Actions/GroupAction.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Metadata.Shoko;
+
+namespace Shoko.Abstractions.Actions;
+
+/// <summary>
+///   Base class for group-scoped executable actions. Derive from this (rather
+///   than implementing <see cref="IExecutableAction"/> directly) to register a
+///   <see cref="ActionScope.Group"/> action; the framework populates
+///   <see cref="Group"/> before <see cref="Execute"/> runs.
+/// </summary>
+public abstract class GroupAction : IExecutableAction, IScopedAction
+{
+    /// <summary>
+    ///   The scope of the action.
+    /// </summary>
+    public ActionScope Scope => ActionScope.Group;
+
+    /// <summary>
+    ///   The group the action operates on. Non-null by the time
+    ///   <see cref="Execute"/> runs — populated by the framework via
+    ///   <see cref="IScopedAction.SetContext"/>.
+    /// </summary>
+    protected IShokoGroup Group { get; private set; } = null!;
+
+    void IScopedAction.SetContext(object context)
+        => Group = (IShokoGroup)context;
+
+    /// <inheritdoc cref="IExecutableAction.Name"/>
+    public abstract string Name { get; }
+
+    /// <inheritdoc cref="IExecutableAction.Permission"/>
+    public abstract ActionPermission Permission { get; }
+
+    /// <inheritdoc cref="IExecutableAction.Execute"/>
+    public abstract Task Execute(CancellationToken token = default);
+}

--- a/Shoko.Abstractions/Actions/IActionCaller.cs
+++ b/Shoko.Abstractions/Actions/IActionCaller.cs
@@ -1,0 +1,32 @@
+using Shoko.Abstractions.User;
+
+namespace Shoko.Abstractions.Actions;
+
+/// <summary>
+///   Opt-in marker interface for actions that want to know which user invoked
+///   them.
+/// </summary>
+/// <remarks>
+///   <para>
+///     Distinct from <see cref="ActionScope"/>'s entity context. Any action,
+///     of any scope, may implement this.
+///   </para>
+///   <para>
+///     Unlike <see cref="IScopedAction"/>, this interface is not internal:
+///     there is no equivalent bypass concern, since a wrong or missing caller
+///     just means the action does not know who invoked it, not a security
+///     boundary.
+///   </para>
+/// </remarks>
+public interface IActionCaller
+{
+    /// <summary>
+    ///   Sets the calling user. Called by the framework only, before
+    ///   <see cref="IExecutableAction.Validate"/> and
+    ///   <see cref="IExecutableAction.Execute"/>.
+    /// </summary>
+    /// <param name="caller">
+    ///   The user that invoked the action.
+    /// </param>
+    void SetCaller(IUser caller);
+}

--- a/Shoko.Abstractions/Actions/IExecutableAction.cs
+++ b/Shoko.Abstractions/Actions/IExecutableAction.cs
@@ -1,0 +1,98 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shoko.Abstractions.Actions;
+
+/// <summary>
+///   A discrete, invokable unit of work that can be registered by core or a
+///   plugin, listed through the API, and executed through the job queue.
+/// </summary>
+/// <remarks>
+///   <para>
+///     Each action's stable identifier is a UUIDv5 deterministically derived
+///     from the action class's fully-qualified name using the owning plugin's
+///     ID as the UUIDv5 namespace.
+///   </para>
+///   <para>
+///     <strong>This ID is not stable across class renames or namespace
+///     moves.</strong> If a plugin author renames or moves the implementing
+///     class, the derived UUID will change. This is by design — deriving from
+///     namespace + class name + plugin ID makes accidental collisions between
+///     unrelated plugins extremely unlikely without requiring an explicit,
+///     collision-managed key field.
+///   </para>
+///   <para>
+///     Every action is always executed through the job queue, so progress and
+///     status are visible. Concurrency is handled by the queue system itself;
+///     there is no per-action opt-in flag.
+///   </para>
+/// </remarks>
+public interface IExecutableAction
+{
+    /// <summary>
+    ///   The display name of the action.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    ///   The description of the action.
+    /// </summary>
+    string? Description => null;
+
+    /// <summary>
+    ///   The category of the action. Defaults to
+    ///   <see cref="ActionCategory.Miscellaneous"/>, the shared fallback
+    ///   category for any action that declares none.
+    /// </summary>
+    ActionCategory Category => ActionCategory.Miscellaneous;
+
+    /// <summary>
+    ///   The permission required to invoke the action.
+    /// </summary>
+    /// <remarks>
+    ///   There is deliberately no default implementation — every action must
+    ///   state its permission explicitly. <see cref="ActionService.AddParts"/>
+    ///   rejects any action type that does not declare it on the type itself.
+    /// </remarks>
+    ActionPermission Permission { get; }
+
+    /// <summary>
+    ///   UI hint for destructive actions. The server does not enforce a
+    ///   confirmation step; the WebUI is expected to prompt before invoking
+    ///   the action when this is <see langword="true"/>.
+    /// </summary>
+    bool RequiresConfirmation => false;
+
+    /// <summary>
+    ///   Optional synchronous pre-check, run by the API before the action is
+    ///   enqueued. Return a non-null result to reject the invocation
+    ///   immediately (e.g. HTTP 400) without ever touching the queue.
+    ///   Default: always allowed.
+    /// </summary>
+    /// <param name="token">
+    ///   The cancellation token bound to the current API request.
+    /// </param>
+    /// <returns>
+    ///   A rejection reason, or <see langword="null"/> to allow the
+    ///   invocation.
+    /// </returns>
+    Task<ActionValidationResult?> Validate(CancellationToken token = default)
+        => Task.FromResult<ActionValidationResult?>(null);
+
+    /// <summary>
+    ///   Execute the action.
+    /// </summary>
+    /// <remarks>
+    ///   The action instance is resolved fresh from DI (transient) for every
+    ///   execution; statefulness is the implementation's own responsibility.
+    ///   Exceptions are caught by the worker and logged as a queue job
+    ///   failure. There is no result-reporting hook — actions that want to
+    ///   report something log, same as the rest of the queue already does.
+    /// </remarks>
+    /// <param name="token">
+    ///   The cancellation token, bound to the queue job lifecycle rather than
+    ///   the invoking request — there is no live HTTP request left by the
+    ///   time a queued action runs.
+    /// </param>
+    Task Execute(CancellationToken token = default);
+}

--- a/Shoko.Abstractions/Actions/IExecutableAction.cs
+++ b/Shoko.Abstractions/Actions/IExecutableAction.cs
@@ -51,8 +51,8 @@ public interface IExecutableAction
     /// </summary>
     /// <remarks>
     ///   There is deliberately no default implementation — every action must
-    ///   state its permission explicitly. <see cref="ActionService.AddParts"/>
-    ///   rejects any action type that does not declare it on the type itself.
+    ///   state its permission explicitly. The action registry rejects at load
+    ///   time any action type that does not declare it on the type itself.
     /// </remarks>
     ActionPermission Permission { get; }
 

--- a/Shoko.Abstractions/Actions/IExecutableAction.cs
+++ b/Shoko.Abstractions/Actions/IExecutableAction.cs
@@ -87,7 +87,7 @@ public interface IExecutableAction
     ///   execution; statefulness is the implementation's own responsibility.
     ///   Exceptions are caught by the worker and logged as a queue job
     ///   failure. There is no result-reporting hook — actions that want to
-    ///   report something log, same as the rest of the queue already does.
+    ///   report something log it, same as the rest of the queue already does.
     /// </remarks>
     /// <param name="token">
     ///   The cancellation token, bound to the queue job lifecycle rather than

--- a/Shoko.Abstractions/Actions/IScopedAction.cs
+++ b/Shoko.Abstractions/Actions/IScopedAction.cs
@@ -1,0 +1,24 @@
+namespace Shoko.Abstractions.Actions;
+
+/// <summary>
+///   Marks a scoped action. Implemented exclusively by the three scoped base
+///   classes (<see cref="SeriesAction"/>, <see cref="GroupAction"/>,
+///   <see cref="EpisodeAction"/>).
+/// </summary>
+/// <remarks>
+///   This interface is <see langword="internal"/> to this assembly so a
+///   plugin cannot implement it directly and bypass the three base classes.
+///   Only the base classes in this assembly may implement it.
+/// </remarks>
+internal interface IScopedAction
+{
+    /// <summary>
+    ///   Sets the entity context. Called by the framework only, before
+    ///   <see cref="IExecutableAction.Validate"/> and
+    ///   <see cref="IExecutableAction.Execute"/>.
+    /// </summary>
+    /// <param name="context">
+    ///   The entity the action will operate on.
+    /// </param>
+    void SetContext(object context);
+}

--- a/Shoko.Abstractions/Actions/SeriesAction.cs
+++ b/Shoko.Abstractions/Actions/SeriesAction.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Metadata.Shoko;
+
+namespace Shoko.Abstractions.Actions;
+
+/// <summary>
+///   Base class for series-scoped executable actions. Derive from this (rather
+///   than implementing <see cref="IExecutableAction"/> directly) to register a
+///   <see cref="ActionScope.Series"/> action; the framework populates
+///   <see cref="Series"/> before <see cref="Execute"/> runs.
+/// </summary>
+public abstract class SeriesAction : IExecutableAction, IScopedAction
+{
+    /// <summary>
+    ///   The scope of the action.
+    /// </summary>
+    public ActionScope Scope => ActionScope.Series;
+
+    /// <summary>
+    ///   The series the action operates on. Non-null by the time
+    ///   <see cref="Execute"/> runs — populated by the framework via
+    ///   <see cref="IScopedAction.SetContext"/>.
+    /// </summary>
+    protected IShokoSeries Series { get; private set; } = null!;
+
+    void IScopedAction.SetContext(object context)
+        => Series = (IShokoSeries)context;
+
+    /// <inheritdoc cref="IExecutableAction.Name"/>
+    public abstract string Name { get; }
+
+    /// <inheritdoc cref="IExecutableAction.Permission"/>
+    public abstract ActionPermission Permission { get; }
+
+    /// <inheritdoc cref="IExecutableAction.Execute"/>
+    public abstract Task Execute(CancellationToken token = default);
+}

--- a/Shoko.Abstractions/Actions/Services/IActionService.cs
+++ b/Shoko.Abstractions/Actions/Services/IActionService.cs
@@ -32,6 +32,10 @@ namespace Shoko.Abstractions.Actions.Services;
 ///     that implement <see cref="IActionCaller"/> require a non-null caller
 ///     and are rejected otherwise.
 ///   </para>
+///   <para>
+///     Invoking an action ID that is not registered throws
+///     <see cref="KeyNotFoundException"/>.
+///   </para>
 /// </remarks>
 public interface IActionService
 {
@@ -52,20 +56,81 @@ public interface IActionService
     /// <summary>
     ///   Invoke a global action by its ID.
     /// </summary>
+    /// <param name="actionId">Action ID.</param>
+    /// <param name="caller">The invoking user, or <see langword="null"/> for a trusted programmatic call.</param>
+    /// <param name="token">Cancellation token.</param>
     Task<ActionValidationResult?> InvokeAsync(Guid actionId, IUser? caller = null, CancellationToken token = default);
+
+    /// <summary>
+    ///   Invoke a global action by its ID with free-form invocation parameters.
+    /// </summary>
+    /// <param name="actionId">Action ID.</param>
+    /// <param name="parameters">
+    ///   The action's free-form invocation parameters. Each entry is populated
+    ///   onto the matching public settable property of a fresh action instance
+    ///   before it executes — the same way queue job properties are populated
+    ///   from <c>JobDataJson</c>. Supported values are booleans, numbers, and
+    ///   string lists; no nested objects. Entries with no matching property
+    ///   are ignored.
+    /// </param>
+    /// <param name="caller">The invoking user, or <see langword="null"/> for a trusted programmatic call.</param>
+    /// <param name="token">Cancellation token.</param>
+    Task<ActionValidationResult?> InvokeAsync(Guid actionId, IReadOnlyDictionary<string, object?> parameters, IUser? caller = null, CancellationToken token = default);
 
     /// <summary>
     ///   Invoke a group-scoped action by its ID.
     /// </summary>
+    /// <param name="actionId">Action ID.</param>
+    /// <param name="group">The group to scope the action to.</param>
+    /// <param name="caller">The invoking user, or <see langword="null"/> for a trusted programmatic call.</param>
+    /// <param name="token">Cancellation token.</param>
     Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoGroup group, IUser? caller = null, CancellationToken token = default);
+
+    /// <summary>
+    ///   Invoke a group-scoped action by its ID with free-form invocation parameters.
+    /// </summary>
+    /// <param name="actionId">Action ID.</param>
+    /// <param name="group">The group to scope the action to.</param>
+    /// <param name="parameters">The action's free-form invocation parameters. See the global overload for details.</param>
+    /// <param name="caller">The invoking user, or <see langword="null"/> for a trusted programmatic call.</param>
+    /// <param name="token">Cancellation token.</param>
+    Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoGroup group, IReadOnlyDictionary<string, object?> parameters, IUser? caller = null, CancellationToken token = default);
 
     /// <summary>
     ///   Invoke a series-scoped action by its ID.
     /// </summary>
+    /// <param name="actionId">Action ID.</param>
+    /// <param name="series">The series to scope the action to.</param>
+    /// <param name="caller">The invoking user, or <see langword="null"/> for a trusted programmatic call.</param>
+    /// <param name="token">Cancellation token.</param>
     Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoSeries series, IUser? caller = null, CancellationToken token = default);
+
+    /// <summary>
+    ///   Invoke a series-scoped action by its ID with free-form invocation parameters.
+    /// </summary>
+    /// <param name="actionId">Action ID.</param>
+    /// <param name="series">The series to scope the action to.</param>
+    /// <param name="parameters">The action's free-form invocation parameters. See the global overload for details.</param>
+    /// <param name="caller">The invoking user, or <see langword="null"/> for a trusted programmatic call.</param>
+    /// <param name="token">Cancellation token.</param>
+    Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoSeries series, IReadOnlyDictionary<string, object?> parameters, IUser? caller = null, CancellationToken token = default);
 
     /// <summary>
     ///   Invoke an episode-scoped action by its ID.
     /// </summary>
+    /// <param name="actionId">Action ID.</param>
+    /// <param name="episode">The episode to scope the action to.</param>
+    /// <param name="caller">The invoking user, or <see langword="null"/> for a trusted programmatic call.</param>
+    /// <param name="token">Cancellation token.</param>
     Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoEpisode episode, IUser? caller = null, CancellationToken token = default);
+
+    /// <summary>
+    ///   Invoke an episode-scoped action by its ID with free-form invocation parameters.
+    /// </summary>
+    /// <param name="actionId">Action ID.</param>
+    /// <param name="episode">The episode to scope the action to.</param>
+    /// <param name="parameters">The action's free-form invocation parameters. See the global overload for details.</param>
+    /// <param name="caller">The invoking user, or <see langword="null"/> for a trusted programmatic call.</param>
+    /// <param name="token">Cancellation token.</param>
+    Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoEpisode episode, IReadOnlyDictionary<string, object?> parameters, IUser? caller = null, CancellationToken token = default);
 }

--- a/Shoko.Abstractions/Actions/Services/IActionService.cs
+++ b/Shoko.Abstractions/Actions/Services/IActionService.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Metadata.Shoko;
+using Shoko.Abstractions.User;
+
+namespace Shoko.Abstractions.Actions.Services;
+
+/// <summary>
+///   Plugin-facing service for listing and invoking registered executable
+///   actions.
+/// </summary>
+/// <remarks>
+///   <para>
+///     Actions are registered by implementing <see cref="IExecutableAction"/>
+///     (or one of the scoped base classes) in the plugin assembly — they are
+///     discovered and validated at plugin load. This service is how plugins
+///     enumerate them and invoke them programmatically.
+///   </para>
+///   <para>
+///     Invocation always goes through the job queue; <see cref="InvokeAsync(System.Guid,Shoko.Abstractions.User.IUser,System.Threading.CancellationToken)"/>
+///     and its overloads return <see langword="null"/> when the action was
+///     accepted and enqueued, or a rejection reason when it was refused
+///     without touching the queue (validation failure, permission denial, or
+///     scope mismatch).
+///   </para>
+///   <para>
+///     When <paramref name="caller"/> is <see langword="null"/>, the call is
+///     treated as a trusted programmatic invocation: the
+///     <see cref="IExecutableAction.Permission"/> check is skipped. Actions
+///     that implement <see cref="IActionCaller"/> require a non-null caller
+///     and are rejected otherwise.
+///   </para>
+/// </remarks>
+public interface IActionService
+{
+    /// <summary>
+    ///   Lists registered actions. <paramref name="scope"/> is a filter, not a
+    ///   required partition — omitting it lists every action. When
+    ///   <paramref name="callerPermission"/> is
+    ///   <see cref="ActionPermission.User"/>, only actions invokable by a
+    ///   regular user are returned.
+    /// </summary>
+    IReadOnlyList<ExecutableActionInfo> GetActions(ActionScope? scope = null, ActionPermission? callerPermission = null);
+
+    /// <summary>
+    ///   Gets the metadata for a registered action by its ID.
+    /// </summary>
+    ExecutableActionInfo? GetActionInfo(Guid actionId);
+
+    /// <summary>
+    ///   Invoke a global action by its ID.
+    /// </summary>
+    Task<ActionValidationResult?> InvokeAsync(Guid actionId, IUser? caller = null, CancellationToken token = default);
+
+    /// <summary>
+    ///   Invoke a group-scoped action by its ID.
+    /// </summary>
+    Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoGroup group, IUser? caller = null, CancellationToken token = default);
+
+    /// <summary>
+    ///   Invoke a series-scoped action by its ID.
+    /// </summary>
+    Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoSeries series, IUser? caller = null, CancellationToken token = default);
+
+    /// <summary>
+    ///   Invoke an episode-scoped action by its ID.
+    /// </summary>
+    Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoEpisode episode, IUser? caller = null, CancellationToken token = default);
+}

--- a/Shoko.Abstractions/Actions/Services/IActionService.cs
+++ b/Shoko.Abstractions/Actions/Services/IActionService.cs
@@ -26,7 +26,7 @@ namespace Shoko.Abstractions.Actions.Services;
 ///     scope mismatch).
 ///   </para>
 ///   <para>
-///     When <paramref name="caller"/> is <see langword="null"/>, the call is
+///     When <c>caller</c> is <see langword="null"/>, the call is
 ///     treated as a trusted programmatic invocation: the
 ///     <see cref="IExecutableAction.Permission"/> check is skipped. Actions
 ///     that implement <see cref="IActionCaller"/> require a non-null caller

--- a/Shoko.Abstractions/Shoko.Abstractions.csproj
+++ b/Shoko.Abstractions/Shoko.Abstractions.csproj
@@ -25,6 +25,10 @@
     </ItemGroup>
 
     <ItemGroup>
+      <InternalsVisibleTo Include="Shoko.Server" />
+    </ItemGroup>
+
+    <ItemGroup>
       <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 

--- a/Shoko.Server/API/v3/Controllers/ActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/ActionController.cs
@@ -103,7 +103,7 @@ public class ActionController : BaseController
         if (_actionService.GetActionInfo(actionId) is null)
             return NotFound("Action not found.");
 
-        var validation = await _actionService.InvokeAsync(actionId, scopeEntity: null, User, token);
+        var validation = await _actionService.InvokeAsync(actionId, User, token);
         return validation is null ? Ok() : BadRequest(validation.Reason);
     }
 

--- a/Shoko.Server/API/v3/Controllers/ActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/ActionController.cs
@@ -1,9 +1,13 @@
+using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Shoko.Abstractions.Actions;
 using Shoko.Abstractions.Metadata.Enums;
 using Shoko.Abstractions.Metadata.Services;
 using Shoko.Abstractions.Video.Services;
@@ -11,6 +15,7 @@ using Shoko.QueueProcessor.Abstractions;
 using Shoko.QueueProcessor.Scheduling;
 using Shoko.Server.API.Annotations;
 using Shoko.Server.API.ModelBinders;
+using Shoko.Server.API.v3.Models.Action;
 using Shoko.Server.API.v3.Models.Shoko;
 using Shoko.Server.Providers.TMDB;
 using Shoko.Server.Repositories.Cached;
@@ -29,6 +34,7 @@ namespace Shoko.Server.API.v3.Controllers;
 [Authorize]
 public class ActionController : BaseController
 {
+    private const string ObsoleteMessage = "Use the new action system instead: GET /api/v3/Action and POST /api/v3/Action/{actionId}.";
     private readonly ILogger<ActionController> _logger;
     private readonly AnimeGroupCreator _groupCreator;
     private readonly ActionService _actionService;
@@ -72,12 +78,44 @@ public class ActionController : BaseController
         _jmmUsers = jmmUsers;
     }
 
+    #region Action Registry
+
+    /// <summary>
+    ///   List all registered actions. <paramref name="scope"/> is an optional
+    ///   filter — omitting it lists everything.
+    /// </summary>
+    /// <param name="scope">Optional. Filter to actions of a specific scope.</param>
+    [HttpGet]
+    public ActionResult<IEnumerable<ActionInfo>> GetActions([FromQuery] ActionScope? scope)
+        => Ok(_actionService.GetActions(scope, User.IsAdmin == 1 ? null : ActionPermission.User)
+            .Select(ActionInfo.FromExecutableActionInfo));
+
+    /// <summary>
+    ///   Invoke a global action by its ID. Returns 200 (accepted), or 400 with
+    ///   a reason when the action's validation (or the caller's permission)
+    ///   rejects the invocation.
+    /// </summary>
+    /// <param name="actionId">Action ID.</param>
+    /// <param name="token">Cancellation token.</param>
+    [HttpPost("{actionId:guid}")]
+    public async Task<ActionResult> Invoke([FromRoute] Guid actionId, CancellationToken token)
+    {
+        if (_actionService.GetActionInfo(actionId) is null)
+            return NotFound("Action not found.");
+
+        var validation = await _actionService.InvokeAsync(actionId, scopeEntity: null, User, token);
+        return validation is null ? Ok() : BadRequest(validation.Reason);
+    }
+
+    #endregion
+
     #region Common Actions
 
     /// <summary>
     /// Run Import. This checks for new files, hashes them etc, scans Drop Folders, checks and scans for community site links (tmdb, etc), and downloads missing images.
     /// </summary>
     /// <returns></returns>
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("RunImport")]
     public async Task<ActionResult> RunImport()
     {
@@ -89,6 +127,7 @@ public class ActionController : BaseController
     /// Queues a task to import only new files found in the managed folders
     /// </summary>
     /// <returns></returns>
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("ImportNewFiles")]
     public async Task<ActionResult> ImportNewFiles()
     {
@@ -100,6 +139,7 @@ public class ActionController : BaseController
     /// This was for web cache hash syncing, and will be for perceptual hashing maybe eventually.
     /// </summary>
     /// <returns></returns>
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("SyncHashes")]
     public ActionResult SyncHashes()
     {
@@ -110,6 +150,7 @@ public class ActionController : BaseController
     /// Sync the votes from Shoko to AniDB.
     /// </summary>
     /// <returns></returns>
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("SyncVotes")]
     public async Task<ActionResult> SyncVotes([FromQuery] bool export = false, [FromQuery] bool import = false)
     {
@@ -126,6 +167,7 @@ public class ActionController : BaseController
     /// Remove Entries in the Shoko Database for Files that are no longer accessible
     /// </summary>
     /// <returns></returns>
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("RemoveMissingFiles/{removeFromMyList:bool?}")]
     public async Task<ActionResult> RemoveMissingFiles(bool removeFromMyList = true)
     {
@@ -137,6 +179,7 @@ public class ActionController : BaseController
     /// Updates and Downloads Missing Images
     /// </summary>
     /// <returns></returns>
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateAllImages")]
     public ActionResult UpdateAllImages()
     {
@@ -153,6 +196,7 @@ public class ActionController : BaseController
     /// <param name="xrefSource">Optional. Filter to a specific cross-reference source.</param>
     /// <param name="force">Optional. Re-download even if images already exist locally.</param>
     /// <returns></returns>
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("DownloadAllImages")]
     public ActionResult DownloadAllImages(
         [FromQuery] DataSource? imageSource = null,
@@ -169,6 +213,7 @@ public class ActionController : BaseController
     /// Scan for TMDB matches for all unlinked AniDB anime.
     /// </summary>
     /// <returns></returns>
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("SearchForTmdbMatches")]
     public ActionResult SearchForTmdbMatches()
     {
@@ -180,6 +225,7 @@ public class ActionController : BaseController
     /// Updates all TMDB Movies in the local database.
     /// </summary>
     /// <returns></returns>
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateAllTmdbMovies")]
     public ActionResult UpdateAllTmdbMovies()
     {
@@ -192,6 +238,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllUnusedTmdbMovies")]
     public ActionResult PurgeAllUnusedTmdbMovies()
     {
@@ -204,6 +251,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllTmdbMovieCollections")]
     public ActionResult PurgeAllTmdbMovieCollections()
     {
@@ -215,6 +263,7 @@ public class ActionController : BaseController
     /// Update all TMDB Shows in the local database.
     /// </summary>
     /// <returns></returns>
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateAllTmdbShows")]
     public ActionResult UpdateAllTmdbShows()
     {
@@ -225,6 +274,7 @@ public class ActionController : BaseController
     /// <summary>
     /// Download any missing TMDB People.
     /// </summary>
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("DownloadMissingTmdbPeople")]
     public ActionResult DownloadMissingTmdbPeople()
     {
@@ -237,6 +287,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllUnusedTmdbImages")]
     public ActionResult PurgeAllUnusedTmdbImages()
     {
@@ -249,6 +300,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllUnusedTmdbShows")]
     public ActionResult PurgeAllUnusedTmdbShows()
     {
@@ -261,6 +313,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllTmdbShowAlternateOrderings")]
     public ActionResult PurgeAllTmdbShowAlternateOrderings()
     {
@@ -276,6 +329,7 @@ public class ActionController : BaseController
     /// <param name="resetAutoLinkingState">Whether to reset the auto-linking state.</param>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllTmdbLinks")]
     public ActionResult PurgeAllTmdbLinks([FromQuery] bool removeShowLinks = true, [FromQuery] bool removeMovieLinks = true, [FromQuery] bool? resetAutoLinkingState = null)
     {
@@ -300,6 +354,7 @@ public class ActionController : BaseController
     /// </param>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllUsedReleases")]
     public ActionResult PurgeAllUsedReleases(
         [FromQuery] bool skipEvents = false,
@@ -321,6 +376,7 @@ public class ActionController : BaseController
     /// </param>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PurgeAllUnusedReleases")]
     public ActionResult PurgeAllUnusedReleases(
         [FromQuery] bool skipEvents = false,
@@ -335,6 +391,7 @@ public class ActionController : BaseController
     /// Validates invalid images and re-downloads them
     /// </summary>
     /// <returns></returns>
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("ValidateAllImages")]
     public async Task<ActionResult> ValidateAllImages()
     {
@@ -351,6 +408,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("AVDumpMismatchedFiles")]
     public async Task<ActionResult> AVDumpMismatchedFiles()
     {
@@ -381,6 +439,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("DownloadMissingAniDBAnimeData")]
     public ActionResult UpdateMissingAnidbXml()
     {
@@ -397,6 +456,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("DownloadMissingAniDBCreators")]
     public ActionResult ScheduleMissingAniDBCreators()
     {
@@ -411,6 +471,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("SyncMyList")]
     public async Task<ActionResult> SyncMyList()
     {
@@ -423,6 +484,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateAllAniDBInfo")]
     public async Task<ActionResult> UpdateAllAniDBInfo()
     {
@@ -435,6 +497,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateAllMediaInfo")]
     public async Task<ActionResult> UpdateAllMediaInfo()
     {
@@ -447,6 +510,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateSeriesStats")]
     public async Task<ActionResult> UpdateSeriesStats()
     {
@@ -460,6 +524,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateMissingAniDBFileInfo")]
     public async Task<ActionResult> UpdateMissingAniDBFileInfo()
     {
@@ -472,6 +537,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("UpdateAniDBCalendar")]
     public async Task<ActionResult> UpdateAniDBCalendarData()
     {
@@ -487,6 +553,7 @@ public class ActionController : BaseController
     /// </remarks>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("RecreateAllGroups")]
     public ActionResult RecreateAllGroups()
     {
@@ -503,6 +570,7 @@ public class ActionController : BaseController
     /// This action requires an admin account because it affects all groups.
     /// </remarks>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("RenameAllGroups")]
     public ActionResult RenameAllGroups()
     {
@@ -517,6 +585,7 @@ public class ActionController : BaseController
     /// This action requires an admin account because it affects the collection.
     /// </remarks>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("CreateMissingSeries")]
     public async Task<ActionResult> CreateMissingSeries()
     {
@@ -529,6 +598,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("PlexSyncAll")]
     public async Task<ActionResult> PlexSyncAll()
     {
@@ -545,6 +615,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("AddAllManualLinksToMyList")]
     public async Task<ActionResult> AddAllManualLinksToMyList()
     {
@@ -562,6 +633,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("GetAniDBNotifications")]
     public async Task<ActionResult> GetAniDBNotifications()
     {
@@ -574,6 +646,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("RefreshAniDBMovedFiles")]
     public async Task<ActionResult> RefreshAniDBMovedFiles()
     {
@@ -586,6 +659,7 @@ public class ActionController : BaseController
     /// </summary>
     /// <returns></returns>
     [Authorize("admin")]
+    [Obsolete(ObsoleteMessage)]
     [HttpGet("VerifyAllRelations")]
     public async Task<ActionResult> VerifyAllRelations()
     {

--- a/Shoko.Server/API/v3/Controllers/EpisodeActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/EpisodeActionController.cs
@@ -1,0 +1,44 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Shoko.Server.API.Annotations;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Settings;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.API.v3.Controllers;
+
+[ApiController]
+[Route("/api/v{version:apiVersion}/Episode/{episodeId:int}/Action")]
+[ApiV3]
+[Authorize]
+public class EpisodeActionController(ActionService actionService, AnimeEpisodeRepository episodes, ISettingsProvider settingsProvider) : BaseController(settingsProvider)
+{
+    /// <summary>
+    ///   Invoke an episode-scoped action by its ID. Entity existence is
+    ///   validated before anything is enqueued; returns 404 if the episode
+    ///   isn't found, 200 (accepted) on success, or 400 with a reason when
+    ///   the action's validation (or the caller's permission) rejects the
+    ///   invocation.
+    /// </summary>
+    /// <param name="episodeId">Episode ID.</param>
+    /// <param name="actionId">Action ID.</param>
+    /// <param name="token">Cancellation token.</param>
+    [HttpPost("{actionId:guid}")]
+    public async Task<ActionResult> Invoke(
+        [FromRoute, Range(1, int.MaxValue)] int episodeId,
+        [FromRoute] Guid actionId,
+        CancellationToken token
+    )
+    {
+        var episodeEntity = episodes.GetByID(episodeId);
+        if (episodeEntity is null)
+            return NotFound("Episode not found.");
+
+        var validation = await actionService.InvokeAsync(actionId, episodeEntity, User, token);
+        return validation is null ? Ok() : BadRequest(validation.Reason);
+    }
+}

--- a/Shoko.Server/API/v3/Controllers/EpisodeActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/EpisodeActionController.cs
@@ -34,6 +34,9 @@ public class EpisodeActionController(ActionService actionService, AnimeEpisodeRe
         CancellationToken token
     )
     {
+        if (actionService.GetActionInfo(actionId) is null)
+            return NotFound("Action not found.");
+
         var episodeEntity = episodes.GetByID(episodeId);
         if (episodeEntity is null)
             return NotFound("Episode not found.");

--- a/Shoko.Server/API/v3/Controllers/GroupActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/GroupActionController.cs
@@ -1,0 +1,44 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Shoko.Server.API.Annotations;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Settings;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.API.v3.Controllers;
+
+[ApiController]
+[Route("/api/v{version:apiVersion}/Group/{groupId:int}/Action")]
+[ApiV3]
+[Authorize]
+public class GroupActionController(ActionService actionService, AnimeGroupRepository groups, ISettingsProvider settingsProvider) : BaseController(settingsProvider)
+{
+    /// <summary>
+    ///   Invoke a group-scoped action by its ID. Entity existence is
+    ///   validated before anything is enqueued; returns 404 if the group
+    ///   isn't found, 200 (accepted) on success, or 400 with a reason when
+    ///   the action's validation (or the caller's permission) rejects the
+    ///   invocation.
+    /// </summary>
+    /// <param name="groupId">Group ID.</param>
+    /// <param name="actionId">Action ID.</param>
+    /// <param name="token">Cancellation token.</param>
+    [HttpPost("{actionId:guid}")]
+    public async Task<ActionResult> Invoke(
+        [FromRoute, Range(1, int.MaxValue)] int groupId,
+        [FromRoute] Guid actionId,
+        CancellationToken token
+    )
+    {
+        var groupEntity = groups.GetByID(groupId);
+        if (groupEntity is null)
+            return NotFound("Group not found.");
+
+        var validation = await actionService.InvokeAsync(actionId, groupEntity, User, token);
+        return validation is null ? Ok() : BadRequest(validation.Reason);
+    }
+}

--- a/Shoko.Server/API/v3/Controllers/GroupActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/GroupActionController.cs
@@ -34,6 +34,9 @@ public class GroupActionController(ActionService actionService, AnimeGroupReposi
         CancellationToken token
     )
     {
+        if (actionService.GetActionInfo(actionId) is null)
+            return NotFound("Action not found.");
+
         var groupEntity = groups.GetByID(groupId);
         if (groupEntity is null)
             return NotFound("Group not found.");

--- a/Shoko.Server/API/v3/Controllers/SeriesActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/SeriesActionController.cs
@@ -34,6 +34,9 @@ public class SeriesActionController(ActionService actionService, AnimeSeriesRepo
         CancellationToken token
     )
     {
+        if (actionService.GetActionInfo(actionId) is null)
+            return NotFound("Action not found.");
+
         var seriesEntity = series.GetByID(seriesId);
         if (seriesEntity is null)
             return NotFound("Series not found.");

--- a/Shoko.Server/API/v3/Controllers/SeriesActionController.cs
+++ b/Shoko.Server/API/v3/Controllers/SeriesActionController.cs
@@ -1,0 +1,44 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Shoko.Server.API.Annotations;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Settings;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.API.v3.Controllers;
+
+[ApiController]
+[Route("/api/v{version:apiVersion}/Series/{seriesId:int}/Action")]
+[ApiV3]
+[Authorize]
+public class SeriesActionController(ActionService actionService, AnimeSeriesRepository series, ISettingsProvider settingsProvider) : BaseController(settingsProvider)
+{
+    /// <summary>
+    ///   Invoke a series-scoped action by its ID. Entity existence is
+    ///   validated before anything is enqueued; returns 404 if the series
+    ///   isn't found, 200 (accepted) on success, or 400 with a reason when
+    ///   the action's validation (or the caller's permission) rejects the
+    ///   invocation.
+    /// </summary>
+    /// <param name="seriesId">Series ID.</param>
+    /// <param name="actionId">Action ID.</param>
+    /// <param name="token">Cancellation token.</param>
+    [HttpPost("{actionId:guid}")]
+    public async Task<ActionResult> Invoke(
+        [FromRoute, Range(1, int.MaxValue)] int seriesId,
+        [FromRoute] Guid actionId,
+        CancellationToken token
+    )
+    {
+        var seriesEntity = series.GetByID(seriesId);
+        if (seriesEntity is null)
+            return NotFound("Series not found.");
+
+        var validation = await actionService.InvokeAsync(actionId, seriesEntity, User, token);
+        return validation is null ? Ok() : BadRequest(validation.Reason);
+    }
+}

--- a/Shoko.Server/API/v3/Models/Action/ActionInfo.cs
+++ b/Shoko.Server/API/v3/Models/Action/ActionInfo.cs
@@ -1,0 +1,77 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.API.v3.Models.Action;
+
+/// <summary>
+///   A registered executable action, as exposed by the listing endpoints.
+/// </summary>
+public class ActionInfo
+{
+    /// <summary>
+    ///   The action's stable UUIDv5 identifier.
+    /// </summary>
+    [Required]
+    public Guid ID { get; set; }
+
+    /// <summary>
+    ///   The action's display name.
+    /// </summary>
+    [Required]
+    public string Name { get; set; }
+
+    /// <summary>
+    ///   The action's description.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    ///   The action's category.
+    /// </summary>
+    [Required]
+    public ActionCategory Category { get; set; }
+
+    /// <summary>
+    ///   The resolved display name for the category — the owning plugin's name
+    ///   for <see cref="ActionCategory.PluginInferred"/>, otherwise the
+    ///   category's own name.
+    /// </summary>
+    [Required]
+    public string CategoryName { get; set; }
+
+    /// <summary>
+    ///   The entity level the action is bound to.
+    /// </summary>
+    [Required]
+    public ActionScope Scope { get; set; }
+
+    /// <summary>
+    ///   The permission required to invoke the action.
+    /// </summary>
+    [Required]
+    public ActionPermission Permission { get; set; }
+
+    /// <summary>
+    ///   UI hint for destructive actions. WebUI is expected to prompt before
+    ///   invoking the action when this is <see langword="true"/>.
+    /// </summary>
+    [Required]
+    public bool RequiresConfirmation { get; set; }
+
+    /// <summary>
+    ///   Maps a registered action to its API representation.
+    /// </summary>
+    public static ActionInfo FromExecutableActionInfo(ExecutableActionInfo info) => new()
+    {
+        ID = info.Id,
+        Name = info.Name,
+        Description = info.Description,
+        Category = info.Category,
+        CategoryName = info.CategoryName,
+        Scope = info.Scope,
+        Permission = info.Permission,
+        RequiresConfirmation = info.RequiresConfirmation,
+    };
+}

--- a/Shoko.Server/API/v3/Models/Action/ActionInfo.cs
+++ b/Shoko.Server/API/v3/Models/Action/ActionInfo.cs
@@ -1,7 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using Shoko.Abstractions.Actions;
-using Shoko.Server.Services;
 
 namespace Shoko.Server.API.v3.Models.Action;
 

--- a/Shoko.Server/Actions/AniDB/AVDumpMismatchedFilesAction.cs
+++ b/Shoko.Server/Actions/AniDB/AVDumpMismatchedFilesAction.cs
@@ -27,7 +27,7 @@ public sealed class AVDumpMismatchedFilesAction(
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // Matches today: [Authorize("admin")] on the legacy AVDumpMismatchedFiles endpoint.
+    // The legacy AVDumpMismatchedFiles endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task<ActionValidationResult?> Validate(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/AVDumpMismatchedFilesAction.cs
+++ b/Shoko.Server/Actions/AniDB/AVDumpMismatchedFilesAction.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Scheduling.Jobs.AniDB;
+using Shoko.Server.Settings;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Queue AVDump jobs for files whose media info and AniDB data are
+///   mismatched (e.g., chapter states differ).
+/// </summary>
+public sealed class AVDumpMismatchedFilesAction(
+    IQueueScheduler scheduler,
+    ISettingsProvider settingsProvider,
+    VideoLocalRepository videoLocals,
+    ILogger<AVDumpMismatchedFilesAction> logger
+) : IExecutableAction
+{
+    public string Name => "AVDump Mismatched Files";
+
+    public string? Description => "Queue AVDump jobs for files whose local media info and AniDB data are mismatched.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    // Matches today: [Authorize("admin")] on the legacy AVDumpMismatchedFiles endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public Task<ActionValidationResult?> Validate(CancellationToken token = default)
+        => Task.FromResult(string.IsNullOrWhiteSpace(settingsProvider.GetSettings().AniDb.AVDumpKey)
+            ? new ActionValidationResult("Missing AVDump API key. Set it in the settings first.")
+            : null);
+
+    public async Task Execute(CancellationToken token = default)
+    {
+        var mismatchedFiles = videoLocals.GetAll()
+            .Where(file => !file.IsEmpty() && file.MediaInfo != null)
+            .Select(file => (Video: file, AniDB: file.ReleaseInfo))
+            .Where(tuple => tuple.AniDB is { ProviderName: "AniDB", IsCorrupted: false } && tuple.Video.MediaInfo?.MenuStreams.Count != 0 != tuple.AniDB.IsChaptered)
+            .Select(tuple => (Path: tuple.Video.FirstResolvedPlace?.Path, tuple.Video))
+            .Where(tuple => !string.IsNullOrEmpty(tuple.Path))
+            .ToDictionary(tuple => tuple.Video.VideoLocalID, tuple => tuple.Path);
+        foreach (var (fileId, filePath) in mismatchedFiles)
+            await scheduler.Enqueue<AVDumpFilesJob>(a => a.Videos = new() { { fileId, filePath } }, ct: token);
+
+        logger.LogInformation("Queued {QueuedAnimeCount} files for avdumping", mismatchedFiles.Count);
+    }
+}

--- a/Shoko.Server/Actions/AniDB/AVDumpMismatchedFilesAction.cs
+++ b/Shoko.Server/Actions/AniDB/AVDumpMismatchedFilesAction.cs
@@ -27,7 +27,6 @@ public sealed class AVDumpMismatchedFilesAction(
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // The legacy AVDumpMismatchedFiles endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task<ActionValidationResult?> Validate(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/AddAllManualLinksToMyListAction.cs
+++ b/Shoko.Server/Actions/AniDB/AddAllManualLinksToMyListAction.cs
@@ -18,7 +18,6 @@ public sealed class AddAllManualLinksToMyListAction(IQueueScheduler scheduler, V
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // The legacy AddAllManualLinksToMyList endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/AddAllManualLinksToMyListAction.cs
+++ b/Shoko.Server/Actions/AniDB/AddAllManualLinksToMyListAction.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Scheduling.Jobs.AniDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Forcibly runs AddToMyList commands for all manually linked files.
+/// </summary>
+public sealed class AddAllManualLinksToMyListAction(IQueueScheduler scheduler, VideoLocalRepository videoLocals) : IExecutableAction
+{
+    public string Name => "Add All Manual Links to MyList";
+
+    public string? Description => "Forcibly run AddToMyList commands for all files with manual links.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    // Matches today: [Authorize("admin")] on the legacy AddAllManualLinksToMyList endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public async Task Execute(CancellationToken token = default)
+    {
+        var files = videoLocals.GetManuallyLinkedVideos();
+        foreach (var vl in files)
+            await scheduler.Enqueue<AddFileToMyListJob>(c => c.Hash = vl.Hash, ct: token);
+    }
+}

--- a/Shoko.Server/Actions/AniDB/AddAllManualLinksToMyListAction.cs
+++ b/Shoko.Server/Actions/AniDB/AddAllManualLinksToMyListAction.cs
@@ -18,7 +18,7 @@ public sealed class AddAllManualLinksToMyListAction(IQueueScheduler scheduler, V
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // Matches today: [Authorize("admin")] on the legacy AddAllManualLinksToMyList endpoint.
+    // The legacy AddAllManualLinksToMyList endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/DownloadMissingAnidbAnimeDataAction.cs
+++ b/Shoko.Server/Actions/AniDB/DownloadMissingAnidbAnimeDataAction.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Download missing AniDB XML data for anime, and fix cross-references with
+///   incomplete data.
+/// </summary>
+public sealed class DownloadMissingAnidbAnimeDataAction(ActionService actionService) : IExecutableAction
+{
+    public string Name => "Download Missing AniDB Anime Data";
+
+    public string? Description => "Download missing AniDB XML data and fix cross-references with incomplete data.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    // Matches today: [Authorize("admin")] on the legacy DownloadMissingAniDBAnimeData endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public async Task Execute(CancellationToken token = default)
+    {
+        await actionService.DownloadMissingAnidbAnimeXmls();
+        await actionService.ScheduleMissingAnidbAnimeForFiles();
+    }
+}

--- a/Shoko.Server/Actions/AniDB/DownloadMissingAnidbAnimeDataAction.cs
+++ b/Shoko.Server/Actions/AniDB/DownloadMissingAnidbAnimeDataAction.cs
@@ -17,7 +17,6 @@ public sealed class DownloadMissingAnidbAnimeDataAction(ActionService actionServ
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // The legacy DownloadMissingAniDBAnimeData endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/DownloadMissingAnidbAnimeDataAction.cs
+++ b/Shoko.Server/Actions/AniDB/DownloadMissingAnidbAnimeDataAction.cs
@@ -17,7 +17,7 @@ public sealed class DownloadMissingAnidbAnimeDataAction(ActionService actionServ
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // Matches today: [Authorize("admin")] on the legacy DownloadMissingAniDBAnimeData endpoint.
+    // The legacy DownloadMissingAniDBAnimeData endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/DownloadMissingAnidbCreatorsAction.cs
+++ b/Shoko.Server/Actions/AniDB/DownloadMissingAnidbCreatorsAction.cs
@@ -16,7 +16,6 @@ public sealed class DownloadMissingAnidbCreatorsAction(ActionService actionServi
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // The legacy DownloadMissingAniDBCreators endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/DownloadMissingAnidbCreatorsAction.cs
+++ b/Shoko.Server/Actions/AniDB/DownloadMissingAnidbCreatorsAction.cs
@@ -16,7 +16,7 @@ public sealed class DownloadMissingAnidbCreatorsAction(ActionService actionServi
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // Matches today: [Authorize("admin")] on the legacy DownloadMissingAniDBCreators endpoint.
+    // The legacy DownloadMissingAniDBCreators endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/DownloadMissingAnidbCreatorsAction.cs
+++ b/Shoko.Server/Actions/AniDB/DownloadMissingAnidbCreatorsAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Download all missing AniDB creator data via the UDP API.
+/// </summary>
+public sealed class DownloadMissingAnidbCreatorsAction(ActionService actionService) : IExecutableAction
+{
+    public string Name => "Download Missing AniDB Creators";
+
+    public string? Description => "Download all missing or incomplete AniDB creator data via the UDP API.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    // Matches today: [Authorize("admin")] on the legacy DownloadMissingAniDBCreators endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public Task Execute(CancellationToken token = default)
+        => actionService.ScheduleMissingAnidbCreators();
+}

--- a/Shoko.Server/Actions/AniDB/GetAnidbNotificationsAction.cs
+++ b/Shoko.Server/Actions/AniDB/GetAnidbNotificationsAction.cs
@@ -17,7 +17,6 @@ public sealed class GetAnidbNotificationsAction(IQueueScheduler scheduler) : IEx
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // The legacy GetAniDBNotifications endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/GetAnidbNotificationsAction.cs
+++ b/Shoko.Server/Actions/AniDB/GetAnidbNotificationsAction.cs
@@ -17,7 +17,7 @@ public sealed class GetAnidbNotificationsAction(IQueueScheduler scheduler) : IEx
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // Matches today: [Authorize("admin")] on the legacy GetAniDBNotifications endpoint.
+    // The legacy GetAniDBNotifications endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/GetAnidbNotificationsAction.cs
+++ b/Shoko.Server/Actions/AniDB/GetAnidbNotificationsAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.AniDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Fetch unread notifications and messages from AniDB.
+/// </summary>
+public sealed class GetAnidbNotificationsAction(IQueueScheduler scheduler) : IExecutableAction
+{
+    public string Name => "Get AniDB Notifications";
+
+    public string? Description => "Fetch unread notifications and messages from AniDB.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    // Matches today: [Authorize("admin")] on the legacy GetAniDBNotifications endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public Task Execute(CancellationToken token = default)
+        => scheduler.Enqueue<CheckAniDBNotificationsJob>(c => c.ForceRefresh = true, ct: token);
+}

--- a/Shoko.Server/Actions/AniDB/RefreshAnidbMovedFilesAction.cs
+++ b/Shoko.Server/Actions/AniDB/RefreshAnidbMovedFilesAction.cs
@@ -16,7 +16,7 @@ public sealed class RefreshAnidbMovedFilesAction(ActionService actionService) : 
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // Matches today: [Authorize("admin")] on the legacy RefreshAniDBMovedFiles endpoint.
+    // The legacy RefreshAniDBMovedFiles endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/RefreshAnidbMovedFilesAction.cs
+++ b/Shoko.Server/Actions/AniDB/RefreshAnidbMovedFilesAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Process any pending AniDB file-moved notifications.
+/// </summary>
+public sealed class RefreshAnidbMovedFilesAction(ActionService actionService) : IExecutableAction
+{
+    public string Name => "Refresh AniDB Moved Files";
+
+    public string? Description => "Process pending AniDB file-moved notifications and update affected files.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    // Matches today: [Authorize("admin")] on the legacy RefreshAniDBMovedFiles endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public Task Execute(CancellationToken token = default)
+        => actionService.RefreshAniDBMovedFiles(true);
+}

--- a/Shoko.Server/Actions/AniDB/RefreshAnidbMovedFilesAction.cs
+++ b/Shoko.Server/Actions/AniDB/RefreshAnidbMovedFilesAction.cs
@@ -16,7 +16,6 @@ public sealed class RefreshAnidbMovedFilesAction(ActionService actionService) : 
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // The legacy RefreshAniDBMovedFiles endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/Series/UpdateAnidbInfoForceSeriesAction.cs
+++ b/Shoko.Server/Actions/AniDB/Series/UpdateAnidbInfoForceSeriesAction.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Metadata.Anidb.Enums;
+using Shoko.Abstractions.Metadata.Anidb.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Force a complete update of AniDB info for the series, bypassing time
+///   checks and HTTP bans. Requires user confirmation.
+/// </summary>
+public sealed class UpdateAnidbInfoForceSeriesAction(IAnidbService anidbService) : SeriesAction
+{
+    public override string Name => "Update AniDB Info - Force";
+
+    public string? Description => "Forces a complete update from AniDB, bypassing usual checks and bans.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public override ActionPermission Permission => ActionPermission.User;
+
+    public bool RequiresConfirmation => true;
+
+    public override Task Execute(CancellationToken token = default)
+        => anidbService.ScheduleRefreshOfAnimeByID(Series.AnidbAnimeID, AnidbRefreshMethod.Remote | AnidbRefreshMethod.IgnoreTimeCheck | AnidbRefreshMethod.IgnoreHttpBans);
+}

--- a/Shoko.Server/Actions/AniDB/Series/UpdateAnidbInfoRemoteSeriesAction.cs
+++ b/Shoko.Server/Actions/AniDB/Series/UpdateAnidbInfoRemoteSeriesAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Metadata.Anidb.Enums;
+using Shoko.Abstractions.Metadata.Anidb.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Update AniDB info for the series using the remote API, respecting
+///   the usual time and ban checks.
+/// </summary>
+public sealed class UpdateAnidbInfoRemoteSeriesAction(IAnidbService anidbService) : SeriesAction
+{
+    public override string Name => "Update AniDB Info - Remote";
+
+    public string? Description => "Gets the latest series information from the AniDB remote API, respecting usual checks.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public override ActionPermission Permission => ActionPermission.User;
+
+    public override Task Execute(CancellationToken token = default)
+        => anidbService.ScheduleRefreshOfAnimeByID(Series.AnidbAnimeID, AnidbRefreshMethod.Remote);
+}

--- a/Shoko.Server/Actions/AniDB/Series/UpdateAnidbInfoSeriesAction.cs
+++ b/Shoko.Server/Actions/AniDB/Series/UpdateAnidbInfoSeriesAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Metadata.Anidb.Enums;
+using Shoko.Abstractions.Metadata.Anidb.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Update AniDB info for the series, using cached data if available and
+///   falling back to the remote API.
+/// </summary>
+public sealed class UpdateAnidbInfoSeriesAction(IAnidbService anidbService) : SeriesAction
+{
+    public override string Name => "Update AniDB Info";
+
+    public string? Description => "Gets the latest series information from the AniDB database.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public override ActionPermission Permission => ActionPermission.User;
+
+    public override Task Execute(CancellationToken token = default)
+        => anidbService.ScheduleRefreshOfAnimeByID(Series.AnidbAnimeID, AnidbRefreshMethod.Cache | AnidbRefreshMethod.DeferToRemoteIfUnsuccessful);
+}

--- a/Shoko.Server/Actions/AniDB/Series/UpdateAnidbInfoXmlCacheSeriesAction.cs
+++ b/Shoko.Server/Actions/AniDB/Series/UpdateAnidbInfoXmlCacheSeriesAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Metadata.Anidb.Enums;
+using Shoko.Abstractions.Metadata.Anidb.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Update AniDB info for the series using only locally cached XML data.
+/// </summary>
+public sealed class UpdateAnidbInfoXmlCacheSeriesAction(IAnidbService anidbService) : SeriesAction
+{
+    public override string Name => "Update AniDB Info - XML Cache";
+
+    public string? Description => "Updates AniDB data using information from local XML cache.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public override ActionPermission Permission => ActionPermission.User;
+
+    public override Task Execute(CancellationToken token = default)
+        => anidbService.ScheduleRefreshOfAnimeByID(Series.AnidbAnimeID, AnidbRefreshMethod.Cache);
+}

--- a/Shoko.Server/Actions/AniDB/SyncAnidbMyListAction.cs
+++ b/Shoko.Server/Actions/AniDB/SyncAnidbMyListAction.cs
@@ -17,7 +17,7 @@ public sealed class SyncAnidbMyListAction(IQueueScheduler scheduler) : IExecutab
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // Matches today: [Authorize("admin")] on the legacy SyncMyList endpoint.
+    // The legacy SyncMyList endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/AniDB/SyncAnidbMyListAction.cs
+++ b/Shoko.Server/Actions/AniDB/SyncAnidbMyListAction.cs
@@ -17,7 +17,6 @@ public sealed class SyncAnidbMyListAction(IQueueScheduler scheduler) : IExecutab
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // The legacy SyncMyList endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/AniDB/SyncAnidbMyListAction.cs
+++ b/Shoko.Server/Actions/AniDB/SyncAnidbMyListAction.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.AniDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Sync all local state to the AniDB MyList. This overwrites AniDB data.
+/// </summary>
+public sealed class SyncAnidbMyListAction(IQueueScheduler scheduler) : IExecutableAction
+{
+    public string Name => "Sync AniDB MyList";
+
+    public string? Description => "Sync all local state to the AniDB MyList. This can overwrite AniDB data irreversibly.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    // Matches today: [Authorize("admin")] on the legacy SyncMyList endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(CancellationToken token = default)
+        => scheduler.Enqueue<SyncAniDBMyListJob>(j => j.ForceRefresh = true, ct: token);
+}

--- a/Shoko.Server/Actions/AniDB/SyncVotesExportAction.cs
+++ b/Shoko.Server/Actions/AniDB/SyncVotesExportAction.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.User;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.AniDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Export local votes to AniDB for the invoking user.
+/// </summary>
+public sealed class SyncVotesExportAction(IQueueScheduler scheduler) : IExecutableAction, IActionCaller
+{
+    private IUser _caller = null!;
+
+    public string Name => "Sync Votes (Export)";
+
+    public string? Description => "Export local votes to AniDB for the invoking user.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public ActionPermission Permission => ActionPermission.User;
+
+    void IActionCaller.SetCaller(IUser caller) => _caller = caller;
+
+    public Task<ActionValidationResult?> Validate(CancellationToken token = default)
+        => Task.FromResult(_caller.IsAnidbUser ? null : new ActionValidationResult("User is not an AniDB user. Nothing to do."));
+
+    public Task Execute(CancellationToken token = default)
+        => scheduler.Enqueue<SyncAniDBVotesJob>(c => (c.UserID, c.Export) = (_caller.ID, true), ct: token);
+}

--- a/Shoko.Server/Actions/AniDB/SyncVotesImportAction.cs
+++ b/Shoko.Server/Actions/AniDB/SyncVotesImportAction.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.User;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.AniDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Import votes from AniDB for the invoking user.
+/// </summary>
+public sealed class SyncVotesImportAction(IQueueScheduler scheduler) : IExecutableAction, IActionCaller
+{
+    private IUser _caller = null!;
+
+    public string Name => "Sync Votes (Import)";
+
+    public string? Description => "Import votes from AniDB for the invoking user.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    public ActionPermission Permission => ActionPermission.User;
+
+    void IActionCaller.SetCaller(IUser caller) => _caller = caller;
+
+    public Task<ActionValidationResult?> Validate(CancellationToken token = default)
+        => Task.FromResult(_caller.IsAnidbUser ? null : new ActionValidationResult("User is not an AniDB user. Nothing to do."));
+
+    public Task Execute(CancellationToken token = default)
+        => scheduler.Enqueue<SyncAniDBVotesJob>(c => (c.UserID, c.Export) = (_caller.ID, false), ct: token);
+}

--- a/Shoko.Server/Actions/AniDB/UpdateAllAnidbInfoAction.cs
+++ b/Shoko.Server/Actions/AniDB/UpdateAllAnidbInfoAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Refresh all AniDB anime info from the remote API.
+/// </summary>
+public sealed class UpdateAllAnidbInfoAction(ActionService actionService) : IExecutableAction
+{
+    public string Name => "Update All AniDB Info";
+
+    public string? Description => "Refresh all AniDB anime information from the remote API.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    // Matches today: [Authorize("admin")] on the legacy UpdateAllAniDBInfo endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public Task Execute(CancellationToken token = default)
+        => actionService.RunImport_UpdateAllAniDB();
+}

--- a/Shoko.Server/Actions/AniDB/UpdateAllAnidbInfoAction.cs
+++ b/Shoko.Server/Actions/AniDB/UpdateAllAnidbInfoAction.cs
@@ -16,7 +16,7 @@ public sealed class UpdateAllAnidbInfoAction(ActionService actionService) : IExe
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // Matches today: [Authorize("admin")] on the legacy UpdateAllAniDBInfo endpoint.
+    // The legacy UpdateAllAniDBInfo endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/UpdateAllAnidbInfoAction.cs
+++ b/Shoko.Server/Actions/AniDB/UpdateAllAnidbInfoAction.cs
@@ -16,7 +16,6 @@ public sealed class UpdateAllAnidbInfoAction(ActionService actionService) : IExe
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // The legacy UpdateAllAniDBInfo endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/UpdateAnidbCalendarAction.cs
+++ b/Shoko.Server/Actions/AniDB/UpdateAnidbCalendarAction.cs
@@ -17,7 +17,7 @@ public sealed class UpdateAnidbCalendarAction(IQueueScheduler scheduler) : IExec
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // Matches today: [Authorize("admin")] on the legacy UpdateAniDBCalendar endpoint.
+    // The legacy UpdateAniDBCalendar endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/UpdateAnidbCalendarAction.cs
+++ b/Shoko.Server/Actions/AniDB/UpdateAnidbCalendarAction.cs
@@ -17,7 +17,6 @@ public sealed class UpdateAnidbCalendarAction(IQueueScheduler scheduler) : IExec
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // The legacy UpdateAniDBCalendar endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/UpdateAnidbCalendarAction.cs
+++ b/Shoko.Server/Actions/AniDB/UpdateAnidbCalendarAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.AniDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Update the AniDB calendar data for use on the dashboard.
+/// </summary>
+public sealed class UpdateAnidbCalendarAction(IQueueScheduler scheduler) : IExecutableAction
+{
+    public string Name => "Update AniDB Calendar";
+
+    public string? Description => "Update the AniDB calendar data for use on the dashboard.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    // Matches today: [Authorize("admin")] on the legacy UpdateAniDBCalendar endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public Task Execute(CancellationToken token = default)
+        => scheduler.Enqueue<GetAniDBCalendarJob>(c => c.ForceRefresh = true, ct: token);
+}

--- a/Shoko.Server/Actions/AniDB/UpdateMissingAnidbFileInfoAction.cs
+++ b/Shoko.Server/Actions/AniDB/UpdateMissingAnidbFileInfoAction.cs
@@ -16,7 +16,6 @@ public sealed class UpdateMissingAnidbFileInfoAction(ActionService actionService
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // The legacy UpdateMissingAniDBFileInfo endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/UpdateMissingAnidbFileInfoAction.cs
+++ b/Shoko.Server/Actions/AniDB/UpdateMissingAnidbFileInfoAction.cs
@@ -16,7 +16,7 @@ public sealed class UpdateMissingAnidbFileInfoAction(ActionService actionService
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // Matches today: [Authorize("admin")] on the legacy UpdateMissingAniDBFileInfo endpoint.
+    // The legacy UpdateMissingAniDBFileInfo endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/UpdateMissingAnidbFileInfoAction.cs
+++ b/Shoko.Server/Actions/AniDB/UpdateMissingAnidbFileInfoAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Update AniDB release info for files with missing or incomplete group data.
+/// </summary>
+public sealed class UpdateMissingAnidbFileInfoAction(ActionService actionService) : IExecutableAction
+{
+    public string Name => "Update Missing AniDB File Info";
+
+    public string? Description => "Update AniDB release info for files with missing or incomplete group information.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    // Matches today: [Authorize("admin")] on the legacy UpdateMissingAniDBFileInfo endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public Task Execute(CancellationToken token = default)
+        => actionService.UpdateAnidbReleaseInfo();
+}

--- a/Shoko.Server/Actions/AniDB/VerifyAllRelationsAction.cs
+++ b/Shoko.Server/Actions/AniDB/VerifyAllRelationsAction.cs
@@ -16,7 +16,7 @@ public sealed class VerifyAllRelationsAction(ActionService actionService) : IExe
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // Matches today: [Authorize("admin")] on the legacy VerifyAllRelations endpoint.
+    // The legacy VerifyAllRelations endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/VerifyAllRelationsAction.cs
+++ b/Shoko.Server/Actions/AniDB/VerifyAllRelationsAction.cs
@@ -16,7 +16,6 @@ public sealed class VerifyAllRelationsAction(ActionService actionService) : IExe
 
     public ActionCategory Category => ActionCategory.AniDB;
 
-    // The legacy VerifyAllRelations endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/AniDB/VerifyAllRelationsAction.cs
+++ b/Shoko.Server/Actions/AniDB/VerifyAllRelationsAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Verify all unverified AniDB relations by fetching current data via the UDP API.
+/// </summary>
+public sealed class VerifyAllRelationsAction(ActionService actionService) : IExecutableAction
+{
+    public string Name => "Verify All Relations";
+
+    public string? Description => "Verify all unverified AniDB relations by fetching current data via the UDP API.";
+
+    public ActionCategory Category => ActionCategory.AniDB;
+
+    // Matches today: [Authorize("admin")] on the legacy VerifyAllRelations endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public Task Execute(CancellationToken token = default)
+        => actionService.VerifyAllUnverifiedRelations();
+}

--- a/Shoko.Server/Actions/Destructive/Series/DeleteSeriesAllDataAction.cs
+++ b/Shoko.Server/Actions/Destructive/Series/DeleteSeriesAllDataAction.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Models.Shoko;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Completely remove all data and files for the series.
+/// </summary>
+public sealed class DeleteSeriesAllDataAction(AnimeSeriesService seriesService) : SeriesAction
+{
+    public override string Name => "Delete Series - All Series Data and Files";
+
+    public string? Description => "Removes ALL DATA AND FILES relating to the series. Use with caution, as you may get temp banned from AniDB if it's abused.";
+
+    public ActionCategory Category => ActionCategory.Destructive;
+
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public override Task Execute(CancellationToken token = default)
+        => seriesService.DeleteSeries((AnimeSeries)Series, deleteFiles: true, updateGroups: true, completelyRemove: true);
+}

--- a/Shoko.Server/Actions/Destructive/Series/DeleteSeriesKeepFilesAction.cs
+++ b/Shoko.Server/Actions/Destructive/Series/DeleteSeriesKeepFilesAction.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Models.Shoko;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Delete the series from Shoko but keep the files on disk.
+/// </summary>
+public sealed class DeleteSeriesKeepFilesAction(AnimeSeriesService seriesService) : SeriesAction
+{
+    public override string Name => "Delete Series - Keep Files";
+
+    public string? Description => "Deletes the series from Shoko but does not delete the files. Cached AniDB data is preserved.";
+
+    public ActionCategory Category => ActionCategory.Destructive;
+
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public override Task Execute(CancellationToken token = default)
+        => seriesService.DeleteSeries((AnimeSeries)Series, deleteFiles: false, updateGroups: true, completelyRemove: false);
+}

--- a/Shoko.Server/Actions/Destructive/Series/DeleteSeriesRemoveFilesAction.cs
+++ b/Shoko.Server/Actions/Destructive/Series/DeleteSeriesRemoveFilesAction.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Models.Shoko;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Delete the series along with its files from disk.
+/// </summary>
+public sealed class DeleteSeriesRemoveFilesAction(AnimeSeriesService seriesService) : SeriesAction
+{
+    public override string Name => "Delete Series - Remove Files";
+
+    public string? Description => "Deletes the series from Shoko along with the files.";
+
+    public ActionCategory Category => ActionCategory.Destructive;
+
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public override Task Execute(CancellationToken token = default)
+        => seriesService.DeleteSeries((AnimeSeries)Series, deleteFiles: true, updateGroups: true, completelyRemove: false);
+}

--- a/Shoko.Server/Actions/Images/DownloadAllImagesAction.cs
+++ b/Shoko.Server/Actions/Images/DownloadAllImagesAction.cs
@@ -26,7 +26,6 @@ public sealed class DownloadAllImagesAction(IImageManager imageManager) : IExecu
 
     public ActionCategory Category => ActionCategory.Images;
 
-    // The legacy DownloadAllImages endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Images/DownloadAllImagesAction.cs
+++ b/Shoko.Server/Actions/Images/DownloadAllImagesAction.cs
@@ -26,7 +26,7 @@ public sealed class DownloadAllImagesAction(IImageManager imageManager) : IExecu
 
     public ActionCategory Category => ActionCategory.Images;
 
-    // Matches today: no [Authorize("admin")] on the legacy DownloadAllImages endpoint.
+    // The legacy DownloadAllImages endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Images/DownloadAllImagesAction.cs
+++ b/Shoko.Server/Actions/Images/DownloadAllImagesAction.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Metadata.Enums;
+using Shoko.Abstractions.Metadata.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Schedule auto-downloads for all images across all entities, optionally
+///   filtered by image source, image type, and/or cross-reference source.
+/// </summary>
+public sealed class DownloadAllImagesAction(IImageManager imageManager) : IExecutableAction
+{
+    public DataSource? ImageSource { get; set; }
+
+    public ImageEntityType? ImageType { get; set; }
+
+    public DataSource? XrefSource { get; set; }
+
+    public bool Force { get; set; }
+
+    public string Name => "Download All Images";
+
+    public string? Description => "Schedule downloads for all images across all entities, optionally filtered by source, type, and cross-reference source.";
+
+    public ActionCategory Category => ActionCategory.Images;
+
+    // Matches today: no [Authorize("admin")] on the legacy DownloadAllImages endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => imageManager.ScheduleAllAutoDownloads(ImageSource, ImageType, XrefSource, Force);
+}

--- a/Shoko.Server/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
+++ b/Shoko.Server/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
@@ -17,7 +17,6 @@ public sealed class PurgeAllUnusedTmdbImagesAction(IImageManager imageManager) :
 
     public ActionCategory Category => ActionCategory.Images;
 
-    // The legacy PurgeAllUnusedTmdbImages endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
+++ b/Shoko.Server/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
@@ -17,7 +17,7 @@ public sealed class PurgeAllUnusedTmdbImagesAction(IImageManager imageManager) :
 
     public ActionCategory Category => ActionCategory.Images;
 
-    // Matches today: [Authorize("admin")] on the legacy PurgeAllUnusedTmdbImages endpoint.
+    // The legacy PurgeAllUnusedTmdbImages endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
+++ b/Shoko.Server/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Metadata.Enums;
+using Shoko.Abstractions.Metadata.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Purge all unused TMDB images that are not linked to any entity.
+/// </summary>
+public sealed class PurgeAllUnusedTmdbImagesAction(IImageManager imageManager) : IExecutableAction
+{
+    public string Name => "Purge Unused TMDB Images";
+
+    public string? Description => "Remove all TMDB images that are not linked to any entity.";
+
+    public ActionCategory Category => ActionCategory.Images;
+
+    // Matches today: [Authorize("admin")] on the legacy PurgeAllUnusedTmdbImages endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(CancellationToken token = default)
+        => imageManager.SchedulePurgeOfOrphanedImages(0, DataSource.TMDB);
+}

--- a/Shoko.Server/Actions/Images/UpdateAllImagesAction.cs
+++ b/Shoko.Server/Actions/Images/UpdateAllImagesAction.cs
@@ -16,7 +16,6 @@ public sealed class UpdateAllImagesAction(IImageManager imageManager) : IExecuta
 
     public ActionCategory Category => ActionCategory.Images;
 
-    // The legacy UpdateAllImages endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Images/UpdateAllImagesAction.cs
+++ b/Shoko.Server/Actions/Images/UpdateAllImagesAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Metadata.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Schedule auto-downloads for all missing images across all entities.
+/// </summary>
+public sealed class UpdateAllImagesAction(IImageManager imageManager) : IExecutableAction
+{
+    public string Name => "Update All Images";
+
+    public string? Description => "Schedule downloads for all missing images across all entities.";
+
+    public ActionCategory Category => ActionCategory.Images;
+
+    // Matches today: no [Authorize("admin")] on the legacy UpdateAllImages endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => imageManager.ScheduleAllAutoDownloads();
+}

--- a/Shoko.Server/Actions/Images/UpdateAllImagesAction.cs
+++ b/Shoko.Server/Actions/Images/UpdateAllImagesAction.cs
@@ -16,7 +16,7 @@ public sealed class UpdateAllImagesAction(IImageManager imageManager) : IExecuta
 
     public ActionCategory Category => ActionCategory.Images;
 
-    // Matches today: no [Authorize("admin")] on the legacy UpdateAllImages endpoint.
+    // The legacy UpdateAllImages endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Images/ValidateAllImagesAction.cs
+++ b/Shoko.Server/Actions/Images/ValidateAllImagesAction.cs
@@ -16,7 +16,6 @@ public sealed class ValidateAllImagesAction(IImageManager imageManager) : IExecu
 
     public ActionCategory Category => ActionCategory.Images;
 
-    // The legacy ValidateAllImages endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Images/ValidateAllImagesAction.cs
+++ b/Shoko.Server/Actions/Images/ValidateAllImagesAction.cs
@@ -16,7 +16,7 @@ public sealed class ValidateAllImagesAction(IImageManager imageManager) : IExecu
 
     public ActionCategory Category => ActionCategory.Images;
 
-    // Matches today: no [Authorize("admin")] on the legacy ValidateAllImages endpoint.
+    // The legacy ValidateAllImages endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Images/ValidateAllImagesAction.cs
+++ b/Shoko.Server/Actions/Images/ValidateAllImagesAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Metadata.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Validate all images and re-download any that are corrupted or invalid.
+/// </summary>
+public sealed class ValidateAllImagesAction(IImageManager imageManager) : IExecutableAction
+{
+    public string Name => "Validate All Images";
+
+    public string? Description => "Validate all images and re-download any that are corrupted or invalid.";
+
+    public ActionCategory Category => ActionCategory.Images;
+
+    // Matches today: no [Authorize("admin")] on the legacy ValidateAllImages endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => imageManager.ScheduleValidateAllImages(prioritize: true);
+}

--- a/Shoko.Server/Actions/Import/Group/RehashGroupFilesAction.cs
+++ b/Shoko.Server/Actions/Import/Group/RehashGroupFilesAction.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Models.Shoko;
+using Shoko.Server.Scheduling.Jobs.Shoko;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Rehash all files for the group.
+/// </summary>
+public sealed class RehashGroupFilesAction(IQueueScheduler scheduler) : GroupAction
+{
+    public override string Name => "Rehash Files";
+
+    public string? Description => "Rehashes every file associated with the group.";
+
+    public ActionCategory Category => ActionCategory.Import;
+
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public override async Task Execute(CancellationToken token = default)
+    {
+        var animeGroup = (AnimeGroup)Group;
+        var files = animeGroup.AllSeries
+            .SelectMany(s => s.VideoLocals)
+            .DistinctBy(v => v.VideoLocalID)
+            .ToList();
+
+        foreach (var file in files)
+        {
+            var filePath = file.FirstResolvedPlace?.Path;
+            if (string.IsNullOrEmpty(filePath))
+                continue;
+            await scheduler.Enqueue<HashFileJob>(c => (c.FilePath, c.ForceHash) = (filePath, true), prioritize: true, ct: token);
+        }
+    }
+}

--- a/Shoko.Server/Actions/Import/Group/RelocateGroupFilesAction.cs
+++ b/Shoko.Server/Actions/Import/Group/RelocateGroupFilesAction.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Video.Services;
+using Shoko.Server.Models.Shoko;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Relocate all files for the group.
+/// </summary>
+public sealed class RelocateGroupFilesAction(IVideoRelocationService relocationService) : GroupAction
+{
+    public override string Name => "Relocate Files";
+
+    public string? Description => "Renames and/or moves every file associated with the group.";
+
+    public ActionCategory Category => ActionCategory.Import;
+
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public override async Task Execute(CancellationToken token = default)
+    {
+        var animeGroup = (AnimeGroup)Group;
+        var files = animeGroup.AllSeries
+            .SelectMany(s => s.VideoLocals)
+            .DistinctBy(v => v.VideoLocalID)
+            .ToList();
+
+        foreach (var file in files)
+            await relocationService.ScheduleAutoRelocationForVideo(file);
+    }
+}

--- a/Shoko.Server/Actions/Import/Group/RescanGroupFilesAction.cs
+++ b/Shoko.Server/Actions/Import/Group/RescanGroupFilesAction.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Video.Services;
+using Shoko.Server.Models.Shoko;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Rescan all files for the group, re-running release matching.
+/// </summary>
+public sealed class RescanGroupFilesAction(IVideoReleaseService releaseService) : GroupAction
+{
+    public override string Name => "Rescan Files";
+
+    public string? Description => "Rescans every file associated with the group.";
+
+    public ActionCategory Category => ActionCategory.Import;
+
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public override async Task Execute(CancellationToken token = default)
+    {
+        var animeGroup = (AnimeGroup)Group;
+        var files = animeGroup.AllSeries
+            .SelectMany(s => s.VideoLocals)
+            .DistinctBy(v => v.VideoLocalID)
+            .ToList();
+
+        foreach (var file in files)
+            await releaseService.ScheduleFindReleaseForVideo(file, force: true);
+    }
+}

--- a/Shoko.Server/Actions/Import/ImportNewFilesAction.cs
+++ b/Shoko.Server/Actions/Import/ImportNewFilesAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Video.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Scan managed folders for new files and import them without running the
+///   full metadata/image pipeline.
+/// </summary>
+public sealed class ImportNewFilesAction(IVideoService videoService) : IExecutableAction
+{
+    public string Name => "Import New Files";
+
+    public string? Description => "Scan managed folders for new files, hash them, and find releases.";
+
+    public ActionCategory Category => ActionCategory.Import;
+
+    // Matches today: no [Authorize("admin")] on the legacy ImportNewFiles endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => videoService.ScheduleScanForManagedFolders(onlyNewFiles: true);
+}

--- a/Shoko.Server/Actions/Import/ImportNewFilesAction.cs
+++ b/Shoko.Server/Actions/Import/ImportNewFilesAction.cs
@@ -17,7 +17,6 @@ public sealed class ImportNewFilesAction(IVideoService videoService) : IExecutab
 
     public ActionCategory Category => ActionCategory.Import;
 
-    // The legacy ImportNewFiles endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Import/ImportNewFilesAction.cs
+++ b/Shoko.Server/Actions/Import/ImportNewFilesAction.cs
@@ -17,7 +17,7 @@ public sealed class ImportNewFilesAction(IVideoService videoService) : IExecutab
 
     public ActionCategory Category => ActionCategory.Import;
 
-    // Matches today: no [Authorize("admin")] on the legacy ImportNewFiles endpoint.
+    // The legacy ImportNewFiles endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Import/RemoveMissingFilesAction.cs
+++ b/Shoko.Server/Actions/Import/RemoveMissingFilesAction.cs
@@ -17,7 +17,7 @@ public sealed class RemoveMissingFilesAction(ActionService actionService) : IExe
 
     public ActionCategory Category => ActionCategory.Import;
 
-    // Matches today: no admin attribute on the legacy RemoveMissingFiles endpoint.
+    // The legacy RemoveMissingFiles endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Import/RemoveMissingFilesAction.cs
+++ b/Shoko.Server/Actions/Import/RemoveMissingFilesAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Remove entries in the Shoko database for files that are no longer
+///   accessible, including their AniDB MyList state.
+/// </summary>
+public sealed class RemoveMissingFilesAction(ActionService actionService) : IExecutableAction
+{
+    public string Name => "Remove Missing Files";
+
+    public string? Description => "Remove entries in the Shoko database for files that are no longer accessible.";
+
+    public ActionCategory Category => ActionCategory.Import;
+
+    // Matches today: no admin attribute on the legacy RemoveMissingFiles endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => actionService.RemoveRecordsWithoutPhysicalFiles(removeMyList: true);
+}

--- a/Shoko.Server/Actions/Import/RemoveMissingFilesAction.cs
+++ b/Shoko.Server/Actions/Import/RemoveMissingFilesAction.cs
@@ -17,7 +17,6 @@ public sealed class RemoveMissingFilesAction(ActionService actionService) : IExe
 
     public ActionCategory Category => ActionCategory.Import;
 
-    // The legacy RemoveMissingFiles endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Import/RemoveMissingFilesNoMyListSyncAction.cs
+++ b/Shoko.Server/Actions/Import/RemoveMissingFilesNoMyListSyncAction.cs
@@ -10,7 +10,7 @@ namespace Shoko.Server.Actions;
 ///   accessible, without syncing their AniDB MyList state.
 /// </summary>
 /// <remarks>
-///   Gap 23 bucket 1: the legacy RemoveMissingFiles endpoint exposed a single
+///   The legacy RemoveMissingFiles endpoint exposed a single
 ///   <c>removeFromMyList</c> toggle with two WebUI-visible entries — modeled as
 ///   two variant actions instead of one parameterized action, keeping
 ///   <see cref="Execute"/> genuinely parameterless.
@@ -23,7 +23,7 @@ public sealed class RemoveMissingFilesNoMyListSyncAction(ActionService actionSer
 
     public ActionCategory Category => ActionCategory.Import;
 
-    // Matches today: no admin attribute on the legacy RemoveMissingFiles endpoint.
+    // The legacy RemoveMissingFiles endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Import/RemoveMissingFilesNoMyListSyncAction.cs
+++ b/Shoko.Server/Actions/Import/RemoveMissingFilesNoMyListSyncAction.cs
@@ -23,7 +23,6 @@ public sealed class RemoveMissingFilesNoMyListSyncAction(ActionService actionSer
 
     public ActionCategory Category => ActionCategory.Import;
 
-    // The legacy RemoveMissingFiles endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Import/RemoveMissingFilesNoMyListSyncAction.cs
+++ b/Shoko.Server/Actions/Import/RemoveMissingFilesNoMyListSyncAction.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Remove entries in the Shoko database for files that are no longer
+///   accessible, without syncing their AniDB MyList state.
+/// </summary>
+/// <remarks>
+///   Gap 23 bucket 1: the legacy RemoveMissingFiles endpoint exposed a single
+///   <c>removeFromMyList</c> toggle with two WebUI-visible entries — modeled as
+///   two variant actions instead of one parameterized action, keeping
+///   <see cref="Execute"/> genuinely parameterless.
+/// </remarks>
+public sealed class RemoveMissingFilesNoMyListSyncAction(ActionService actionService) : IExecutableAction
+{
+    public string Name => "Remove Missing Files (No MyList Sync)";
+
+    public string? Description => "Remove entries in the Shoko database for files that are no longer accessible, without syncing their AniDB MyList state.";
+
+    public ActionCategory Category => ActionCategory.Import;
+
+    // Matches today: no admin attribute on the legacy RemoveMissingFiles endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => actionService.RemoveRecordsWithoutPhysicalFiles(removeMyList: false);
+}

--- a/Shoko.Server/Actions/Import/RunImportAction.cs
+++ b/Shoko.Server/Actions/Import/RunImportAction.cs
@@ -18,7 +18,6 @@ public sealed class RunImportAction(IQueueScheduler scheduler) : IExecutableActi
 
     public ActionCategory Category => ActionCategory.Import;
 
-    // The legacy RunImport endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Import/RunImportAction.cs
+++ b/Shoko.Server/Actions/Import/RunImportAction.cs
@@ -18,7 +18,7 @@ public sealed class RunImportAction(IQueueScheduler scheduler) : IExecutableActi
 
     public ActionCategory Category => ActionCategory.Import;
 
-    // Matches today: no [Authorize("admin")] on the legacy RunImport endpoint.
+    // The legacy RunImport endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Import/RunImportAction.cs
+++ b/Shoko.Server/Actions/Import/RunImportAction.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.Actions;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Run the full import pipeline: scan for new files, hash them, find
+///   releases, update metadata, and download missing images.
+/// </summary>
+public sealed class RunImportAction(IQueueScheduler scheduler) : IExecutableAction
+{
+    public string Name => "Run Import";
+
+    public string? Description => "Check for new files, hash them, scan for metadata matches, and download missing images.";
+
+    public ActionCategory Category => ActionCategory.Import;
+
+    // Matches today: no [Authorize("admin")] on the legacy RunImport endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => scheduler.Enqueue<ImportJob>(ct: token);
+}

--- a/Shoko.Server/Actions/Import/Series/RehashSeriesFilesAction.cs
+++ b/Shoko.Server/Actions/Import/Series/RehashSeriesFilesAction.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Models.Shoko;
+using Shoko.Server.Scheduling.Jobs.Shoko;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Rehash all files for the series.
+/// </summary>
+public sealed class RehashSeriesFilesAction(IQueueScheduler scheduler) : SeriesAction
+{
+    public override string Name => "Rehash Files";
+
+    public string? Description => "Rehashes every file associated with the series.";
+
+    public ActionCategory Category => ActionCategory.Import;
+
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public override async Task Execute(CancellationToken token = default)
+    {
+        var animeSeries = (AnimeSeries)Series;
+        foreach (var file in animeSeries.VideoLocals)
+        {
+            var filePath = file.FirstResolvedPlace?.Path;
+            if (string.IsNullOrEmpty(filePath))
+                continue;
+            await scheduler.Enqueue<HashFileJob>(c => (c.FilePath, c.ForceHash) = (filePath, true), prioritize: true, ct: token);
+        }
+    }
+}

--- a/Shoko.Server/Actions/Import/Series/RelocateSeriesFilesAction.cs
+++ b/Shoko.Server/Actions/Import/Series/RelocateSeriesFilesAction.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Video.Services;
+using Shoko.Server.Models.Shoko;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Relocate all files for the series.
+/// </summary>
+public sealed class RelocateSeriesFilesAction(IVideoRelocationService relocationService) : SeriesAction
+{
+    public override string Name => "Relocate Files";
+
+    public string? Description => "Renames and/or moves every file associated with the series.";
+
+    public ActionCategory Category => ActionCategory.Import;
+
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public override async Task Execute(CancellationToken token = default)
+    {
+        var animeSeries = (AnimeSeries)Series;
+        foreach (var file in animeSeries.VideoLocals)
+            await relocationService.ScheduleAutoRelocationForVideo(file);
+    }
+}

--- a/Shoko.Server/Actions/Import/Series/RescanSeriesFilesAction.cs
+++ b/Shoko.Server/Actions/Import/Series/RescanSeriesFilesAction.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Video.Services;
+using Shoko.Server.Models.Shoko;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Rescan all files for the series, re-running release matching.
+/// </summary>
+public sealed class RescanSeriesFilesAction(IVideoReleaseService releaseService) : SeriesAction
+{
+    public override string Name => "Rescan Files";
+
+    public string? Description => "Rescans every file associated with the series.";
+
+    public ActionCategory Category => ActionCategory.Import;
+
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public override async Task Execute(CancellationToken token = default)
+    {
+        var animeSeries = (AnimeSeries)Series;
+        foreach (var file in animeSeries.VideoLocals)
+            await releaseService.ScheduleFindReleaseForVideo(file, force: true);
+    }
+}

--- a/Shoko.Server/Actions/Maintenance/CreateMissingSeriesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/CreateMissingSeriesAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Create anime series entries for files that have release info but no
+///   corresponding series.
+/// </summary>
+public sealed class CreateMissingSeriesAction(ActionService actionService) : IExecutableAction
+{
+    public string Name => "Create Missing Series";
+
+    public string? Description => "Create series entries for files that have release info but no corresponding series.";
+
+    public ActionCategory Category => ActionCategory.Maintenance;
+
+    // Matches today: [Authorize("admin")] on the legacy CreateMissingSeries endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public Task Execute(CancellationToken token = default)
+        => actionService.CreateMissingSeries();
+}

--- a/Shoko.Server/Actions/Maintenance/CreateMissingSeriesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/CreateMissingSeriesAction.cs
@@ -17,7 +17,7 @@ public sealed class CreateMissingSeriesAction(ActionService actionService) : IEx
 
     public ActionCategory Category => ActionCategory.Maintenance;
 
-    // Matches today: [Authorize("admin")] on the legacy CreateMissingSeries endpoint.
+    // The legacy CreateMissingSeries endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Maintenance/CreateMissingSeriesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/CreateMissingSeriesAction.cs
@@ -17,7 +17,6 @@ public sealed class CreateMissingSeriesAction(ActionService actionService) : IEx
 
     public ActionCategory Category => ActionCategory.Maintenance;
 
-    // The legacy CreateMissingSeries endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Maintenance/PlexSyncAllAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PlexSyncAllAction.cs
@@ -18,7 +18,6 @@ public sealed class PlexSyncAllAction(IQueueScheduler scheduler, JMMUserReposito
 
     public ActionCategory Category => ActionCategory.Sync;
 
-    // The legacy PlexSyncAll endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Maintenance/PlexSyncAllAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PlexSyncAllAction.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Scheduling.Jobs.Plex;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Sync watch states with Plex for all users with a Plex token.
+/// </summary>
+public sealed class PlexSyncAllAction(IQueueScheduler scheduler, JMMUserRepository jmmUsers) : IExecutableAction
+{
+    public string Name => "Plex Sync All";
+
+    public string? Description => "Sync watch states with Plex for all users with a configured Plex token.";
+
+    public ActionCategory Category => ActionCategory.Sync;
+
+    // Matches today: [Authorize("admin")] on the legacy PlexSyncAll endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public async Task Execute(CancellationToken token = default)
+    {
+        foreach (var user in jmmUsers.GetAll())
+        {
+            if (string.IsNullOrEmpty(user.PlexToken)) continue;
+            await scheduler.Enqueue<SyncPlexWatchedStatesJob>(c => c.User = user, ct: token);
+        }
+    }
+}

--- a/Shoko.Server/Actions/Maintenance/PlexSyncAllAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PlexSyncAllAction.cs
@@ -18,7 +18,7 @@ public sealed class PlexSyncAllAction(IQueueScheduler scheduler, JMMUserReposito
 
     public ActionCategory Category => ActionCategory.Sync;
 
-    // Matches today: [Authorize("admin")] on the legacy PlexSyncAll endpoint.
+    // The legacy PlexSyncAll endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
@@ -17,7 +17,7 @@ public sealed class PurgeAllUnusedReleasesAction(IVideoReleaseService videoRelea
 
     public ActionCategory Category => ActionCategory.Destructive;
 
-    // Matches today: [Authorize("admin")] on the legacy PurgeAllUnusedReleases endpoint.
+    // The legacy PurgeAllUnusedReleases endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Video.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Purge all unused (unlinked) releases from the database, optionally
+///   filtered by provider.
+/// </summary>
+public sealed class PurgeAllUnusedReleasesAction(IVideoReleaseService videoReleaseService) : IExecutableAction
+{
+    public string Name => "Purge All Unused Releases";
+
+    public string? Description => "Remove all unused (unlinked) releases from the database, optionally filtered by provider.";
+
+    public ActionCategory Category => ActionCategory.Destructive;
+
+    // Matches today: [Authorize("admin")] on the legacy PurgeAllUnusedReleases endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(CancellationToken token = default)
+        => videoReleaseService.PurgeUnusedReleases(providerNames: null, skipEvents: false);
+}

--- a/Shoko.Server/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
@@ -17,7 +17,6 @@ public sealed class PurgeAllUnusedReleasesAction(IVideoReleaseService videoRelea
 
     public ActionCategory Category => ActionCategory.Destructive;
 
-    // The legacy PurgeAllUnusedReleases endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
@@ -17,7 +17,7 @@ public sealed class PurgeAllUsedReleasesAction(IVideoReleaseService videoRelease
 
     public ActionCategory Category => ActionCategory.Destructive;
 
-    // Matches today: [Authorize("admin")] on the legacy PurgeAllUsedReleases endpoint.
+    // The legacy PurgeAllUsedReleases endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
@@ -17,7 +17,6 @@ public sealed class PurgeAllUsedReleasesAction(IVideoReleaseService videoRelease
 
     public ActionCategory Category => ActionCategory.Destructive;
 
-    // The legacy PurgeAllUsedReleases endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Video.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Purge all used (linked) releases from the database, optionally filtered
+///   by provider.
+/// </summary>
+public sealed class PurgeAllUsedReleasesAction(IVideoReleaseService videoReleaseService) : IExecutableAction
+{
+    public string Name => "Purge All Used Releases";
+
+    public string? Description => "Remove all used (linked) releases from the database, optionally filtered by provider.";
+
+    public ActionCategory Category => ActionCategory.Destructive;
+
+    // Matches today: [Authorize("admin")] on the legacy PurgeAllUsedReleases endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(CancellationToken token = default)
+        => videoReleaseService.PurgeUsedReleases(providerNames: null, skipEvents: false);
+}

--- a/Shoko.Server/Actions/Maintenance/RecreateAllGroupsAction.cs
+++ b/Shoko.Server/Actions/Maintenance/RecreateAllGroupsAction.cs
@@ -17,7 +17,7 @@ public sealed class RecreateAllGroupsAction(AnimeGroupCreator groupCreator) : IE
 
     public ActionCategory Category => ActionCategory.Maintenance;
 
-    // Matches today: [Authorize("admin")] on the legacy RecreateAllGroups endpoint.
+    // The legacy RecreateAllGroups endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Maintenance/RecreateAllGroupsAction.cs
+++ b/Shoko.Server/Actions/Maintenance/RecreateAllGroupsAction.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Tasks;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Delete all existing groups and recreate them from scratch based on
+///   current settings.
+/// </summary>
+public sealed class RecreateAllGroupsAction(AnimeGroupCreator groupCreator) : IExecutableAction
+{
+    public string Name => "Recreate All Groups";
+
+    public string? Description => "Delete all groups and recreate them from scratch based on current settings.";
+
+    public ActionCategory Category => ActionCategory.Maintenance;
+
+    // Matches today: [Authorize("admin")] on the legacy RecreateAllGroups endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(CancellationToken token = default)
+        => groupCreator.RecreateAllGroups();
+}

--- a/Shoko.Server/Actions/Maintenance/RecreateAllGroupsAction.cs
+++ b/Shoko.Server/Actions/Maintenance/RecreateAllGroupsAction.cs
@@ -17,7 +17,6 @@ public sealed class RecreateAllGroupsAction(AnimeGroupCreator groupCreator) : IE
 
     public ActionCategory Category => ActionCategory.Maintenance;
 
-    // The legacy RecreateAllGroups endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Maintenance/RenameAllGroupsAction.cs
+++ b/Shoko.Server/Actions/Maintenance/RenameAllGroupsAction.cs
@@ -17,7 +17,6 @@ public sealed class RenameAllGroupsAction(IShokoGroupManager groupManager) : IEx
 
     public ActionCategory Category => ActionCategory.Maintenance;
 
-    // The legacy RenameAllGroups endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Maintenance/RenameAllGroupsAction.cs
+++ b/Shoko.Server/Actions/Maintenance/RenameAllGroupsAction.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Metadata.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Rename all groups that do not have a custom name set, using the current
+///   language preferences.
+/// </summary>
+public sealed class RenameAllGroupsAction(IShokoGroupManager groupManager) : IExecutableAction
+{
+    public string Name => "Rename All Groups";
+
+    public string? Description => "Rename all groups without a custom name using the current language preferences.";
+
+    public ActionCategory Category => ActionCategory.Maintenance;
+
+    // Matches today: [Authorize("admin")] on the legacy RenameAllGroups endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public Task Execute(CancellationToken token = default)
+    {
+        groupManager.RenameAllGroups();
+        return Task.CompletedTask;
+    }
+}

--- a/Shoko.Server/Actions/Maintenance/RenameAllGroupsAction.cs
+++ b/Shoko.Server/Actions/Maintenance/RenameAllGroupsAction.cs
@@ -17,7 +17,7 @@ public sealed class RenameAllGroupsAction(IShokoGroupManager groupManager) : IEx
 
     public ActionCategory Category => ActionCategory.Maintenance;
 
-    // Matches today: [Authorize("admin")] on the legacy RenameAllGroups endpoint.
+    // The legacy RenameAllGroups endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Maintenance/UpdateAllMediaInfoAction.cs
+++ b/Shoko.Server/Actions/Maintenance/UpdateAllMediaInfoAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.Actions;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Update media info for all files in the collection.
+/// </summary>
+public sealed class UpdateAllMediaInfoAction(IQueueScheduler scheduler) : IExecutableAction
+{
+    public string Name => "Update All Media Info";
+
+    public string? Description => "Re-read and update media info for all files in the collection.";
+
+    public ActionCategory Category => ActionCategory.Maintenance;
+
+    // Matches today: [Authorize("admin")] on the legacy UpdateAllMediaInfo endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public Task Execute(CancellationToken token = default)
+        => scheduler.Enqueue<MediaInfoAllFilesJob>(ct: token);
+}

--- a/Shoko.Server/Actions/Maintenance/UpdateAllMediaInfoAction.cs
+++ b/Shoko.Server/Actions/Maintenance/UpdateAllMediaInfoAction.cs
@@ -17,7 +17,7 @@ public sealed class UpdateAllMediaInfoAction(IQueueScheduler scheduler) : IExecu
 
     public ActionCategory Category => ActionCategory.Maintenance;
 
-    // Matches today: [Authorize("admin")] on the legacy UpdateAllMediaInfo endpoint.
+    // The legacy UpdateAllMediaInfo endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Maintenance/UpdateAllMediaInfoAction.cs
+++ b/Shoko.Server/Actions/Maintenance/UpdateAllMediaInfoAction.cs
@@ -17,7 +17,6 @@ public sealed class UpdateAllMediaInfoAction(IQueueScheduler scheduler) : IExecu
 
     public ActionCategory Category => ActionCategory.Maintenance;
 
-    // The legacy UpdateAllMediaInfo endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Maintenance/UpdateSeriesStatsAction.cs
+++ b/Shoko.Server/Actions/Maintenance/UpdateSeriesStatsAction.cs
@@ -16,7 +16,7 @@ public sealed class UpdateSeriesStatsAction(ActionService actionService) : IExec
 
     public ActionCategory Category => ActionCategory.Maintenance;
 
-    // Matches today: [Authorize("admin")] on the legacy UpdateSeriesStats endpoint.
+    // The legacy UpdateSeriesStats endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Maintenance/UpdateSeriesStatsAction.cs
+++ b/Shoko.Server/Actions/Maintenance/UpdateSeriesStatsAction.cs
@@ -16,7 +16,6 @@ public sealed class UpdateSeriesStatsAction(ActionService actionService) : IExec
 
     public ActionCategory Category => ActionCategory.Maintenance;
 
-    // The legacy UpdateSeriesStats endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Maintenance/UpdateSeriesStatsAction.cs
+++ b/Shoko.Server/Actions/Maintenance/UpdateSeriesStatsAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Recalculate stats for all series and re-apply group filters.
+/// </summary>
+public sealed class UpdateSeriesStatsAction(ActionService actionService) : IExecutableAction
+{
+    public string Name => "Update Series Stats";
+
+    public string? Description => "Recalculate statistics for all series and re-apply group filters.";
+
+    public ActionCategory Category => ActionCategory.Maintenance;
+
+    // Matches today: [Authorize("admin")] on the legacy UpdateSeriesStats endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public Task Execute(CancellationToken token = default)
+        => actionService.UpdateAllStats();
+}

--- a/Shoko.Server/Actions/Tmdb/DownloadMissingTmdbPeopleAction.cs
+++ b/Shoko.Server/Actions/Tmdb/DownloadMissingTmdbPeopleAction.cs
@@ -16,7 +16,6 @@ public sealed class DownloadMissingTmdbPeopleAction(TmdbMetadataService tmdbServ
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy DownloadMissingTmdbPeople endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/DownloadMissingTmdbPeopleAction.cs
+++ b/Shoko.Server/Actions/Tmdb/DownloadMissingTmdbPeopleAction.cs
@@ -16,7 +16,7 @@ public sealed class DownloadMissingTmdbPeopleAction(TmdbMetadataService tmdbServ
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: no [Authorize("admin")] on the legacy DownloadMissingTmdbPeople endpoint.
+    // The legacy DownloadMissingTmdbPeople endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/DownloadMissingTmdbPeopleAction.cs
+++ b/Shoko.Server/Actions/Tmdb/DownloadMissingTmdbPeopleAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Download any missing TMDB person (cast/crew) data.
+/// </summary>
+public sealed class DownloadMissingTmdbPeopleAction(TmdbMetadataService tmdbService) : IExecutableAction
+{
+    public string Name => "Download Missing TMDB People";
+
+    public string? Description => "Download any missing TMDB person (cast and crew) data.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: no [Authorize("admin")] on the legacy DownloadMissingTmdbPeople endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => tmdbService.RepairMissingPeople();
+}

--- a/Shoko.Server/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
@@ -16,7 +16,7 @@ public sealed class PurgeAllTmdbLinksAction(ITmdbLinkingService linkingService) 
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: [Authorize("admin")] on the legacy PurgeAllTmdbLinks endpoint.
+    // The legacy PurgeAllTmdbLinks endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
@@ -1,0 +1,41 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Metadata.Tmdb.Services;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Remove all AniDB-TMDB links and optionally reset the auto-linking state.
+/// </summary>
+public sealed class PurgeAllTmdbLinksAction(ITmdbLinkingService linkingService) : IExecutableAction
+{
+    public string Name => "Purge All TMDB Links";
+
+    public string? Description => "Remove all AniDB-TMDB links and reset the auto-linking state.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: [Authorize("admin")] on the legacy PurgeAllTmdbLinks endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    /// <summary>Whether to remove show links.</summary>
+    public bool RemoveShowLinks { get; set; } = true;
+
+    /// <summary>Whether to remove movie links.</summary>
+    public bool RemoveMovieLinks { get; set; } = true;
+
+    /// <summary>Whether to reset the auto-linking state.</summary>
+    public bool? ResetAutoLinkingState { get; set; }
+
+    public Task Execute(CancellationToken token = default)
+    {
+        if (RemoveShowLinks || RemoveMovieLinks)
+            linkingService.RemoveAllLinks(RemoveShowLinks, RemoveMovieLinks);
+        if (ResetAutoLinkingState.HasValue)
+            linkingService.ResetAutoLinkingState(ResetAutoLinkingState.Value);
+        return Task.CompletedTask;
+    }
+}

--- a/Shoko.Server/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
@@ -16,7 +16,6 @@ public sealed class PurgeAllTmdbLinksAction(ITmdbLinkingService linkingService) 
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy PurgeAllTmdbLinks endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
@@ -16,7 +16,6 @@ public sealed class PurgeAllTmdbMovieCollectionsAction(TmdbMetadataService tmdbS
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy PurgeAllTmdbMovieCollections endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Purge all TMDB movie collections from the local database.
+/// </summary>
+public sealed class PurgeAllTmdbMovieCollectionsAction(TmdbMetadataService tmdbService) : IExecutableAction
+{
+    public string Name => "Purge TMDB Movie Collections";
+
+    public string? Description => "Remove all TMDB movie collections from the local database.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: [Authorize("admin")] on the legacy PurgeAllTmdbMovieCollections endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(CancellationToken token = default)
+        => tmdbService.PurgeAllMovieCollections();
+}

--- a/Shoko.Server/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
@@ -16,7 +16,7 @@ public sealed class PurgeAllTmdbMovieCollectionsAction(TmdbMetadataService tmdbS
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: [Authorize("admin")] on the legacy PurgeAllTmdbMovieCollections endpoint.
+    // The legacy PurgeAllTmdbMovieCollections endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
@@ -16,7 +16,7 @@ public sealed class PurgeAllTmdbShowAlternateOrderingsAction(TmdbMetadataService
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: [Authorize("admin")] on the legacy PurgeAllTmdbShowAlternateOrderings endpoint.
+    // The legacy PurgeAllTmdbShowAlternateOrderings endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
@@ -16,7 +16,6 @@ public sealed class PurgeAllTmdbShowAlternateOrderingsAction(TmdbMetadataService
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy PurgeAllTmdbShowAlternateOrderings endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Purge all TMDB show alternate orderings from the local database.
+/// </summary>
+public sealed class PurgeAllTmdbShowAlternateOrderingsAction(TmdbMetadataService tmdbService) : IExecutableAction
+{
+    public string Name => "Purge TMDB Show Alternate Orderings";
+
+    public string? Description => "Remove all TMDB show alternate orderings (episode groups) from the local database.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: [Authorize("admin")] on the legacy PurgeAllTmdbShowAlternateOrderings endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(CancellationToken token = default)
+    {
+        tmdbService.PurgeAllShowEpisodeGroups();
+        return Task.CompletedTask;
+    }
+}

--- a/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
@@ -16,7 +16,7 @@ public sealed class PurgeAllUnusedTmdbMoviesAction(TmdbMetadataService tmdbServi
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: [Authorize("admin")] on the legacy PurgeAllUnusedTmdbMovies endpoint.
+    // The legacy PurgeAllUnusedTmdbMovies endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Purge all TMDB movies that are not linked to any AniDB anime.
+/// </summary>
+public sealed class PurgeAllUnusedTmdbMoviesAction(TmdbMetadataService tmdbService) : IExecutableAction
+{
+    public string Name => "Purge Unused TMDB Movies";
+
+    public string? Description => "Remove all TMDB movies that are not linked to any AniDB anime.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: [Authorize("admin")] on the legacy PurgeAllUnusedTmdbMovies endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(CancellationToken token = default)
+        => tmdbService.PurgeAllUnusedMovies();
+}

--- a/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
@@ -16,7 +16,6 @@ public sealed class PurgeAllUnusedTmdbMoviesAction(TmdbMetadataService tmdbServi
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy PurgeAllUnusedTmdbMovies endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
@@ -16,7 +16,7 @@ public sealed class PurgeAllUnusedTmdbShowsAction(TmdbMetadataService tmdbServic
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: [Authorize("admin")] on the legacy PurgeAllUnusedTmdbShows endpoint.
+    // The legacy PurgeAllUnusedTmdbShows endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Purge all TMDB shows that are not linked to any AniDB anime.
+/// </summary>
+public sealed class PurgeAllUnusedTmdbShowsAction(TmdbMetadataService tmdbService) : IExecutableAction
+{
+    public string Name => "Purge Unused TMDB Shows";
+
+    public string? Description => "Remove all TMDB shows that are not linked to any AniDB anime.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: [Authorize("admin")] on the legacy PurgeAllUnusedTmdbShows endpoint.
+    public ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public Task Execute(CancellationToken token = default)
+        => tmdbService.PurgeAllUnusedShows();
+}

--- a/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
@@ -16,7 +16,6 @@ public sealed class PurgeAllUnusedTmdbShowsAction(TmdbMetadataService tmdbServic
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy PurgeAllUnusedTmdbShows endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Tmdb/SearchForTmdbMatchesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/SearchForTmdbMatchesAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Scan for TMDB matches for all AniDB anime that are not yet linked.
+/// </summary>
+public sealed class SearchForTmdbMatchesAction(TmdbMetadataService tmdbService) : IExecutableAction
+{
+    public string Name => "Search for TMDB Matches";
+
+    public string? Description => "Scan for TMDB show and movie matches for all unlinked AniDB anime.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: no [Authorize("admin")] on the legacy SearchForTmdbMatches endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => tmdbService.ScanForMatches();
+}

--- a/Shoko.Server/Actions/Tmdb/SearchForTmdbMatchesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/SearchForTmdbMatchesAction.cs
@@ -16,7 +16,6 @@ public sealed class SearchForTmdbMatchesAction(TmdbMetadataService tmdbService) 
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy SearchForTmdbMatches endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/SearchForTmdbMatchesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/SearchForTmdbMatchesAction.cs
@@ -16,7 +16,7 @@ public sealed class SearchForTmdbMatchesAction(TmdbMetadataService tmdbService) 
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: no [Authorize("admin")] on the legacy SearchForTmdbMatches endpoint.
+    // The legacy SearchForTmdbMatches endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/Series/AutoMatchTmdbEpisodesSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/AutoMatchTmdbEpisodesSeriesAction.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Automatically match TMDB episodes for the series.
+/// </summary>
+public sealed class AutoMatchTmdbEpisodesSeriesAction(TmdbLinkingService linkingService) : SeriesAction
+{
+    public override string Name => "Auto-Match TMDB Episodes";
+
+    public string? Description => "Automatically matches Shoko episodes with TMDB episodes.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: [Authorize("admin")] on the legacy TMDB/Show/CrossReferences/Episode/Auto endpoint.
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public override Task Execute(CancellationToken token = default)
+    {
+        var tmdbShowId = Series.TmdbShowCrossReferences is [{ } first, ..]
+            ? first.TmdbShowID
+            : 0;
+        if (tmdbShowId is 0)
+            return Task.CompletedTask;
+
+        linkingService.MatchAnidbToTmdbEpisodes(Series.AnidbAnimeID, tmdbShowId, null, useExisting: true, useExistingOtherShows: null, saveToDatabase: true);
+        return Task.CompletedTask;
+    }
+}

--- a/Shoko.Server/Actions/Tmdb/Series/AutoMatchTmdbEpisodesSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/AutoMatchTmdbEpisodesSeriesAction.cs
@@ -16,7 +16,7 @@ public sealed class AutoMatchTmdbEpisodesSeriesAction(TmdbLinkingService linking
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: [Authorize("admin")] on the legacy TMDB/Show/CrossReferences/Episode/Auto endpoint.
+    // The legacy TMDB/Show/CrossReferences/Episode/Auto endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public override ActionPermission Permission => ActionPermission.Admin;
 
     public override Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/Series/AutoMatchTmdbEpisodesSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/AutoMatchTmdbEpisodesSeriesAction.cs
@@ -16,7 +16,6 @@ public sealed class AutoMatchTmdbEpisodesSeriesAction(TmdbLinkingService linking
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy TMDB/Show/CrossReferences/Episode/Auto endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public override ActionPermission Permission => ActionPermission.Admin;
 
     public override Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/Series/AutoSearchTmdbSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/AutoSearchTmdbSeriesAction.cs
@@ -16,7 +16,6 @@ public sealed class AutoSearchTmdbSeriesAction(TmdbMetadataService tmdbService) 
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy TMDB/Action/AutoSearch endpoint had no admin gate; keep User-level to avoid regressing callers.
     public override ActionPermission Permission => ActionPermission.User;
 
     public override Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/Series/AutoSearchTmdbSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/AutoSearchTmdbSeriesAction.cs
@@ -16,7 +16,7 @@ public sealed class AutoSearchTmdbSeriesAction(TmdbMetadataService tmdbService) 
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: no [Authorize("admin")] on the legacy TMDB/Action/AutoSearch endpoint.
+    // The legacy TMDB/Action/AutoSearch endpoint had no admin gate; keep User-level to avoid regressing callers.
     public override ActionPermission Permission => ActionPermission.User;
 
     public override Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/Series/AutoSearchTmdbSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/AutoSearchTmdbSeriesAction.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Automatically search for a TMDB match for the series.
+/// </summary>
+public sealed class AutoSearchTmdbSeriesAction(TmdbMetadataService tmdbService) : SeriesAction
+{
+    public override string Name => "Auto-Search TMDB Match";
+
+    public string? Description => "Automatically searches for a TMDB match.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: no [Authorize("admin")] on the legacy TMDB/Action/AutoSearch endpoint.
+    public override ActionPermission Permission => ActionPermission.User;
+
+    public override Task Execute(CancellationToken token = default)
+        => tmdbService.ScheduleSearchForMatch(Series.AnidbAnimeID, false);
+}

--- a/Shoko.Server/Actions/Tmdb/Series/DownloadTmdbMovieImagesSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/DownloadTmdbMovieImagesSeriesAction.cs
@@ -17,7 +17,6 @@ public sealed class DownloadTmdbMovieImagesSeriesAction(IQueueScheduler schedule
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy TMDB/Movie/Action/DownloadImages endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public override ActionPermission Permission => ActionPermission.Admin;
 
     public override async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/Series/DownloadTmdbMovieImagesSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/DownloadTmdbMovieImagesSeriesAction.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Download images for all TMDB movies linked to the series.
+/// </summary>
+public sealed class DownloadTmdbMovieImagesSeriesAction(IQueueScheduler scheduler) : SeriesAction
+{
+    public override string Name => "Download TMDB Movie Images";
+
+    public string? Description => "Download any missing images for linked TMDB movies.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: [Authorize("admin")] on the legacy TMDB/Movie/Action/DownloadImages endpoint.
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public override async Task Execute(CancellationToken token = default)
+    {
+        foreach (var xref in Series.TmdbMovieCrossReferences)
+            await scheduler.Enqueue<DownloadTmdbMovieImagesJob>(j =>
+            {
+                j.TmdbMovieID = xref.TmdbMovieID;
+                j.ForceDownload = false;
+            }, ct: token);
+    }
+}

--- a/Shoko.Server/Actions/Tmdb/Series/DownloadTmdbMovieImagesSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/DownloadTmdbMovieImagesSeriesAction.cs
@@ -17,7 +17,7 @@ public sealed class DownloadTmdbMovieImagesSeriesAction(IQueueScheduler schedule
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: [Authorize("admin")] on the legacy TMDB/Movie/Action/DownloadImages endpoint.
+    // The legacy TMDB/Movie/Action/DownloadImages endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public override ActionPermission Permission => ActionPermission.Admin;
 
     public override async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/Series/RefreshTmdbMoviesSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/RefreshTmdbMoviesSeriesAction.cs
@@ -17,7 +17,7 @@ public sealed class RefreshTmdbMoviesSeriesAction(IQueueScheduler scheduler) : S
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: [Authorize("admin")] on the legacy TMDB/Movie/Action/Refresh endpoint.
+    // The legacy TMDB/Movie/Action/Refresh endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public override ActionPermission Permission => ActionPermission.Admin;
 
     public override async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/Series/RefreshTmdbMoviesSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/RefreshTmdbMoviesSeriesAction.cs
@@ -1,0 +1,35 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Refresh all TMDB movies linked to the series.
+/// </summary>
+public sealed class RefreshTmdbMoviesSeriesAction(IQueueScheduler scheduler) : SeriesAction
+{
+    public override string Name => "Refresh TMDB Movies";
+
+    public string? Description => "Refresh all linked TMDB movie metadata.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: [Authorize("admin")] on the legacy TMDB/Movie/Action/Refresh endpoint.
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public override async Task Execute(CancellationToken token = default)
+    {
+        foreach (var xref in Series.TmdbMovieCrossReferences)
+            await scheduler.Enqueue<UpdateTmdbMovieJob>(j =>
+            {
+                j.TmdbMovieID = xref.TmdbMovieID;
+                j.ForceRefresh = false; // body.Force default
+                j.DownloadImages = true; // body.DownloadImages default
+                j.DownloadCrewAndCast = null; // body.DownloadCrewAndCast default
+                j.DownloadCollections = null; // body.DownloadCollections default
+            }, ct: token);
+    }
+}

--- a/Shoko.Server/Actions/Tmdb/Series/RefreshTmdbMoviesSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/RefreshTmdbMoviesSeriesAction.cs
@@ -17,7 +17,6 @@ public sealed class RefreshTmdbMoviesSeriesAction(IQueueScheduler scheduler) : S
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy TMDB/Movie/Action/Refresh endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public override ActionPermission Permission => ActionPermission.Admin;
 
     public override async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Reset all TMDB episode mappings for the series.
+/// </summary>
+public sealed class ResetTmdbEpisodeMappingsSeriesAction(TmdbLinkingService linkingService) : SeriesAction
+{
+    public override string Name => "Reset TMDB Episode Mappings";
+
+    public string? Description => "Reset all TMDB episode mappings for the series.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: [Authorize("admin")] on the legacy TMDB/Show/CrossReferences/Episode endpoint.
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public bool RequiresConfirmation => true;
+
+    public override Task Execute(CancellationToken token = default)
+    {
+        linkingService.ResetAllEpisodeLinks(Series.AnidbAnimeID, true);
+        return Task.CompletedTask;
+    }
+}

--- a/Shoko.Server/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
@@ -16,7 +16,6 @@ public sealed class ResetTmdbEpisodeMappingsSeriesAction(TmdbLinkingService link
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy TMDB/Show/CrossReferences/Episode endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public override ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
@@ -16,7 +16,7 @@ public sealed class ResetTmdbEpisodeMappingsSeriesAction(TmdbLinkingService link
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: [Authorize("admin")] on the legacy TMDB/Show/CrossReferences/Episode endpoint.
+    // The legacy TMDB/Show/CrossReferences/Episode endpoint was admin-gated; keep Admin-level so the permission surface does not widen.
     public override ActionPermission Permission => ActionPermission.Admin;
 
     public bool RequiresConfirmation => true;

--- a/Shoko.Server/Actions/Tmdb/Series/UpdateTmdbImagesForceSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/UpdateTmdbImagesForceSeriesAction.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Force a complete redownload of TMDB images for the series.
+/// </summary>
+public sealed class UpdateTmdbImagesForceSeriesAction(IQueueScheduler scheduler) : SeriesAction
+{
+    public override string Name => "Update TMDB Images - Force";
+
+    public string? Description => "Forces a complete redownload of images from TMDB.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: [Authorize("admin")] on the legacy TMDB/Movie|Show/Action/DownloadImages endpoints.
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public override async Task Execute(CancellationToken token = default)
+    {
+        foreach (var xref in Series.TmdbShowCrossReferences)
+            await scheduler.Enqueue<DownloadTmdbShowImagesJob>(j =>
+            {
+                j.TmdbShowID = xref.TmdbShowID;
+                j.ForceDownload = true;
+            }, ct: token);
+        foreach (var xref in Series.TmdbMovieCrossReferences)
+            await scheduler.Enqueue<DownloadTmdbMovieImagesJob>(j =>
+            {
+                j.TmdbMovieID = xref.TmdbMovieID;
+                j.ForceDownload = true;
+            }, ct: token);
+    }
+}

--- a/Shoko.Server/Actions/Tmdb/Series/UpdateTmdbImagesForceSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/UpdateTmdbImagesForceSeriesAction.cs
@@ -17,7 +17,7 @@ public sealed class UpdateTmdbImagesForceSeriesAction(IQueueScheduler scheduler)
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: [Authorize("admin")] on the legacy TMDB/Movie|Show/Action/DownloadImages endpoints.
+    // The legacy TMDB/Movie|Show/Action/DownloadImages endpoints were admin-gated; keep Admin-level so the permission surface does not widen.
     public override ActionPermission Permission => ActionPermission.Admin;
 
     public override async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/Series/UpdateTmdbImagesForceSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/UpdateTmdbImagesForceSeriesAction.cs
@@ -17,7 +17,6 @@ public sealed class UpdateTmdbImagesForceSeriesAction(IQueueScheduler scheduler)
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy TMDB/Movie|Show/Action/DownloadImages endpoints were admin-gated; keep Admin-level so the permission surface does not widen.
     public override ActionPermission Permission => ActionPermission.Admin;
 
     public override async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/Series/UpdateTmdbInfoSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/UpdateTmdbInfoSeriesAction.cs
@@ -1,0 +1,45 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.Server.Scheduling.Jobs.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Update all TMDB shows linked to the series.
+/// </summary>
+public sealed class UpdateTmdbInfoSeriesAction(IQueueScheduler scheduler) : SeriesAction
+{
+    public override string Name => "Update TMDB Info";
+
+    public string? Description => "Gets the latest series information from TMDB.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: [Authorize("admin")] on the legacy TMDB/Show|Movie/Action/Refresh endpoints.
+    public override ActionPermission Permission => ActionPermission.Admin;
+
+    public override async Task Execute(CancellationToken token = default)
+    {
+        foreach (var xref in Series.TmdbShowCrossReferences)
+            await scheduler.Enqueue<UpdateTmdbShowJob>(j =>
+            {
+                j.TmdbShowID = xref.TmdbShowID;
+                j.ForceRefresh = false; // body.Force default
+                j.DownloadImages = true; // body.DownloadImages default
+                j.DownloadCrewAndCast = null; // body.DownloadCrewAndCast default
+                j.DownloadAlternateOrdering = null; // body.DownloadAlternateOrdering default
+                j.DownloadNetworks = null; // body.DownloadNetworks default
+            }, ct: token);
+        foreach (var xref in Series.TmdbMovieCrossReferences)
+            await scheduler.Enqueue<UpdateTmdbMovieJob>(j =>
+            {
+                j.TmdbMovieID = xref.TmdbMovieID;
+                j.ForceRefresh = false; // body.Force default
+                j.DownloadImages = true; // body.DownloadImages default
+                j.DownloadCrewAndCast = null; // body.DownloadCrewAndCast default
+                j.DownloadCollections = null; // body.DownloadCollections default
+            }, ct: token);
+    }
+}

--- a/Shoko.Server/Actions/Tmdb/Series/UpdateTmdbInfoSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/UpdateTmdbInfoSeriesAction.cs
@@ -17,7 +17,6 @@ public sealed class UpdateTmdbInfoSeriesAction(IQueueScheduler scheduler) : Seri
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy TMDB/Show|Movie/Action/Refresh endpoints were admin-gated; keep Admin-level so the permission surface does not widen.
     public override ActionPermission Permission => ActionPermission.Admin;
 
     public override async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/Series/UpdateTmdbInfoSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/UpdateTmdbInfoSeriesAction.cs
@@ -17,7 +17,7 @@ public sealed class UpdateTmdbInfoSeriesAction(IQueueScheduler scheduler) : Seri
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: [Authorize("admin")] on the legacy TMDB/Show|Movie/Action/Refresh endpoints.
+    // The legacy TMDB/Show|Movie/Action/Refresh endpoints were admin-gated; keep Admin-level so the permission surface does not widen.
     public override ActionPermission Permission => ActionPermission.Admin;
 
     public override async Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/UpdateAllTmdbMoviesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/UpdateAllTmdbMoviesAction.cs
@@ -17,7 +17,7 @@ public sealed class UpdateAllTmdbMoviesAction(TmdbMetadataService tmdbService) :
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: no [Authorize("admin")] on the legacy UpdateAllTmdbMovies endpoint.
+    // The legacy UpdateAllTmdbMovies endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/UpdateAllTmdbMoviesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/UpdateAllTmdbMoviesAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Update all TMDB movies in the local database from the remote API.
+///   Only refreshes metadata; does not download images.
+/// </summary>
+public sealed class UpdateAllTmdbMoviesAction(TmdbMetadataService tmdbService) : IExecutableAction
+{
+    public string Name => "Update All TMDB Movies";
+
+    public string? Description => "Update all TMDB movie metadata in the local database without downloading images.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: no [Authorize("admin")] on the legacy UpdateAllTmdbMovies endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => tmdbService.UpdateAllMovies(true, false);
+}

--- a/Shoko.Server/Actions/Tmdb/UpdateAllTmdbMoviesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/UpdateAllTmdbMoviesAction.cs
@@ -17,7 +17,6 @@ public sealed class UpdateAllTmdbMoviesAction(TmdbMetadataService tmdbService) :
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy UpdateAllTmdbMovies endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/UpdateAllTmdbMoviesWithImagesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/UpdateAllTmdbMoviesWithImagesAction.cs
@@ -17,7 +17,7 @@ public sealed class UpdateAllTmdbMoviesWithImagesAction(TmdbMetadataService tmdb
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: no [Authorize("admin")] on the legacy UpdateAllTmdbMovies endpoint.
+    // The legacy UpdateAllTmdbMovies endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/UpdateAllTmdbMoviesWithImagesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/UpdateAllTmdbMoviesWithImagesAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Update all TMDB movies in the local database from the remote API,
+///   including downloading any missing images.
+/// </summary>
+public sealed class UpdateAllTmdbMoviesWithImagesAction(TmdbMetadataService tmdbService) : IExecutableAction
+{
+    public string Name => "Update All TMDB Movies (with Images)";
+
+    public string? Description => "Update all TMDB movie metadata and download any missing images.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: no [Authorize("admin")] on the legacy UpdateAllTmdbMovies endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => tmdbService.UpdateAllMovies(true, true);
+}

--- a/Shoko.Server/Actions/Tmdb/UpdateAllTmdbMoviesWithImagesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/UpdateAllTmdbMoviesWithImagesAction.cs
@@ -17,7 +17,6 @@ public sealed class UpdateAllTmdbMoviesWithImagesAction(TmdbMetadataService tmdb
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy UpdateAllTmdbMovies endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/UpdateAllTmdbShowsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/UpdateAllTmdbShowsAction.cs
@@ -17,7 +17,7 @@ public sealed class UpdateAllTmdbShowsAction(TmdbMetadataService tmdbService) : 
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: no [Authorize("admin")] on the legacy UpdateAllTmdbShows endpoint.
+    // The legacy UpdateAllTmdbShows endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/UpdateAllTmdbShowsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/UpdateAllTmdbShowsAction.cs
@@ -17,7 +17,6 @@ public sealed class UpdateAllTmdbShowsAction(TmdbMetadataService tmdbService) : 
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy UpdateAllTmdbShows endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/UpdateAllTmdbShowsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/UpdateAllTmdbShowsAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Update all TMDB shows in the local database from the remote API.
+///   Only refreshes metadata; does not download images.
+/// </summary>
+public sealed class UpdateAllTmdbShowsAction(TmdbMetadataService tmdbService) : IExecutableAction
+{
+    public string Name => "Update All TMDB Shows";
+
+    public string? Description => "Update all TMDB show metadata in the local database without downloading images.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: no [Authorize("admin")] on the legacy UpdateAllTmdbShows endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => tmdbService.UpdateAllShows(true, false);
+}

--- a/Shoko.Server/Actions/Tmdb/UpdateAllTmdbShowsWithImagesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/UpdateAllTmdbShowsWithImagesAction.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Shoko.Abstractions.Actions;
+using Shoko.Server.Providers.TMDB;
+
+namespace Shoko.Server.Actions;
+
+/// <summary>
+///   Update all TMDB shows in the local database from the remote API,
+///   including downloading any missing images.
+/// </summary>
+public sealed class UpdateAllTmdbShowsWithImagesAction(TmdbMetadataService tmdbService) : IExecutableAction
+{
+    public string Name => "Update All TMDB Shows (with Images)";
+
+    public string? Description => "Update all TMDB show metadata and download any missing images.";
+
+    public ActionCategory Category => ActionCategory.TMDB;
+
+    // Matches today: no [Authorize("admin")] on the legacy UpdateAllTmdbShows endpoint.
+    public ActionPermission Permission => ActionPermission.User;
+
+    public Task Execute(CancellationToken token = default)
+        => tmdbService.UpdateAllShows(true, true);
+}

--- a/Shoko.Server/Actions/Tmdb/UpdateAllTmdbShowsWithImagesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/UpdateAllTmdbShowsWithImagesAction.cs
@@ -17,7 +17,6 @@ public sealed class UpdateAllTmdbShowsWithImagesAction(TmdbMetadataService tmdbS
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // The legacy UpdateAllTmdbShows endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Actions/Tmdb/UpdateAllTmdbShowsWithImagesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/UpdateAllTmdbShowsWithImagesAction.cs
@@ -17,7 +17,7 @@ public sealed class UpdateAllTmdbShowsWithImagesAction(TmdbMetadataService tmdbS
 
     public ActionCategory Category => ActionCategory.TMDB;
 
-    // Matches today: no [Authorize("admin")] on the legacy UpdateAllTmdbShows endpoint.
+    // The legacy UpdateAllTmdbShows endpoint had no admin gate; keep User-level to avoid regressing callers.
     public ActionPermission Permission => ActionPermission.User;
 
     public Task Execute(CancellationToken token = default)

--- a/Shoko.Server/Plugin/PluginManager.cs
+++ b/Shoko.Server/Plugin/PluginManager.cs
@@ -9,7 +9,9 @@ using System.Runtime.Loader;
 using System.Threading.Tasks;
 using ImageMagick;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Shoko.Abstractions.Actions;
 using Shoko.Abstractions.Config;
 using Shoko.Abstractions.Config.Services;
 using Shoko.Abstractions.Core;
@@ -384,6 +386,15 @@ public partial class PluginManager(ILogger<PluginManager> logger, ISystemService
             logger.LogTrace("Scanning plugin assembly for queue jobs. ({DllName})", Path.GetFileNameWithoutExtension(pluginInfo.DLLs[0]));
             serviceCollection.AddQueueJobsFromAssembly(pluginInfo.PluginType!.Assembly);
         }
+
+        // Register plugin-provided executable actions as transient services so the
+        // action execution job can resolve them fresh from DI per execution.
+        foreach (var actionType in _pluginTypes
+                     .SelectMany(pluginInfo => pluginInfo.Types)
+                     .Where(type => type is { IsClass: true, IsAbstract: false } && typeof(IExecutableAction).IsAssignableFrom(type)))
+        {
+            serviceCollection.TryAddTransient(actionType);
+        }
     }
 
     public void InitPlugins()
@@ -460,6 +471,16 @@ public partial class PluginManager(ILogger<PluginManager> logger, ISystemService
 
         var supplementaryMetadataService = ISystemService.StaticServices.GetRequiredService<SupplementaryMetadataService>();
         supplementaryMetadataService.AddParts(GetExports<ISupplementaryMetadataProvider>());
+
+        // Register the discovered executable actions — plugin-provided types first,
+        // then core-provided types from this assembly, all validated at load time.
+        var actionService = ISystemService.StaticServices.GetRequiredService<ActionService>();
+        actionService.AddParts(GetTypes<IExecutableAction>()
+            .Where(type => type is { IsClass: true, IsAbstract: false })
+            .Select(type => (GetPluginInfo(type.Assembly)!.ID, type)));
+        actionService.AddParts(typeof(PluginManager).Assembly.GetExportedTypes()
+            .Where(type => type is { IsClass: true, IsAbstract: false } && typeof(IExecutableAction).IsAssignableFrom(type))
+            .Select(type => (CorePlugin.StaticID, type)));
     }
 
     private IEnumerable<(string?, string[], bool)> GetPluginDirectories()

--- a/Shoko.Server/Plugin/PluginManager.cs
+++ b/Shoko.Server/Plugin/PluginManager.cs
@@ -472,15 +472,10 @@ public partial class PluginManager(ILogger<PluginManager> logger, ISystemService
         var supplementaryMetadataService = ISystemService.StaticServices.GetRequiredService<SupplementaryMetadataService>();
         supplementaryMetadataService.AddParts(GetExports<ISupplementaryMetadataProvider>());
 
-        // Register the discovered executable actions — plugin-provided types first,
-        // then core-provided types from this assembly, all validated at load time.
         var actionService = ISystemService.StaticServices.GetRequiredService<ActionService>();
         actionService.AddParts(GetTypes<IExecutableAction>()
             .Where(type => type is { IsClass: true, IsAbstract: false })
             .Select(type => (GetPluginInfo(type.Assembly)!.ID, type)));
-        actionService.AddParts(typeof(PluginManager).Assembly.GetExportedTypes()
-            .Where(type => type is { IsClass: true, IsAbstract: false } && typeof(IExecutableAction).IsAssignableFrom(type))
-            .Select(type => (CorePlugin.StaticID, type)));
     }
 
     private IEnumerable<(string?, string[], bool)> GetPluginDirectories()

--- a/Shoko.Server/Scheduling/Jobs/Actions/ActionExecutionJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Actions/ActionExecutionJob.cs
@@ -55,9 +55,9 @@ public class ActionExecutionJob(
     public int CallerUserId { get; set; }
 
     /// <summary>
-    ///   The action's free-form invocation parameters (Gap 23 bucket 2),
-    ///   populated onto the matching public settable properties of the action
-    ///   instance before it executes.
+    ///   The action's free-form invocation parameters (the open-ended invocation
+    ///   parameter case), populated onto the matching public settable properties
+    ///   of the action instance before it executes.
     /// </summary>
     /// <remarks>
     ///   Part of the dedup key, so the same action invoked on the same scope
@@ -88,12 +88,12 @@ public class ActionExecutionJob(
 
         _logger.LogInformation("Executing action \"{ActionName}\" ({ActionId})", info.Name, ActionId);
 
-        // Gap 9: transient — a fresh instance per execution, resolved from DI.
+        // Transient — a fresh instance per execution, resolved from DI.
         var action = (IExecutableAction)services.GetRequiredService(actionService.GetActionType(ActionId));
 
-        // Gap 23 bucket 2: populate the action's free-form properties from
-        // JobDataJson before it executes — the same mechanism every other job
-        // property already uses. Unknown property names are ignored.
+        // Populate the action's free-form properties from JobDataJson before it
+        // executes — the same mechanism every other job property already uses.
+        // Unknown property names are ignored.
         ActionService.PopulateParameters(action, Parameters);
 
         if (action is IScopedAction scoped)
@@ -115,7 +115,7 @@ public class ActionExecutionJob(
         // ActionService.InvokeAsync before this job was even enqueued. Re-running it
         // here would be redundant and could observe different state than what the
         // caller saw when they got their 200.
-        // Gap 11: the job's own lifetime token, not request-bound — there is no live
+        // The job's own lifetime token, not request-bound — there is no live
         // HTTP request left by the time a queued action runs.
         await action.Execute();
 

--- a/Shoko.Server/Scheduling/Jobs/Actions/ActionExecutionJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Actions/ActionExecutionJob.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Shoko.Abstractions.Actions;
 using Shoko.Abstractions.User;
 using Shoko.QueueProcessor.Abstractions;
@@ -60,6 +59,12 @@ public class ActionExecutionJob(
     ///   populated onto the matching public settable properties of the action
     ///   instance before it executes.
     /// </summary>
+    /// <remarks>
+    ///   Part of the dedup key, so the same action invoked on the same scope
+    ///   and caller with different parameters still enqueues instead of
+    ///   collapsing into an already-queued job.
+    /// </remarks>
+    [JobKeyMember(index: 3)]
     public Dictionary<string, object?>? Parameters { get; set; }
 
     public override string TypeName => "Action Execution";
@@ -89,8 +94,7 @@ public class ActionExecutionJob(
         // Gap 23 bucket 2: populate the action's free-form properties from
         // JobDataJson before it executes — the same mechanism every other job
         // property already uses. Unknown property names are ignored.
-        if (Parameters is { Count: > 0 })
-            JsonConvert.PopulateObject(JsonConvert.SerializeObject(Parameters), action);
+        ActionService.PopulateParameters(action, Parameters);
 
         if (action is IScopedAction scoped)
         {

--- a/Shoko.Server/Scheduling/Jobs/Actions/ActionExecutionJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Actions/ActionExecutionJob.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using Shoko.Abstractions.Actions;
 using Shoko.Abstractions.User;
 using Shoko.QueueProcessor.Abstractions;
@@ -54,6 +55,13 @@ public class ActionExecutionJob(
     [JobKeyMember(index: 2)]
     public int CallerUserId { get; set; }
 
+    /// <summary>
+    ///   The action's free-form invocation parameters (Gap 23 bucket 2),
+    ///   populated onto the matching public settable properties of the action
+    ///   instance before it executes.
+    /// </summary>
+    public Dictionary<string, object?>? Parameters { get; set; }
+
     public override string TypeName => "Action Execution";
 
     public override string Title => actionService.GetActionName(ActionId);
@@ -77,6 +85,12 @@ public class ActionExecutionJob(
 
         // Gap 9: transient — a fresh instance per execution, resolved from DI.
         var action = (IExecutableAction)services.GetRequiredService(actionService.GetActionType(ActionId));
+
+        // Gap 23 bucket 2: populate the action's free-form properties from
+        // JobDataJson before it executes — the same mechanism every other job
+        // property already uses. Unknown property names are ignored.
+        if (Parameters is { Count: > 0 })
+            JsonConvert.PopulateObject(JsonConvert.SerializeObject(Parameters), action);
 
         if (action is IScopedAction scoped)
         {

--- a/Shoko.Server/Scheduling/Jobs/Actions/ActionExecutionJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Actions/ActionExecutionJob.cs
@@ -86,7 +86,7 @@ public class ActionExecutionJob(
             scoped.SetContext(ResolveScopeEntity(info.Scope, entityId));
         }
 
-        if (action is IActionCaller callerAware)
+        if (CallerUserId > 0 && action is IActionCaller callerAware)
         {
             var caller = users.GetByID(CallerUserId)
                 ?? throw new InvalidOperationException($"User not found: {CallerUserId}");

--- a/Shoko.Server/Scheduling/Jobs/Actions/ActionExecutionJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Actions/ActionExecutionJob.cs
@@ -76,7 +76,7 @@ public class ActionExecutionJob(
         _logger.LogInformation("Executing action \"{ActionName}\" ({ActionId})", info.Name, ActionId);
 
         // Gap 9: transient — a fresh instance per execution, resolved from DI.
-        var action = (IExecutableAction)services.GetRequiredService(info.ActionType);
+        var action = (IExecutableAction)services.GetRequiredService(actionService.GetActionType(ActionId));
 
         if (action is IScopedAction scoped)
         {

--- a/Shoko.Server/Scheduling/Jobs/Actions/ActionExecutionJob.cs
+++ b/Shoko.Server/Scheduling/Jobs/Actions/ActionExecutionJob.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.User;
+using Shoko.QueueProcessor.Abstractions;
+using Shoko.QueueProcessor.Acquisition.Attributes;
+using Shoko.QueueProcessor.Builder;
+using Shoko.Server.Models.Shoko;
+using Shoko.Server.Repositories.Cached;
+using Shoko.Server.Services;
+
+namespace Shoko.Server.Scheduling.Jobs.Actions;
+
+/// <summary>
+///   The one generic wrapper job that executes every registered action.
+///   Enqueued by <see cref="ActionService.InvokeAsync"/> with the action ID,
+///   scope, scope entity ID, and calling user ID populated from
+///   <c>JobDataJson</c> — the same mechanism every other
+///   <see cref="IQueueJob"/> in this codebase already uses.
+/// </summary>
+[DatabaseRequired]
+[JobKeyMember("Action")]
+[JobKeyGroup(JobKeyGroup.Actions)]
+public class ActionExecutionJob(
+    IServiceProvider services,
+    ActionService actionService,
+    JMMUserRepository users,
+    AnimeSeriesRepository series,
+    AnimeGroupRepository groups,
+    AnimeEpisodeRepository episodes
+) : BaseJob
+{
+    [JobKeyMember(index: 0)]
+    public Guid ActionId { get; set; }
+
+    /// <summary>
+    ///   The scope of the action, mirrored from
+    ///   <see cref="ExecutableActionInfo.Scope"/> at enqueue time.
+    /// </summary>
+    public ActionScope Scope { get; set; }
+
+    /// <summary>
+    ///   The ID of the entity to scope the action to, if applicable.
+    /// </summary>
+    [JobKeyMember(index: 1)]
+    public int? ScopeEntityId { get; set; }
+
+    /// <summary>
+    ///   The ID of the user that invoked the action.
+    /// </summary>
+    [JobKeyMember(index: 2)]
+    public int CallerUserId { get; set; }
+
+    public override string TypeName => "Action Execution";
+
+    public override string Title => actionService.GetActionName(ActionId);
+
+    public override Dictionary<string, object> Details => new()
+    {
+        { "Action", actionService.GetActionName(ActionId) },
+        { "Scope", Scope },
+    };
+
+    public override async Task Execute()
+    {
+        var info = actionService.GetActionInfo(ActionId);
+        if (info is null)
+        {
+            _logger.LogWarning("ActionExecutionJob: Action not found: {ActionId}", ActionId);
+            return;
+        }
+
+        _logger.LogInformation("Executing action \"{ActionName}\" ({ActionId})", info.Name, ActionId);
+
+        // Gap 9: transient — a fresh instance per execution, resolved from DI.
+        var action = (IExecutableAction)services.GetRequiredService(info.ActionType);
+
+        if (action is IScopedAction scoped)
+        {
+            if (ScopeEntityId is not { } entityId)
+                throw new InvalidOperationException($"Scoped action '{info.Name}' ({info.Id}) has no scope entity ID.");
+
+            scoped.SetContext(ResolveScopeEntity(info.Scope, entityId));
+        }
+
+        if (action is IActionCaller callerAware)
+        {
+            var caller = users.GetByID(CallerUserId)
+                ?? throw new InvalidOperationException($"User not found: {CallerUserId}");
+            callerAware.SetCaller(caller);
+        }
+
+        // Validate is NOT re-run here — it already ran synchronously in
+        // ActionService.InvokeAsync before this job was even enqueued. Re-running it
+        // here would be redundant and could observe different state than what the
+        // caller saw when they got their 200.
+        // Gap 11: the job's own lifetime token, not request-bound — there is no live
+        // HTTP request left by the time a queued action runs.
+        await action.Execute();
+
+        _logger.LogInformation("Finished executing action \"{ActionName}\" ({ActionId})", info.Name, ActionId);
+    }
+
+    private object ResolveScopeEntity(ActionScope scope, int entityId) => scope switch
+    {
+        ActionScope.Series => series.GetByID(entityId) ?? throw new KeyNotFoundException($"Series not found: {entityId}"),
+        ActionScope.Group => groups.GetByID(entityId) ?? throw new KeyNotFoundException($"Group not found: {entityId}"),
+        ActionScope.Episode => episodes.GetByID(entityId) ?? throw new KeyNotFoundException($"Episode not found: {entityId}"),
+        _ => throw new InvalidOperationException("Global actions have no scope entity."),
+    };
+}

--- a/Shoko.Server/Services/ActionService.cs
+++ b/Shoko.Server/Services/ActionService.cs
@@ -225,7 +225,7 @@ public class ActionService : IActionService
             // collision-free by construction since plugin names are unique. Anything else
             // falls back to the category's own name.
             var categoryName = probe.Category is ActionCategory.PluginInferred
-                ? _pluginManager.GetPluginInfo(pluginId)?.Name ?? actionType.Assembly.GetName().Name
+                ? _pluginManager.GetPluginInfo(pluginId)?.Name ?? actionType.Assembly.GetName().Name!
                 : probe.Category.ToString();
 
             _actions[id] = new RegisteredAction(new ExecutableActionInfo(

--- a/Shoko.Server/Services/ActionService.cs
+++ b/Shoko.Server/Services/ActionService.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using Shoko.Abstractions.Actions;
 using Shoko.Abstractions.Actions.Services;
 using Shoko.Abstractions.Extensions;
@@ -273,6 +274,22 @@ public class ActionService : IActionService
             ? info.ActionType
             : throw new KeyNotFoundException($"No action registered for {actionId}");
 
+    /// <summary>
+    ///   Populates the action's free-form properties (Gap 23 bucket 2) from an
+    ///   invocation parameter payload. Unknown property names are ignored.
+    /// Used both before <see cref="IExecutableAction.Validate"/> runs on the
+    /// probe instance and before <see cref="IExecutableAction.Execute"/> runs
+    /// inside <see cref="ActionExecutionJob"/>, so both observe the same
+    /// caller-supplied values.
+    /// </summary>
+    internal static void PopulateParameters(IExecutableAction action, IReadOnlyDictionary<string, object?>? parameters)
+    {
+        if (parameters is not { Count: > 0 })
+            return;
+
+        JsonConvert.PopulateObject(JsonConvert.SerializeObject(parameters), action);
+    }
+
     /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IUser?, CancellationToken)"/>
     public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IUser? caller = null, CancellationToken token = default)
         => InvokeCoreAsync(actionId, scopeEntity: null, parameters: null, caller, token);
@@ -358,6 +375,10 @@ public class ActionService : IActionService
 
             callerAware.SetCaller(caller);
         }
+
+        // Populate the probe with the caller's parameters too, so Validate
+        // observes the same values Execute will, not the compiled-in defaults.
+        PopulateParameters(probe, parameters);
 
         var validation = await probe.Validate(token);
         if (validation is not null)

--- a/Shoko.Server/Services/ActionService.cs
+++ b/Shoko.Server/Services/ActionService.cs
@@ -275,19 +275,35 @@ public class ActionService : IActionService
 
     /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IUser?, CancellationToken)"/>
     public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IUser? caller = null, CancellationToken token = default)
-        => InvokeCoreAsync(actionId, scopeEntity: null, caller, token);
+        => InvokeCoreAsync(actionId, scopeEntity: null, parameters: null, caller, token);
+
+    /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IReadOnlyDictionary{string, object?}, IUser?, CancellationToken)"/>
+    public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IReadOnlyDictionary<string, object?> parameters, IUser? caller = null, CancellationToken token = default)
+        => InvokeCoreAsync(actionId, scopeEntity: null, parameters, caller, token);
 
     /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IShokoGroup, IUser?, CancellationToken)"/>
     public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoGroup group, IUser? caller = null, CancellationToken token = default)
-        => InvokeCoreAsync(actionId, group, caller, token);
+        => InvokeCoreAsync(actionId, group, parameters: null, caller, token);
+
+    /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IShokoGroup, IReadOnlyDictionary{string, object?}, IUser?, CancellationToken)"/>
+    public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoGroup group, IReadOnlyDictionary<string, object?> parameters, IUser? caller = null, CancellationToken token = default)
+        => InvokeCoreAsync(actionId, group, parameters, caller, token);
 
     /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IShokoSeries, IUser?, CancellationToken)"/>
     public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoSeries series, IUser? caller = null, CancellationToken token = default)
-        => InvokeCoreAsync(actionId, series, caller, token);
+        => InvokeCoreAsync(actionId, series, parameters: null, caller, token);
+
+    /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IShokoSeries, IReadOnlyDictionary{string, object?}, IUser?, CancellationToken)"/>
+    public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoSeries series, IReadOnlyDictionary<string, object?> parameters, IUser? caller = null, CancellationToken token = default)
+        => InvokeCoreAsync(actionId, series, parameters, caller, token);
 
     /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IShokoEpisode, IUser?, CancellationToken)"/>
     public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoEpisode episode, IUser? caller = null, CancellationToken token = default)
-        => InvokeCoreAsync(actionId, episode, caller, token);
+        => InvokeCoreAsync(actionId, episode, parameters: null, caller, token);
+
+    /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IShokoEpisode, IReadOnlyDictionary{string, object?}, IUser?, CancellationToken)"/>
+    public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoEpisode episode, IReadOnlyDictionary<string, object?> parameters, IUser? caller = null, CancellationToken token = default)
+        => InvokeCoreAsync(actionId, episode, parameters, caller, token);
 
     /// <summary>
     ///   The invoke entry point. Scope-agnostic on purpose — the caller
@@ -300,7 +316,7 @@ public class ActionService : IActionService
     ///   rejection reason — mapped to a 400 by the controller — when the
     ///   invocation was refused without ever touching the queue.
     /// </returns>
-    private async Task<ActionValidationResult?> InvokeCoreAsync(Guid actionId, object? scopeEntity, IUser? caller, CancellationToken token)
+    private async Task<ActionValidationResult?> InvokeCoreAsync(Guid actionId, object? scopeEntity, IReadOnlyDictionary<string, object?>? parameters, IUser? caller, CancellationToken token)
     {
         if (!_actions.TryGetValue(actionId, out var registered))
             throw new KeyNotFoundException($"No action registered for {actionId}");
@@ -361,6 +377,7 @@ public class ActionService : IActionService
             };
             j.Scope = info.Scope;
             j.CallerUserId = caller?.ID ?? 0;
+            j.Parameters = parameters?.ToDictionary(pair => pair.Key, pair => pair.Value);
         }, ct: token);
 
         // Gap 7: bare ack — no tracking ID.

--- a/Shoko.Server/Services/ActionService.cs
+++ b/Shoko.Server/Services/ActionService.cs
@@ -7,10 +7,12 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Actions.Services;
 using Shoko.Abstractions.Extensions;
 using Shoko.Abstractions.Metadata.Anidb.Enums;
 using Shoko.Abstractions.Metadata.Anidb.Services;
 using Shoko.Abstractions.Metadata.Services;
+using Shoko.Abstractions.Metadata.Shoko;
 using Shoko.Abstractions.Plugin;
 using Shoko.Abstractions.User;
 using Shoko.Abstractions.Utilities;
@@ -33,7 +35,7 @@ using Shoko.Server.Settings;
 
 namespace Shoko.Server.Services;
 
-public class ActionService
+public class ActionService : IActionService
 {
     private readonly ILogger<ActionService> _logger;
 
@@ -68,7 +70,15 @@ public class ActionService
     ///   <see cref="AddParts"/>. A fresh transient instance is resolved from
     ///   DI for every validation and execution.
     /// </summary>
-    private readonly Dictionary<Guid, ExecutableActionInfo> _actions = new();
+    private readonly Dictionary<Guid, RegisteredAction> _actions = new();
+
+    /// <summary>
+    ///   A registered action type paired with the metadata exposed to plugins.
+    ///   The concrete type is deliberately not part of
+    ///   <see cref="ExecutableActionInfo"/> so the abstraction surface never
+    ///   leaks server internals.
+    /// </summary>
+    private sealed record RegisteredAction(ExecutableActionInfo Info, Type ActionType);
 
     private readonly VideoLocalRepository _videoLocals;
 
@@ -218,18 +228,17 @@ public class ActionService
                 ? _pluginManager.GetPluginInfo(pluginId)?.Name ?? actionType.Assembly.GetName().Name
                 : probe.Category.ToString();
 
-            _actions[id] = new ExecutableActionInfo(
+            _actions[id] = new RegisteredAction(new ExecutableActionInfo(
                 id,
-                actionType,
-                scope,
-                pluginId,
                 probe.Name,
                 probe.Description,
                 probe.Category,
                 categoryName,
+                scope,
                 probe.Permission,
-                probe.RequiresConfirmation
-            );
+                probe.RequiresConfirmation,
+                pluginId
+            ), actionType);
         }
     }
 
@@ -238,22 +247,50 @@ public class ActionService
     ///   required partition — omitting it lists every action. Non-admin callers
     ///   only see actions they may invoke.
     /// </summary>
-    public IEnumerable<ExecutableActionInfo> GetActions(ActionScope? scope, ActionPermission? callerPermission)
+    public IReadOnlyList<ExecutableActionInfo> GetActions(ActionScope? scope = null, ActionPermission? callerPermission = null)
         => _actions.Values
+            .Select(a => a.Info)
             .Where(a => (scope is null || a.Scope == scope) &&
                         (callerPermission != ActionPermission.User || a.Permission == ActionPermission.User))
             .OrderBy(a => a.Category)
             .ThenBy(a => a.CategoryName)
-            .ThenBy(a => a.Name);
+            .ThenBy(a => a.Name)
+            .ToList();
 
     public ExecutableActionInfo? GetActionInfo(Guid actionId)
-        => _actions.TryGetValue(actionId, out var info) ? info : null;
+        => _actions.TryGetValue(actionId, out var info) ? info.Info : null;
 
     public string GetActionName(Guid actionId)
-        => _actions.TryGetValue(actionId, out var info) ? info.Name : actionId.ToString();
+        => _actions.TryGetValue(actionId, out var info) ? info.Info.Name : actionId.ToString();
 
     /// <summary>
-    ///   The invoke entry point. Scope-agnostic on purpose — the controller
+    ///   The concrete action type for an action ID. Kept internal — plugins
+    ///   work with <see cref="ExecutableActionInfo"/> and IDs only, while the
+    ///   execution job uses this to resolve a fresh instance from DI.
+    /// </summary>
+    internal Type GetActionType(Guid actionId)
+        => _actions.TryGetValue(actionId, out var info)
+            ? info.ActionType
+            : throw new KeyNotFoundException($"No action registered for {actionId}");
+
+    /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IUser?, CancellationToken)"/>
+    public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IUser? caller = null, CancellationToken token = default)
+        => InvokeCoreAsync(actionId, scopeEntity: null, caller, token);
+
+    /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IShokoGroup, IUser?, CancellationToken)"/>
+    public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoGroup group, IUser? caller = null, CancellationToken token = default)
+        => InvokeCoreAsync(actionId, group, caller, token);
+
+    /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IShokoSeries, IUser?, CancellationToken)"/>
+    public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoSeries series, IUser? caller = null, CancellationToken token = default)
+        => InvokeCoreAsync(actionId, series, caller, token);
+
+    /// <inheritdoc cref="IActionService.InvokeAsync(Guid, IShokoEpisode, IUser?, CancellationToken)"/>
+    public Task<ActionValidationResult?> InvokeAsync(Guid actionId, IShokoEpisode episode, IUser? caller = null, CancellationToken token = default)
+        => InvokeCoreAsync(actionId, episode, caller, token);
+
+    /// <summary>
+    ///   The invoke entry point. Scope-agnostic on purpose — the caller
     ///   resolves <paramref name="scopeEntity"/> (an <see cref="AnimeSeries"/>,
     ///   <see cref="AnimeGroup"/>, <see cref="AnimeEpisode"/>, or
     ///   <see langword="null"/> for Global) before calling this.
@@ -263,22 +300,48 @@ public class ActionService
     ///   rejection reason — mapped to a 400 by the controller — when the
     ///   invocation was refused without ever touching the queue.
     /// </returns>
-    public async Task<ActionValidationResult?> InvokeAsync(Guid actionId, object? scopeEntity, IUser caller, CancellationToken token)
+    private async Task<ActionValidationResult?> InvokeCoreAsync(Guid actionId, object? scopeEntity, IUser? caller, CancellationToken token)
     {
-        if (!_actions.TryGetValue(actionId, out var info))
+        if (!_actions.TryGetValue(actionId, out var registered))
             throw new KeyNotFoundException($"No action registered for {actionId}");
 
-        if (info.Permission is ActionPermission.Admin && !caller.IsAdmin)
+        var info = registered.Info;
+
+        // Reject invocations via the wrong scope (e.g. a series-scoped action invoked
+        // with no series, or a global action invoked with one) instead of letting the
+        // context cast fail later in the job.
+        var expectedScope = scopeEntity switch
+        {
+            AnimeSeries => ActionScope.Series,
+            AnimeGroup => ActionScope.Group,
+            AnimeEpisode => ActionScope.Episode,
+            _ => ActionScope.Global,
+        };
+        if (info.Scope != expectedScope)
+        {
+            return new ActionValidationResult(
+                $"The action '{info.Name}' ({info.Id}) is not applicable to the {expectedScope.ToString().ToLowerInvariant()} scope."
+            );
+        }
+
+        // Trusted programmatic calls (no caller) skip the permission gate; HTTP
+        // invocations always pass the authenticated user.
+        if (caller is not null && info.Permission is ActionPermission.Admin && !caller.IsAdmin)
             return new ActionValidationResult("Administrator privileges are required for this action.");
 
         // Gap 24: Validate runs synchronously, before anything touches the queue.
         // Needs a real instance (not just JobDataJson) since Validate isn't queued —
         // resolved, context-populated, and discarded, same lifetime rules as Gap 9.
-        var probe = (IExecutableAction)_services.GetRequiredService(info.ActionType);
+        var probe = (IExecutableAction)_services.GetRequiredService(registered.ActionType);
         if (probe is IScopedAction scoped && scopeEntity is not null)
             scoped.SetContext(scopeEntity);
         if (probe is IActionCaller callerAware)
+        {
+            if (caller is null)
+                return new ActionValidationResult($"The action '{info.Name}' requires a calling user.");
+
             callerAware.SetCaller(caller);
+        }
 
         var validation = await probe.Validate(token);
         if (validation is not null)
@@ -297,7 +360,7 @@ public class ActionService
                 _ => null,
             };
             j.Scope = info.Scope;
-            j.CallerUserId = caller.ID;
+            j.CallerUserId = caller?.ID ?? 0;
         }, ct: token);
 
         // Gap 7: bare ack — no tracking ID.

--- a/Shoko.Server/Services/ActionService.cs
+++ b/Shoko.Server/Services/ActionService.cs
@@ -184,10 +184,10 @@ public class ActionService : IActionService
     {
         foreach (var (pluginId, actionType) in discoveredActions)
         {
-            // Gap 28: reject any type implementing IScopedAction that isn't one of the
-            // three base classes. Redundant once IScopedAction is `internal` (a plugin
-            // assembly literally cannot implement an internal interface from another
-            // assembly), but kept as a documented, load-time-checked guard.
+            // Reject any type implementing IScopedAction that isn't one of the three base
+            // classes. The guard is redundant — IScopedAction is internal, so a plugin
+            // assembly cannot implement it — but it is intentionally kept so misuse fails
+            // fast at startup instead of at execution time.
             var baseType = actionType.BaseType;
             if (typeof(IScopedAction).IsAssignableFrom(actionType) &&
                 baseType != typeof(SeriesAction) &&
@@ -200,8 +200,8 @@ public class ActionService : IActionService
                 );
             }
 
-            // Gap 21: UUIDv5, deterministic, namespaced by the owning plugin's ID.
-            // Gap 5: not stable across renames/moves, by design.
+            // IDs are UUIDv5, deterministic, namespaced by the owning plugin's ID, and
+            // deliberately not stable across class renames or namespace moves.
             var id = UuidUtility.GetV5(actionType.FullName!, pluginId);
 
             var scope = actionType.IsAssignableTo(typeof(SeriesAction)) ? ActionScope.Series
@@ -211,9 +211,9 @@ public class ActionService : IActionService
 
             var probe = (IExecutableAction)_services.GetRequiredService(actionType);
 
-            // Gap 8/19: no silent default for Permission — every action must declare it on
-            // the type itself. A getter provided by a base type or an interface default is
-            // rejected here at load time.
+            // No silent default for Permission — every action must declare it on the type
+            // itself, and a getter provided by a base type or an interface default is
+            // rejected at load time.
             if (actionType.GetProperty(nameof(IExecutableAction.Permission))?.GetMethod?.DeclaringType != actionType)
             {
                 throw new InvalidOperationException(
@@ -222,9 +222,9 @@ public class ActionService : IActionService
                 );
             }
 
-            // Gap 1/29: PluginInferred resolves to the owning plugin's own display name —
-            // collision-free by construction since plugin names are unique. Anything else
-            // falls back to the category's own name.
+            // PluginInferred resolves to the owning plugin's own display name — collision-free
+            // by construction since plugin names are unique. Anything else falls back to the
+            // category's own name.
             var categoryName = probe.Category is ActionCategory.PluginInferred
                 ? _pluginManager.GetPluginInfo(pluginId)?.Name ?? actionType.Assembly.GetName().Name!
                 : probe.Category.ToString();
@@ -275,12 +275,13 @@ public class ActionService : IActionService
             : throw new KeyNotFoundException($"No action registered for {actionId}");
 
     /// <summary>
-    ///   Populates the action's free-form properties (Gap 23 bucket 2) from an
-    ///   invocation parameter payload. Unknown property names are ignored.
-    /// Used both before <see cref="IExecutableAction.Validate"/> runs on the
-    /// probe instance and before <see cref="IExecutableAction.Execute"/> runs
-    /// inside <see cref="ActionExecutionJob"/>, so both observe the same
-    /// caller-supplied values.
+    ///   Populates the action's free-form properties (the open-ended invocation
+    ///   parameter case) from a parameter payload. Unknown property names are
+    ///   ignored. Used both before <see cref="IExecutableAction.Validate"/>
+    ///   runs on the probe instance and before
+    ///   <see cref="IExecutableAction.Execute"/> runs inside
+    ///   <see cref="ActionExecutionJob"/>, so both observe the same
+    ///   caller-supplied values.
     /// </summary>
     internal static void PopulateParameters(IExecutableAction action, IReadOnlyDictionary<string, object?>? parameters)
     {
@@ -362,9 +363,9 @@ public class ActionService : IActionService
         if (caller is not null && info.Permission is ActionPermission.Admin && !caller.IsAdmin)
             return new ActionValidationResult("Administrator privileges are required for this action.");
 
-        // Gap 24: Validate runs synchronously, before anything touches the queue.
-        // Needs a real instance (not just JobDataJson) since Validate isn't queued —
-        // resolved, context-populated, and discarded, same lifetime rules as Gap 9.
+        // Validate runs synchronously, before anything touches the queue. It needs a
+        // real instance (not just JobDataJson) since Validate isn't queued — resolved,
+        // context-populated, and discarded, with the same transient lifetime as execution.
         var probe = (IExecutableAction)_services.GetRequiredService(registered.ActionType);
         if (probe is IScopedAction scoped && scopeEntity is not null)
             scoped.SetContext(scopeEntity);
@@ -384,8 +385,9 @@ public class ActionService : IActionService
         if (validation is not null)
             return validation;
 
-        // Gap 15: always queued from here on. ActionExecutionJob re-resolves a fresh
-        // instance later (Gap 9: transient) — the probe instance above is discarded.
+        // Always queued from here on — there is no direct-execution path. The job
+        // re-resolves a fresh transient instance later; the probe instance above is
+        // discarded.
         await _scheduler.Enqueue<ActionExecutionJob>(j =>
         {
             j.ActionId = actionId;
@@ -401,7 +403,7 @@ public class ActionService : IActionService
             j.Parameters = parameters?.ToDictionary(pair => pair.Key, pair => pair.Value);
         }, ct: token);
 
-        // Gap 7: bare ack — no tracking ID.
+        // Bare ack — no tracking ID.
         return null;
     }
 

--- a/Shoko.Server/Services/ActionService.cs
+++ b/Shoko.Server/Services/ActionService.cs
@@ -2,13 +2,18 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Shoko.Abstractions.Actions;
 using Shoko.Abstractions.Extensions;
 using Shoko.Abstractions.Metadata.Anidb.Enums;
 using Shoko.Abstractions.Metadata.Anidb.Services;
 using Shoko.Abstractions.Metadata.Services;
 using Shoko.Abstractions.Plugin;
+using Shoko.Abstractions.User;
+using Shoko.Abstractions.Utilities;
 using Shoko.Abstractions.Video.Services;
 using Shoko.QueueProcessor.Abstractions;
 using Shoko.QueueProcessor.Scheduling;
@@ -54,6 +59,17 @@ public class ActionService
 
     private readonly IPluginPackageManager _pluginPackageManager;
 
+    private readonly IPluginManager _pluginManager;
+
+    private readonly IServiceProvider _services;
+
+    /// <summary>
+    ///   Registered action types and their metadata. Populated once during
+    ///   <see cref="AddParts"/>. A fresh transient instance is resolved from
+    ///   DI for every validation and execution.
+    /// </summary>
+    private readonly Dictionary<Guid, ExecutableActionInfo> _actions = new();
+
     private readonly VideoLocalRepository _videoLocals;
 
     private readonly VideoLocal_PlaceRepository _videoLocalPlaces;
@@ -93,6 +109,8 @@ public class ActionService
         DatabaseFactory databaseFactory,
         HttpXmlUtils xmlUtils,
         IPluginPackageManager pluginPackageManager,
+        IPluginManager pluginManager,
+        IServiceProvider services,
         VideoLocalRepository videoLocals,
         VideoLocal_PlaceRepository videoLocalPlaces,
         StoredReleaseInfoRepository storedReleaseInfos,
@@ -120,6 +138,8 @@ public class ActionService
         _databaseFactory = databaseFactory;
         _xmlUtils = xmlUtils;
         _pluginPackageManager = pluginPackageManager;
+        _pluginManager = pluginManager;
+        _services = services;
         _videoLocals = videoLocals;
         _videoLocalPlaces = videoLocalPlaces;
         _storedReleaseInfos = storedReleaseInfos;
@@ -134,6 +154,157 @@ public class ActionService
         _scheduledUpdates = scheduledUpdates;
         _anidbAnimeRelations = anidbAnimeRelations;
     }
+
+    #region Action Registry
+
+    /// <summary>
+    ///   Registers discovered action types and validates them. Called from
+    ///   <c>PluginManager.InitPlugins</c> for core and plugin-provided
+    ///   actions alike.
+    /// </summary>
+    /// <remarks>
+    ///   Fails fast with a named error when a registered type breaks one of
+    ///   the load-time rules, rather than a NRE three weeks in.
+    /// </remarks>
+    /// <param name="discoveredActions">
+    ///   The discovered action types and the ID of the plugin that owns them.
+    /// </param>
+    public void AddParts(IEnumerable<(Guid PluginId, Type ActionType)> discoveredActions)
+    {
+        foreach (var (pluginId, actionType) in discoveredActions)
+        {
+            // Gap 28: reject any type implementing IScopedAction that isn't one of the
+            // three base classes. Redundant once IScopedAction is `internal` (a plugin
+            // assembly literally cannot implement an internal interface from another
+            // assembly), but kept as a documented, load-time-checked guard.
+            var baseType = actionType.BaseType;
+            if (typeof(IScopedAction).IsAssignableFrom(actionType) &&
+                baseType != typeof(SeriesAction) &&
+                baseType != typeof(GroupAction) &&
+                baseType != typeof(EpisodeAction))
+            {
+                throw new InvalidOperationException(
+                    $"Action type '{actionType.FullName}' implements IScopedAction but does not derive from " +
+                    $"{nameof(SeriesAction)}, {nameof(GroupAction)}, or {nameof(EpisodeAction)}."
+                );
+            }
+
+            // Gap 21: UUIDv5, deterministic, namespaced by the owning plugin's ID.
+            // Gap 5: not stable across renames/moves, by design.
+            var id = UuidUtility.GetV5(actionType.FullName!, pluginId);
+
+            var scope = actionType.IsAssignableTo(typeof(SeriesAction)) ? ActionScope.Series
+                : actionType.IsAssignableTo(typeof(GroupAction)) ? ActionScope.Group
+                : actionType.IsAssignableTo(typeof(EpisodeAction)) ? ActionScope.Episode
+                : ActionScope.Global;
+
+            var probe = (IExecutableAction)_services.GetRequiredService(actionType);
+
+            // Gap 8/19: no silent default for Permission — every action must declare it on
+            // the type itself. A getter provided by a base type or an interface default is
+            // rejected here at load time.
+            if (actionType.GetProperty(nameof(IExecutableAction.Permission))?.GetMethod?.DeclaringType != actionType)
+            {
+                throw new InvalidOperationException(
+                    $"Action type '{actionType.FullName}' does not declare its own Permission. " +
+                    "Every action must state its permission explicitly."
+                );
+            }
+
+            // Gap 1/29: PluginInferred resolves to the owning plugin's own display name —
+            // collision-free by construction since plugin names are unique. Anything else
+            // falls back to the category's own name.
+            var categoryName = probe.Category is ActionCategory.PluginInferred
+                ? _pluginManager.GetPluginInfo(pluginId)?.Name ?? actionType.Assembly.GetName().Name
+                : probe.Category.ToString();
+
+            _actions[id] = new ExecutableActionInfo(
+                id,
+                actionType,
+                scope,
+                pluginId,
+                probe.Name,
+                probe.Description,
+                probe.Category,
+                categoryName,
+                probe.Permission,
+                probe.RequiresConfirmation
+            );
+        }
+    }
+
+    /// <summary>
+    ///   Lists registered actions. <paramref name="scope"/> is a filter, not a
+    ///   required partition — omitting it lists every action. Non-admin callers
+    ///   only see actions they may invoke.
+    /// </summary>
+    public IEnumerable<ExecutableActionInfo> GetActions(ActionScope? scope, ActionPermission? callerPermission)
+        => _actions.Values
+            .Where(a => (scope is null || a.Scope == scope) &&
+                        (callerPermission != ActionPermission.User || a.Permission == ActionPermission.User))
+            .OrderBy(a => a.Category)
+            .ThenBy(a => a.CategoryName)
+            .ThenBy(a => a.Name);
+
+    public ExecutableActionInfo? GetActionInfo(Guid actionId)
+        => _actions.TryGetValue(actionId, out var info) ? info : null;
+
+    public string GetActionName(Guid actionId)
+        => _actions.TryGetValue(actionId, out var info) ? info.Name : actionId.ToString();
+
+    /// <summary>
+    ///   The invoke entry point. Scope-agnostic on purpose — the controller
+    ///   resolves <paramref name="scopeEntity"/> (an <see cref="AnimeSeries"/>,
+    ///   <see cref="AnimeGroup"/>, <see cref="AnimeEpisode"/>, or
+    ///   <see langword="null"/> for Global) before calling this.
+    /// </summary>
+    /// <returns>
+    ///   <see langword="null"/> when the action was accepted and enqueued, or a
+    ///   rejection reason — mapped to a 400 by the controller — when the
+    ///   invocation was refused without ever touching the queue.
+    /// </returns>
+    public async Task<ActionValidationResult?> InvokeAsync(Guid actionId, object? scopeEntity, IUser caller, CancellationToken token)
+    {
+        if (!_actions.TryGetValue(actionId, out var info))
+            throw new KeyNotFoundException($"No action registered for {actionId}");
+
+        if (info.Permission is ActionPermission.Admin && !caller.IsAdmin)
+            return new ActionValidationResult("Administrator privileges are required for this action.");
+
+        // Gap 24: Validate runs synchronously, before anything touches the queue.
+        // Needs a real instance (not just JobDataJson) since Validate isn't queued —
+        // resolved, context-populated, and discarded, same lifetime rules as Gap 9.
+        var probe = (IExecutableAction)_services.GetRequiredService(info.ActionType);
+        if (probe is IScopedAction scoped && scopeEntity is not null)
+            scoped.SetContext(scopeEntity);
+        if (probe is IActionCaller callerAware)
+            callerAware.SetCaller(caller);
+
+        var validation = await probe.Validate(token);
+        if (validation is not null)
+            return validation;
+
+        // Gap 15: always queued from here on. ActionExecutionJob re-resolves a fresh
+        // instance later (Gap 9: transient) — the probe instance above is discarded.
+        await _scheduler.Enqueue<ActionExecutionJob>(j =>
+        {
+            j.ActionId = actionId;
+            j.ScopeEntityId = scopeEntity switch
+            {
+                AnimeSeries series => series.AnimeSeriesID,
+                AnimeGroup group => group.AnimeGroupID,
+                AnimeEpisode episode => episode.AnimeEpisodeID,
+                _ => null,
+            };
+            j.Scope = info.Scope;
+            j.CallerUserId = caller.ID;
+        }, ct: token);
+
+        // Gap 7: bare ack — no tracking ID.
+        return null;
+    }
+
+    #endregion
 
     public async Task RunImport_IntegrityCheck()
     {

--- a/Shoko.Server/Services/ExecutableActionInfo.cs
+++ b/Shoko.Server/Services/ExecutableActionInfo.cs
@@ -1,0 +1,55 @@
+using System;
+using Shoko.Abstractions.Actions;
+
+namespace Shoko.Server.Services;
+
+/// <summary>
+///   Metadata for a registered executable action, cached at registration time
+///   in <see cref="ActionService.AddParts"/> so listings never need to
+///   resolve an instance.
+/// </summary>
+/// <param name="Id">
+///   The action's stable UUIDv5 identifier, derived from the action type's
+///   fully-qualified name namespaced by the owning plugin's ID.
+/// </param>
+/// <param name="ActionType">
+///   The concrete action type, resolved transiently from DI per execution.
+/// </param>
+/// <param name="Scope">
+///   The entity level the action is bound to.
+/// </param>
+/// <param name="PluginId">
+///   The ID of the plugin that owns the action.
+/// </param>
+/// <param name="Name">
+///   The action's display name.
+/// </param>
+/// <param name="Description">
+///   The action's description.
+/// </param>
+/// <param name="Category">
+///   The action's category.
+/// </param>
+/// <param name="CategoryName">
+///   The resolved display name for the category — the owning plugin's name
+///   for <see cref="ActionCategory.PluginInferred"/>, otherwise the
+///   category's own name.
+/// </param>
+/// <param name="Permission">
+///   The permission required to invoke the action.
+/// </param>
+/// <param name="RequiresConfirmation">
+///   UI hint for destructive actions.
+/// </param>
+public record ExecutableActionInfo(
+    Guid Id,
+    Type ActionType,
+    ActionScope Scope,
+    Guid PluginId,
+    string Name,
+    string? Description,
+    ActionCategory Category,
+    string CategoryName,
+    ActionPermission Permission,
+    bool RequiresConfirmation
+);

--- a/Shoko.Server/Services/SystemService.cs
+++ b/Shoko.Server/Services/SystemService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -11,10 +12,12 @@ using MessagePack;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NLog.Extensions.Logging;
 using NLog.Web;
+using Shoko.Abstractions.Actions;
 using Shoko.Abstractions.Config;
 using Shoko.Abstractions.Config.Services;
 using Shoko.Abstractions.Connectivity.Services;
@@ -435,6 +438,15 @@ public class SystemService : ISystemService
             services.AddSingleton<IImageManager, ImageManager>();
             services.AddSingleton<IConnectivityService, ConnectivityService>();
             services.AddScoped<AnimeGroupCreator>();
+
+            // Register all core-provided executable actions as transient services, resolved
+            // fresh from DI per execution. Plugin-provided actions are registered in
+            // PluginManager.RegisterPlugins.
+            foreach (var actionType in typeof(SystemService).Assembly.GetTypes()
+                         .Where(type => type is { IsClass: true, IsAbstract: false } && typeof(IExecutableAction).IsAssignableFrom(type)))
+            {
+                services.TryAddTransient(actionType);
+            }
 
             services.AddRepositories();
             services.AddSentryConfig(settingsProvider);

--- a/Shoko.Server/Services/SystemService.cs
+++ b/Shoko.Server/Services/SystemService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -12,12 +11,11 @@ using MessagePack;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NLog.Extensions.Logging;
 using NLog.Web;
-using Shoko.Abstractions.Actions;
+using Shoko.Abstractions.Actions.Services;
 using Shoko.Abstractions.Config;
 using Shoko.Abstractions.Config.Services;
 using Shoko.Abstractions.Connectivity.Services;
@@ -415,6 +413,7 @@ public class SystemService : ISystemService
             services.AddSingleton<IFuzzySearchService, FuzzySearchService>();
             services.AddSingleton<LegacyFilterConverter>();
             services.AddSingleton<ActionService>();
+            services.AddSingleton<IActionService>(sp => sp.GetRequiredService<ActionService>());
             services.AddSingleton<AnimeSeriesService>();
             services.AddSingleton<AnimeGroupService>();
             services.AddSingleton<ShokoGroupManager>();
@@ -438,15 +437,6 @@ public class SystemService : ISystemService
             services.AddSingleton<IImageManager, ImageManager>();
             services.AddSingleton<IConnectivityService, ConnectivityService>();
             services.AddScoped<AnimeGroupCreator>();
-
-            // Register all core-provided executable actions as transient services, resolved
-            // fresh from DI per execution. Plugin-provided actions are registered in
-            // PluginManager.RegisterPlugins.
-            foreach (var actionType in typeof(SystemService).Assembly.GetTypes()
-                         .Where(type => type is { IsClass: true, IsAbstract: false } && typeof(IExecutableAction).IsAssignableFrom(type)))
-            {
-                services.TryAddTransient(actionType);
-            }
 
             services.AddRepositories();
             services.AddSentryConfig(settingsProvider);


### PR DESCRIPTION
## Summary

Implements the plugin-registrable action system from RFC [#1380](https://github.com/ShokoAnime/ShokoServer/discussions/1380) (spec v7).

- `IExecutableAction` with required `Name`/`Permission`, optional `Validate` pre-check, `RequiresConfirmation` UI hint, and the `SeriesAction`/`GroupAction`/`EpisodeAction` base classes with an internal `IScopedAction` context setter, plus `IActionCaller` for caller identity.
- `ActionService` registration with load-time validation (permission must be declared on the type itself; `IScopedAction` bypasses are rejected), UUIDv5 action IDs namespaced by plugin ID.
- `ActionExecutionJob` — every action always runs through the job queue, deduped by action + scope entity + caller.
- New endpoints: `GET /api/v3/Action?scope=`, `POST /api/v3/Action/{actionId}`, and `POST /api/v3/{Group|Series|Episode}/{id}/Action/{actionId}` — 200 ack / 400 validation rejection / 404 unknown entity, no tracking ID.
- Ported ~60 existing actions from `ActionController` and the scoped controllers to the new shape, using the Gap 23 two-bucket split (variant classes for closed parameter sets, defaults-only or settable properties for open-ended ones). Legacy endpoints remain available, marked `[Obsolete]`.
- Core actions are discovered through the plugin manager like any other plugin — no separate core registration.

## Beyond the RFC (bolt-ons)

The RFC defines the HTTP API and the registration model, but never addresses how **plugins** list or invoke actions programmatically. This PR adds:

- **`IActionService` in `Shoko.Abstractions`** — plugins can enumerate registered actions (`GetActions`/`GetActionInfo`) and invoke them via typed `InvokeAsync` overloads for global/series/group/episode scopes. Invocation still goes through the queue; the result is `null` on acceptance or an `ActionValidationResult` reason on rejection.
- **Invoke-time scope validation** — invoking an action with a mismatched scope (or no entity for a scoped action) is rejected up front instead of failing later with a cast error inside the job.
- **Caller semantics** — `IActionCaller` actions require a non-null caller and are rejected otherwise; trusted programmatic invocations without a caller skip the `Permission` gate.
- **Permission enforcement on the HTTP invoke path** — the RFC models `Permission` but the reference controllers don't enforce it; here admin-only actions are rejected for non-admin callers.

## Notes

- `Shoko.Abstractions` gains `InternalsVisibleTo("Shoko.Server")` so the load-time `IScopedAction` guard (Gap 28) is enforceable from the server.
- Full solution builds; `Shoko.Tests` passes (517/517).
