### PR TITLE
fix(search): match titles when the query carries a trailing qualifier

### DIFF
--- a/Shoko.Server/Utilities/FuzzySearchIndex.cs
+++ b/Shoko.Server/Utilities/FuzzySearchIndex.cs
@@ -143,9 +143,8 @@ public class FuzzySearchIndex<T>
                         Result = item,
                     };
                 }
-                else if (fuzzy && normalized.Length >= normalizedQuery.Length - maxErrors && SeriesSearch.IsLatinScript(normalized))
+                else if (fuzzy && SeriesSearch.IsLatinScript(normalized) && SeriesSearch.TryGetFuzzyDistance(normalizedQuery, normalized, out var dist))
                 {
-                    var dist = SeriesSearch.MinEditDistInText(normalizedQuery, normalized);
                     if (dist > maxErrors)
                         continue;
 

--- a/Shoko.Server/Utilities/SeriesSearch.cs
+++ b/Shoko.Server/Utilities/SeriesSearch.cs
@@ -148,6 +148,42 @@ public static class SeriesSearch
         return min;
     }
 
+    /// <summary>
+    /// Computes the edit distance between a normalized query and a normalized title,
+    /// treating leading and trailing slop on whichever of the two is longer as free.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="MinEditDistInText"/> only skips a free prefix/suffix in the text, so a
+    /// query carrying tokens the title lacks — e.g. "Sousou no Frieren (2023)" against
+    /// "Sousou no Frieren" — is charged for every extra character and blows past
+    /// <see cref="GetMaxErrors"/>. Searching the longer of the two for the shorter one
+    /// makes the comparison symmetric, at the cost of needing a length guard so a
+    /// two-letter title such as "GK" doesn't match nearly every query.
+    /// </remarks>
+    /// <param name="normalizedQuery">The normalized query.</param>
+    /// <param name="normalizedTitle">The normalized title.</param>
+    /// <param name="distance">The resulting distance, if the two are comparable.</param>
+    /// <returns><c>true</c> if the two are comparable in length, otherwise <c>false</c>.</returns>
+    internal static bool TryGetFuzzyDistance(string normalizedQuery, string normalizedTitle, out int distance)
+    {
+        if (normalizedTitle.Length >= normalizedQuery.Length)
+        {
+            distance = MinEditDistInText(normalizedQuery, normalizedTitle);
+            return true;
+        }
+
+        // Ignoring the query's slop is only reasonable while the title still accounts for
+        // most of the query; otherwise every short title matches every long query.
+        if (normalizedTitle.Length * 2 < normalizedQuery.Length)
+        {
+            distance = 0;
+            return false;
+        }
+
+        distance = MinEditDistInText(normalizedTitle, normalizedQuery);
+        return true;
+    }
+
     public static SearchResult<T> DiceFuzzySearch<T>(string text, string pattern, T value)
     {
         if (string.IsNullOrWhiteSpace(text) || string.IsNullOrWhiteSpace(pattern))
@@ -293,9 +329,8 @@ public static class SeriesSearch
                                 Result = t,
                             };
                         }
-                        else if (fuzzy && IsLatinScript(normalizedTitle) && normalizedTitle.Length >= normalizedSearch.Length - maxErrors)
+                        else if (fuzzy && IsLatinScript(normalizedTitle) && TryGetFuzzyDistance(normalizedSearch, normalizedTitle, out var dist))
                         {
-                            var dist = MinEditDistInText(normalizedSearch, normalizedTitle);
                             if (dist > maxErrors)
                                 continue;
                             result = new SearchResult<T>

--- a/Shoko.Tests/FuzzySearchIndexTests.cs
+++ b/Shoko.Tests/FuzzySearchIndexTests.cs
@@ -134,6 +134,29 @@ public class FuzzySearchIndexTests
     public void MinEditDistInText_ReturnsCorrectEditCount(string query, string text, int expected)
         => Assert.Equal(expected, SeriesSearch.MinEditDistInText(query, text));
 
+    // ── TryGetFuzzyDistance ──────────────────────────────────────────────────
+
+    [Theory]
+    // Title at least as long as the query — free slop in the title, same as MinEditDistInText.
+    [InlineData("bleach", "bleach the movie memories of nobody", true, 0)]
+    [InlineData("kimetzu", "kimetsu no yaiba", true, 1)]
+    // Query longer than the title — the slop moves to the query and is free.
+    [InlineData("sousou no frieren 2023", "sousou no frieren", true, 0)]
+    [InlineData("bleach 2004", "bleach", true, 0)]
+    [InlineData("steins gate 2011", "steins gate", true, 0)]
+    // Query longer than the title, with a typo on top of the trailing slop.
+    [InlineData("stiens gate 2011", "steins gate", true, 1)]
+    // Title shorter than half the query — too little to say anything, so no distance.
+    [InlineData("gate keepers 2000", "gk", false, 0)]
+    [InlineData("bleach thousand year blood war", "bleach", false, 0)]
+    public void TryGetFuzzyDistance_IsSymmetricWithinTheLengthGuard(string query, string title, bool expectedComparable, int expectedDistance)
+    {
+        var comparable = SeriesSearch.TryGetFuzzyDistance(query, title, out var distance);
+        Assert.Equal(expectedComparable, comparable);
+        if (expectedComparable)
+            Assert.Equal(expectedDistance, distance);
+    }
+
     // ── Exact and substring search ───────────────────────────────────────────
 
     [Theory]
@@ -291,5 +314,60 @@ public class FuzzySearchIndexTests
     {
         // Trigrams of this nonsense string ("zzk", "zkz", "kzq", ...) do not appear in any test title.
         Assert.Empty(Search("zzzkzqxqzqxkzqxq"));
+    }
+
+    // ── Trailing qualifiers in the query (e.g. " (<year>)") ──────────────────
+
+    [Theory]
+    // The year is not part of any stored title, so the query is longer than everything it should match.
+    [InlineData("Bleach (2004)", 2369)]
+    [InlineData("Steins;Gate (2011)", 9018)]
+    [InlineData("Ramen Aka Neko (2024)", 18289)]
+    [InlineData("Gate Keepers (2000)", 91)]
+    [InlineData("Whisper Me a Love Song (2024)", 17819)]
+    // Brackets and a bare year normalize to the same thing as parentheses.
+    [InlineData("Ramen Aka Neko [2024]", 18289)]
+    [InlineData("Ramen Aka Neko 2024", 18289)]
+    // A typo on top of the trailing year still lands within the error budget.
+    [InlineData("Stiens Gate (2011)", 9018)]
+    // Other trailing qualifiers behave the same way.
+    [InlineData("Gate Keepers (TV)", 91)]
+    public void Search_QueryWithTrailingQualifier_StillFindsAnime(string query, int expectedAnimeId)
+    {
+        var results = Search(query).ToList();
+        Assert.Contains(results, r => r.Result.AnimeId == expectedAnimeId);
+    }
+
+    [Fact]
+    public void Search_TitleWithYearMatchedByQueryWithout_StillFindsAnime()
+    {
+        // The mirror case: "Boku no Hero Academia (2024)" is the stored title.
+        var results = Search("Boku no Hero Academia").ToList();
+        Assert.Contains(results, r => r.Result.AnimeId == 17931);
+    }
+
+    [Fact]
+    public void Search_TrailingQualifier_DoesNotSetExactMatchFlag()
+    {
+        // The year is slop, not a substring match, so it must not rank as an exact hit.
+        var results = Search("Ramen Aka Neko (2024)").ToList();
+        var target = results.First(r => r.Result.AnimeId == 18289);
+        Assert.False(target.ExactMatch);
+    }
+
+    [Fact]
+    public void Search_NonFuzzy_TrailingQualifierDoesNotMatch()
+    {
+        // Tolerating the trailing year is a fuzzy affordance; strict mode must stay strict.
+        var results = Search("Bleach (2004)", fuzzy: false).ToList();
+        Assert.DoesNotContain(results, r => r.Result.AnimeId == 2369);
+    }
+
+    [Fact]
+    public void Search_ShortTitle_DoesNotMatchMuchLongerQuery()
+    {
+        // "GK" is short enough that free query slop would otherwise match nearly anything.
+        var results = Search("GK Gekijouban Blue Lock Episode Nagi").ToList();
+        Assert.DoesNotContain(results, r => r.Result.AnimeId == 91);
     }
 }


### PR DESCRIPTION
Since `dc486893c` ("Better Fuzzy Search"), a query carrying a trailing token the stored title lacks — most visibly a ` (<year>)` — returns nothing at all.

| Query | Stored title | Before | After |
|---|---|---|---|
| `Sousou no Frieren (2023)` | `Sousou no Frieren` | **miss** | match |
| `Boku no Hero Academia (2024)` | `Boku no Hero Academia` | **miss** | match |
| `Bleach (2004)` | `Bleach` | **miss** | match |
| `Steins;Gate (2011)` | `Steins;Gate` | **miss** | match |
| `Sousou no Frieren` | `Sousou no Frieren (2023)` | match | match |

The mirror direction always worked, which is why this went unnoticed — a series *stored* with a year in its title is still found by a query without one.

## Cause

`MinEditDistInText` is semi-global over the **text only**: row 0 is all zeros (free text-prefix skip) and the result is the minimum over the last row (free text-suffix skip). Slop in the **query** is charged in full. Two gates then reject the pair:

1. **The length gate** — `normalized.Length >= normalizedQuery.Length - maxErrors` skips the comparison outright when the query is longer, so no distance is ever computed.
2. **The error cap** — `GetMaxErrors` caps at 3, and appending a year is always exactly 5 edits. Even with the gate removed it could never pass, at *any* query length.

The parentheses are innocent: `NormalizeForIndex` already maps `(`, `)`, `[` and `]` to spaces, so `[2023]` and a bare `2023` fail identically. The cliff isn't year-specific either — `S1` and `(TV)` squeaked through at exactly `dist == maxErrors`, while anything four or more characters longer fell off.

Before `dc486893c` the Sørensen–Dice path tolerated all of these; it compared bigram sets, so five unmatched characters out of twenty-two barely moved the score.

## Fix

`SeriesSearch.TryGetFuzzyDistance` replaces the length gate and the direct distance call at both fuzzy call sites (`FuzzySearchIndex.SearchLatin`, `SeriesSearch.SearchCollection`):

- **title ≥ query** — unchanged, `MinEditDistInText(query, title)`.
- **query > title** — arguments swapped, moving the free prefix/suffix onto the query.
- **length guard** — the swapped path requires `title.Length * 2 >= query.Length`, so a two-letter title like `GK` can't match nearly every query. It applies **only** to the swapped direction, so a short typo'd query still matches a long title exactly as before (`belach` → `Gekijouban Bleach: Memories of Nobody`).

`GetMaxErrors` is untouched — the cap was never the right lever, since the cost of a year is constant regardless of query length.

## Behavioural note for reviewers

This removes the cliff for **all** trailing qualifiers, not just years — `(TV)`, `S1`, and similar slop now match on the same footing. That restores the pre-`dc486893c` Dice behaviour, but it is a slightly wider change than "years now work", so it's worth a second opinion on whether the `* 2` guard is the right threshold.

## Testing

- `Shoko.Tests` — 542/542 pass.
- Reverting only the two source files while keeping the new tests fails **13** of them, so the tests are not vacuous.
- `Debug` and `Release` both build clean, 0 warnings.

New coverage in `FuzzySearchIndexTests`: `TryGetFuzzyDistance` in both directions plus both guard rejections; end-to-end cases for `(2004)`, `[2024]`, a bare year, `(TV)`, and a typo stacked on a trailing year; and cases pinning the mirror direction, `ExactMatch` staying false for slop matches, strict (non-fuzzy) mode staying strict, and short titles not matching much longer queries.

---

Investigated, written and verified by Claude.
