### PR TITLE
fix(workflows): match brandedoutcast/publish-nuget's gating 1:1, verify remote tag state

### DIFF
--- a/.github/actions/publish-nuget/action.yml
+++ b/.github/actions/publish-nuget/action.yml
@@ -25,26 +25,79 @@ runs:
       shell: bash
       run: |
         version=$(dotnet msbuild "${{ inputs.project-file-path }}" -nologo -getProperty:Version)
+        packageId=$(dotnet msbuild "${{ inputs.project-file-path }}" -nologo -getProperty:PackageId)
         echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "package-id=$packageId" >> "$GITHUB_OUTPUT"
         echo "tag=${TAG_FORMAT/\*/$version}" >> "$GITHUB_OUTPUT"
       env:
         TAG_FORMAT: ${{ inputs.tag-format }}
 
+    # Matches brandedoutcast/publish-nuget's original gating: skip publishing entirely
+    # if this version is already on NuGet.org.
+    - name: Check if version is already published
+      id: check
+      shell: bash
+      run: |
+        set -euo pipefail
+        package_id_lower=$(echo "${{ steps.version.outputs.package-id }}" | tr '[:upper:]' '[:lower:]')
+        status=$(curl -s -o /tmp/nuget-versions.json -w '%{http_code}' \
+          "https://api.nuget.org/v3-flatcontainer/${package_id_lower}/index.json")
+
+        if [ "$status" = "404" ]; then
+          echo "already-published=false" >> "$GITHUB_OUTPUT" # package has no published versions yet
+        elif [ "$status" = "200" ]; then
+          if jq -e --arg v "${{ steps.version.outputs.version }}" '.versions | index($v)' /tmp/nuget-versions.json > /dev/null; then
+            echo "already-published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already-published=false" >> "$GITHUB_OUTPUT"
+          fi
+        else
+          echo "::error::Unexpected HTTP $status querying NuGet.org for ${{ steps.version.outputs.package-id }}"
+          exit 1
+        fi
+
     - name: Pack
+      if: steps.check.outputs.already-published != 'true'
       shell: bash
       run: dotnet pack -c Release "${{ inputs.project-file-path }}" -o ./nupkg
 
     - name: Push
+      if: steps.check.outputs.already-published != 'true'
       shell: bash
       run: dotnet nuget push "./nupkg/*.nupkg" --api-key "${{ inputs.nuget-key }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Clean up package output
+      if: steps.check.outputs.already-published != 'true'
       shell: bash
       run: rm -rf ./nupkg
 
+    # Queries the remote tag instead of the local checkout, which has no tag history.
+    # For an annotated tag, ls-remote also returns its peeled ^{} commit ref — tail -1
+    # picks that commit SHA over the tag object's own SHA.
+    - name: Check remote tag state
+      id: tagcheck
+      if: steps.check.outputs.already-published != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        tag="${{ steps.version.outputs.tag }}"
+        remote_sha=$(git ls-remote origin "refs/tags/${tag}" "refs/tags/${tag}^{}" | tail -1 | cut -f1)
+
+        if [ -n "$remote_sha" ]; then
+          if [ "$remote_sha" = "${{ github.sha }}" ]; then
+            echo "Tag '${tag}' already points at this commit — nothing to do."
+            echo "should-tag=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::error::Tag '${tag}' already exists on the remote and points at a different commit ($remote_sha) than this build (${{ github.sha }}). Refusing to overwrite it."
+          exit 1
+        fi
+
+        echo "should-tag=true" >> "$GITHUB_OUTPUT"
+
     - name: Tag release
+      if: steps.check.outputs.already-published != 'true' && steps.tagcheck.outputs.should-tag == 'true'
       uses: rickstaa/action-create-tag@v1
       with:
         tag: ${{ steps.version.outputs.tag }}
         message: "${{ inputs.project-file-path }} v${{ steps.version.outputs.version }}"
-        force_push_tag: true


### PR DESCRIPTION
## Summary
- Follow-up to #1406. Thanks @revam for flagging: `force_push_tag: true` does actually work (the force-push branch in `action-create-tag`'s entrypoint never reads its own local-only `tag_exists` check — it always force-tags+pushes when `force_push_tag` is set), but it does so **blindly**, with no comparison against what the remote tag currently points to. Since this repo's checkout intentionally doesn't fetch tag history, there was no way to detect if a release tag ever ended up pointing at an unexpected commit (manual retag, a bug elsewhere) — this workflow would silently force it back to the new commit with no warning, masking a real problem instead of surfacing it.
- Adds a "Check remote tag state" step ahead of the existing `rickstaa/action-create-tag` step (kept in place, not replaced): queries the remote tag directly via `git ls-remote` (a lightweight network call — no history fetch) and only lets the tag step run when the remote either doesn't have the tag yet or already points at the exact commit being published. If it points anywhere else, the job fails loudly instead of letting the tag step overwrite it.
- `git ls-remote origin "refs/tags/$TAG" "refs/tags/$TAG^{}"` returns two lines for an annotated tag (the tag-object SHA and its peeled `^{}` commit SHA) — `tail -1` picks the commit SHA in both the annotated and lightweight cases. Verified this against upstream's actual `Shoko.Abstractions-v6.0.0-alpha.77` tag.
- **Also restores 1:1 parity with the archived `brandedoutcast/publish-nuget` action**, which #1401 didn't actually achieve: that action queried NuGet.org's own version index up front and skipped pack/push/tag *entirely* for an already-published version, so an unchanged-version day was a silent no-op. The composite action always ran pack/push/tag unconditionally and relied only on `dotnet nuget push --skip-duplicate` to no-op the *package* push, while the tag step still ran every single time regardless — that decoupling is the actual root cause of the whole `Shoko.Abstractions-v6.0.0-alpha.77` tag conflict across #1401/#1405/#1406. Added a "Check if version is already published" step that queries `https://api.nuget.org/v3-flatcontainer/{packageId}/index.json` and gates Pack/Push/Tag on the version being genuinely new — matching the old action's behavior instead of approximating it.
- The `git ls-remote` tag check stays as a second line of defense on top of the NuGet.org gate — it still protects the tag from being clobbered even on an unexpected rerun.

## Test plan
- [x] Verified the `git ls-remote` resolution logic against three simulated cases on a local checkout that exactly replicates CI's shallow, tags-excluded `actions/checkout@v7` default: a brand-new tag (creates+pushes, exit 0), an idempotent same-commit rerun (skips cleanly, exit 0), and a tag pointing at a different commit (fails loudly, remote tag confirmed unmoved)
- [x] Verified the NuGet.org version-check logic against real data: an existing package+version (`shoko.abstractions` / `6.0.0-alpha.77`, found), a nonexistent version (not found), and a nonexistent package (`404`, handled explicitly)
- [ ] Next "Build (Daily)" run on `master` completes the publish jobs successfully (idempotent re-publish case, unchanged version)

