### PR TITLE
feat(api): move release group endpoints into ReleaseInfo with source filtering

### DIFF
--- a/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation_Utilities.cs
+++ b/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation_Utilities.cs
@@ -126,7 +126,7 @@ public partial class ShokoServiceImplementation
     [HttpGet("ReleaseGroups")]
     public List<string> GetAllReleaseGroups()
     {
-        return RepoFactory.StoredReleaseInfo.GetUsedReleaseGroups().Select(r => r.Name).ToList();
+        return RepoFactory.StoredReleaseInfo.GetUsedReleaseGroups(null).Select(r => r.Name).ToList();
     }
 
     [HttpGet("File/DeleteMultipleFilesWithPreferences/{userID}")]

--- a/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation_Utilities.cs
+++ b/Shoko.Server/API/v1/Implementations/ShokoServiceImplementation_Utilities.cs
@@ -126,7 +126,7 @@ public partial class ShokoServiceImplementation
     [HttpGet("ReleaseGroups")]
     public List<string> GetAllReleaseGroups()
     {
-        return RepoFactory.StoredReleaseInfo.GetUsedReleaseGroups(null).Select(r => r.Name).ToList();
+        return RepoFactory.StoredReleaseInfo.GetUsedReleaseGroups(new HashSet<string> { "AniDB" }).Select(r => r.Name).ToList();
     }
 
     [HttpGet("File/DeleteMultipleFilesWithPreferences/{userID}")]

--- a/Shoko.Server/API/v3/Controllers/AniDBController.cs
+++ b/Shoko.Server/API/v3/Controllers/AniDBController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
@@ -55,19 +56,21 @@ public class AniDBController(
     /// <param name="page">The page index.</param>
     /// <param name="includeMissing">Include missing release groups.</param>
     /// <returns></returns>
+    [Obsolete("Deprecated in favor of the release info API. Will be removed in a future version.")]
     [HttpGet("ReleaseGroup")]
     public ActionResult<ListResult<ReleaseGroup>> GetReleaseGroups(
         [FromQuery, Range(0, 1000)] int pageSize = 20,
         [FromQuery, Range(1, int.MaxValue)] int page = 1,
         [FromQuery] IncludeOnlyFilter includeMissing = IncludeOnlyFilter.False)
     {
+        var anidb = new HashSet<string> { "AniDB" };
         return includeMissing switch
         {
-            IncludeOnlyFilter.False => storedReleaseInfos.GetUsedReleaseGroups()
+            IncludeOnlyFilter.False => storedReleaseInfos.GetUsedReleaseGroups(anidb)
                 .ToListResult(g => new ReleaseGroup(g), page, pageSize),
-            IncludeOnlyFilter.Only => storedReleaseInfos.GetUnusedReleaseGroups()
+            IncludeOnlyFilter.Only => storedReleaseInfos.GetUnusedReleaseGroups(anidb)
                 .ToListResult(g => new ReleaseGroup(g), page, pageSize),
-            _ => storedReleaseInfos.GetReleaseGroups()
+            _ => storedReleaseInfos.GetReleaseGroups(anidb)
                 .ToListResult(g => new ReleaseGroup(g), page, pageSize),
         };
     }
@@ -77,6 +80,7 @@ public class AniDBController(
     /// </summary>
     /// <param name="groupID">The release group id.</param>
     /// <returns></returns>
+    [Obsolete("Deprecated in favor of the release info API. Will be removed in a future version.")]
     [HttpGet("ReleaseGroup/{groupID}")]
     public ActionResult<ReleaseGroup> GetReleaseGroup(int groupID)
     {

--- a/Shoko.Server/API/v3/Controllers/ReleaseInfoController.cs
+++ b/Shoko.Server/API/v3/Controllers/ReleaseInfoController.cs
@@ -22,6 +22,7 @@ using Shoko.Server.Repositories.Cached;
 using Shoko.Server.Settings;
 
 using ReleaseInfo = Shoko.Server.API.v3.Models.Release.ReleaseInfo;
+using ReleaseGroup = Shoko.Server.API.v3.Models.Release.ReleaseGroup;
 
 namespace Shoko.Server.API.v3.Controllers;
 
@@ -32,11 +33,12 @@ namespace Shoko.Server.API.v3.Controllers;
 /// <param name="pluginManager">Plugin manager.</param>
 /// <param name="videoReleaseService">Video release service.</param>
 /// <param name="videoRepository">Video repository.</param>
+/// <param name="storedReleaseInfos">Stored release info repository.</param>
 [ApiController]
 [Route("/api/v{version:apiVersion}/[controller]")]
 [ApiV3]
 [Authorize]
-public class ReleaseInfoController(ISettingsProvider settingsProvider, IPluginManager pluginManager, IVideoReleaseService videoReleaseService, VideoLocalRepository videoRepository) : BaseController(settingsProvider)
+public class ReleaseInfoController(ISettingsProvider settingsProvider, IPluginManager pluginManager, IVideoReleaseService videoReleaseService, VideoLocalRepository videoRepository, StoredReleaseInfoRepository storedReleaseInfos) : BaseController(settingsProvider)
 {
     /// <summary>
     /// Gets a summary of the release information service's properties.
@@ -379,5 +381,50 @@ public class ReleaseInfoController(ISettingsProvider settingsProvider, IPluginMa
     )
         => videoReleaseService.GetAllReleases(releaseProviders)
             .ToListResult(r => new ReleaseInfo(r), page, pageSize);
+
+    /// <summary>
+    /// Get the known release groups stored in Shoko.
+    /// </summary>
+    /// <param name="pageSize">Limits the number of results per page. Set to 0 to disable the limit.</param>
+    /// <param name="page">Page number.</param>
+    /// <param name="includeMissing">Include missing release groups.</param>
+    /// <param name="source">Optional. Filter to only include release groups from the given sources.</param>
+    /// <returns>A sliced part of the results for the current query.</returns>
+    [HttpGet("ReleaseGroup")]
+    public ActionResult<ListResult<ReleaseGroup>> GetReleaseGroups(
+        [FromQuery, Range(0, 1000)] int pageSize = 20,
+        [FromQuery, Range(1, int.MaxValue)] int page = 1,
+        [FromQuery] IncludeOnlyFilter includeMissing = IncludeOnlyFilter.False,
+        [FromQuery, ModelBinder(typeof(CommaDelimitedModelBinder))] List<string>? source = null)
+    {
+        var sources = source is { Count: > 0 } ? source.ToHashSet() : null;
+        return includeMissing switch
+        {
+            IncludeOnlyFilter.False => storedReleaseInfos.GetUsedReleaseGroups(sources)
+                .ToListResult(g => new ReleaseGroup(g), page, pageSize),
+            IncludeOnlyFilter.Only => storedReleaseInfos.GetUnusedReleaseGroups(sources)
+                .ToListResult(g => new ReleaseGroup(g), page, pageSize),
+            _ => storedReleaseInfos.GetReleaseGroups(sources)
+                .ToListResult(g => new ReleaseGroup(g), page, pageSize),
+        };
+    }
+
+    /// <summary>
+    /// Get a release group by its source and ID.
+    /// </summary>
+    /// <param name="source">The release group source.</param>
+    /// <param name="groupID">The release group ID.</param>
+    /// <returns>The release group, or a 404 response if it was not found.</returns>
+    [ProducesResponseType(404)]
+    [ProducesResponseType(typeof(ReleaseGroup), 200)]
+    [HttpGet("ReleaseGroup/{source}/{groupID}")]
+    public ActionResult<ReleaseGroup> GetReleaseGroup([FromRoute] string source, [FromRoute] string groupID)
+    {
+        var releaseInfo = storedReleaseInfos.GetByGroupAndProviderIDs(groupID, source).FirstOrDefault();
+        if (releaseInfo is not IReleaseInfo { Group: { } group })
+            return NotFound();
+
+        return new ReleaseGroup(group);
+    }
 }
 

--- a/Shoko.Server/Filters/ExpressionDiscovery.cs
+++ b/Shoko.Server/Filters/ExpressionDiscovery.cs
@@ -147,7 +147,7 @@ internal static class ExpressionDiscovery
 
             nameof(HasReleaseGroupNameExpression) =>
             (
-                RepoFactory.StoredReleaseInfo.GetUsedReleaseGroups()
+                RepoFactory.StoredReleaseInfo.GetUsedReleaseGroups(null)
                     .Select(r => r.Name)
                     .ToArray(),
                 null,

--- a/Shoko.Server/Repositories/Cached/StoredReleaseInfoRepository.cs
+++ b/Shoko.Server/Repositories/Cached/StoredReleaseInfoRepository.cs
@@ -77,29 +77,22 @@ public class StoredReleaseInfoRepository : BaseCachedRepository<StoredReleaseInf
             ? _anidbAnimeIDs!.GetMultiple(animeId)
             : [];
 
-    public IReadOnlyList<IReleaseGroup> GetReleaseGroups()
-        => GetAll()
-            .Select(a => a is IReleaseInfo { Group.Source: "AniDB" } releaseInfo ? releaseInfo.Group : null)
-            .WhereNotNull()
-            .DistinctBy(g => (g.ID, g.Source))
-            .OrderBy(g => g.Name)
-            .ThenBy(g => g.ShortName)
-            .ThenBy(g => g.ID)
-            .ToList();
+    public IReadOnlyList<IReleaseGroup> GetReleaseGroups(IReadOnlySet<string>? sources)
+        => GetReleaseGroupsCore(sources, null);
 
-    public IReadOnlyList<IReleaseGroup> GetUsedReleaseGroups()
-        => GetAll()
-            .Select(a => a is IReleaseInfo { Group.Source: "AniDB" } releaseInfo && RepoFactory.VideoLocal.GetByEd2kAndSize(a.ED2K, a.FileSize) is { } ? releaseInfo.Group : null)
-            .WhereNotNull()
-            .DistinctBy(g => (g.ID, g.Source))
-            .OrderBy(g => g.Name)
-            .ThenBy(g => g.ShortName)
-            .ThenBy(g => g.ID)
-            .ToList();
+    public IReadOnlyList<IReleaseGroup> GetUsedReleaseGroups(IReadOnlySet<string>? sources)
+        => GetReleaseGroupsCore(sources, true);
 
-    public IReadOnlyList<IReleaseGroup> GetUnusedReleaseGroups()
+    public IReadOnlyList<IReleaseGroup> GetUnusedReleaseGroups(IReadOnlySet<string>? sources)
+        => GetReleaseGroupsCore(sources, false);
+
+    private IReadOnlyList<IReleaseGroup> GetReleaseGroupsCore(IReadOnlySet<string>? sources, bool? isUsed)
         => GetAll()
-            .Select(a => a is IReleaseInfo { Group.Source: "AniDB" } releaseInfo && RepoFactory.VideoLocal.GetByEd2kAndSize(a.ED2K, a.FileSize) is not { } ? releaseInfo.Group : null)
+            .Select(a => a is IReleaseInfo { Group: { } group }
+                && (sources is null || sources.Contains(group.Source))
+                && (isUsed is null || RepoFactory.VideoLocal.GetByEd2kAndSize(a.ED2K, a.FileSize) is { } == isUsed.Value)
+                ? group
+                : null)
             .WhereNotNull()
             .DistinctBy(g => (g.ID, g.Source))
             .OrderBy(g => g.Name)


### PR DESCRIPTION
## Summary

Moves the AniDB release group endpoints into the release info API and generalizes them so they are no longer hardcoded to AniDB groups. Clients can now filter release groups by their `Source` (e.g. `AniDB`, `User`, or plugin-defined sources) instead of always receiving AniDB-only results.

## New endpoints

### `GET /api/v3/ReleaseInfo/ReleaseGroup`

Lists the release groups known to Shoko.

| Parameter | Type | Default | Description |
| --- | --- | --- | --- |
| `pageSize` | `int` | `20` | Number of results per page. Set to `0` to disable pagination. |
| `page` | `int` | `1` | Page index. |
| `includeMissing` | `IncludeOnlyFilter` | `false` | `false` = used groups, `only` = unused groups, `true` = all. |
| `source` | comma-delimited `string` | *(all sources)* | Filters to the given group sources. |

Example: `GET /api/v3/ReleaseInfo/ReleaseGroup?source=AniDB&includeMissing=true`

### `GET /api/v3/ReleaseInfo/ReleaseGroup/{source}/{groupID}`

Returns a single release group identified by its source and ID.

- `source` — the release group source (e.g. `AniDB`, `User`).
- `groupID` — the release group ID.

Returns `404` when no group matches.

Example: `GET /api/v3/ReleaseInfo/ReleaseGroup/AniDB/69`

## Deprecated endpoints

- `GET /api/v3/AniDB/ReleaseGroup`
- `GET /api/v3/AniDB/ReleaseGroup/{groupID}`

Both are now marked `[Obsolete]` and will be removed in a future version. Their behavior is unchanged until then.

## Why `source` + `ID` for the detail endpoint

A release group's identity is the `(GroupID, GroupSource)` pair — `GroupID` alone is **not** unique across sources (the repository index is keyed on `(GroupID, GroupSource)`, and results are deduplicated by that pair). The detail endpoint therefore takes both a `source` and a `groupID`.

This also fixes a latent bug in the old `GET /api/v3/AniDB/ReleaseGroup/{groupID}` endpoint, which pattern-matched the returned collection as a single `IReleaseInfo` (never true), so it always returned `404`.

## Behavior changes for existing consumers

- `ExpressionDiscovery` (`HasReleaseGroupNameExpression` autocomplete) now returns **used** release groups from **all** sources, instead of only AniDB used groups. The v1 `GET /api/v1/ReleaseGroups` endpoint is unchanged (still returns AniDB used groups only).

## Repository changes

`StoredReleaseInfoRepository`'s three release group queries (`GetReleaseGroups`, `GetUsedReleaseGroups`, `GetUnusedReleaseGroups`) now accept an optional `IReadOnlySet<string>?` source filter and share a single `GetReleaseGroupsCore` implementation. The old parameterless AniDB-only overloads were removed; the obsolete AniDB endpoint and the v1 endpoint now pass `"AniDB"` explicitly.

## Testing

- `dotnet build Shoko.Server.sln` — succeeds with 0 errors.
