### PR TITLE
fix(workflows): force-push the release tag on nuget publish

### DIFF
--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -47,4 +47,4 @@ runs:
       with:
         tag: ${{ steps.version.outputs.tag }}
         message: "${{ inputs.project-file-path }} v${{ steps.version.outputs.version }}"
-        tag_exists_error: false
+        force_push_tag: true


### PR DESCRIPTION
## Summary
- Follow-up to #1405, which set `tag_exists_error: false` on the `rickstaa/action-create-tag@v1` step to stop the daily nuget-publish jobs failing on unbumped versions. That did not actually fix it — confirmed on the next "Build (Daily)" run after #1405 merged, still failing identically: https://github.com/ShokoAnime/ShokoServer/actions/runs/31939093126
- Root cause of why #1405 didn't work: `action-create-tag`'s existence check ([entrypoint.sh](https://github.com/rickstaa/action-create-tag/blob/main/entrypoint.sh)) is `git tag -l "${TAG}"` — a **local** tag check. The daily-build runner does a fresh checkout with no tags fetched, so the action always sees the tag as "not existing" locally, takes the create-fresh-tag path, and attempts a plain `git push origin "$TAG"` — which the remote rejects because the tag from the prior publish is already there. `tag_exists_error` only gates the branch that runs when the *local* check finds the tag, so it never even executes.
- Fix: `force_push_tag: true` instead. This unconditionally does `git tag -fa` + `git push --force`, which succeeds regardless of whether the local checkout knows about the existing tag, and is a no-op in practice since it's re-pointing the tag at the same commit it already points to.

## Test plan
- [x] Reproduced #1405 not fixing the issue via the next daily-build run on `master` after it merged
- [ ] Next scheduled/triggered "Build (Daily)" run on `master` completes the publish jobs successfully