### PR TITLE
fix(workflows): don't fail nuget publish when release tag already exists

### DIFF
--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -47,3 +47,4 @@ runs:
       with:
         tag: ${{ steps.version.outputs.tag }}
         message: "${{ inputs.project-file-path }} v${{ steps.version.outputs.version }}"
+        tag_exists_error: false


### PR DESCRIPTION
## Summary
- Follow-up to #1401, which replaced the archived `brandedoutcast/publish-nuget` action with a custom composite action.
- Every "Build (Daily)" run since #1401 merged has failed on all four `Publish * Nuget` jobs (`Shoko.Abstractions`, `Shoko.QueueProcessor`, `Shoko.BuildTools`, `Shoko.BuildTools.Targets`): https://github.com/ShokoAnime/ShokoServer/actions/runs/31938406541
- Root cause: `dotnet nuget push --skip-duplicate` correctly tolerates republishing a package whose version wasn't bumped since the last successful run, but the subsequent `rickstaa/action-create-tag@v1` step has no equivalent tolerance — it hard-fails with "Updates were rejected because the tag already exists in the remote" whenever the git tag from that prior publish is still there. This will happen on every daily run between version bumps, so the nuget-publish jobs are currently broken on `master`.
- Fix: set `tag_exists_error: false` on the tag-creation step so it skips (rather than fails) when the tag is already present, matching the idempotent behavior of the push step above it.

## Test plan
- [x] Reproduced the failure by inspecting the two post-#1401 "Build (Daily)" runs on `master`, both failing identically on all four publish jobs with "tag already exists"
- [ ] Next scheduled/triggered "Build (Daily)" run on `master` completes the publish jobs successfully