### PR TITLE
fix: missing-episode stats going stale, hiding series from the Missing Episodes page

### DIFF
--- a/Shoko.Server/Repositories/Cached/AnimeEpisodeRepository.cs
+++ b/Shoko.Server/Repositories/Cached/AnimeEpisodeRepository.cs
@@ -217,7 +217,8 @@ GROUP BY
 
     // Group_CompletionStatus.Complete = 3, Group_CompletionStatus.Finished = 5
     // EpisodeType.Episode = 1
-    // AirDate is stored as Unix timestamp (seconds). LastEpisodeNumber >= EpisodeNumber approximates HasGroupReleasedEpisode.
+    // AirDate = 0 means unknown; kept as a candidate here and resolved exactly via HasAired in GetMissing().
+    // LastEpisodeNumber >= EpisodeNumber approximates HasGroupReleasedEpisode.
     // GS.GroupID (int) = SRI.GroupID (varchar) relies on implicit int↔string coercion present in SQLite, MySQL, and SQL Server.
     private const string MissingEpisodesQuery = @"
 SELECT AE.AnimeEpisodeID
@@ -225,8 +226,7 @@ FROM AnimeEpisode AE
 INNER JOIN AniDB_Episode ADBE ON AE.AniDB_EpisodeID = ADBE.EpisodeID
 WHERE AE.IsHidden = 0
   AND ADBE.EpisodeType = 1
-  AND ADBE.AirDate != 0
-  AND ADBE.AirDate < :currentTime
+  AND (ADBE.AirDate = 0 OR ADBE.AirDate < :currentTime)
   AND NOT EXISTS (SELECT 1 FROM CrossRef_File_Episode CFE WHERE CFE.EpisodeID = ADBE.EpisodeID)
   AND (
       NOT EXISTS (SELECT 1 FROM AniDB_GroupStatus GS WHERE GS.AnimeID = ADBE.AnimeID)
@@ -244,8 +244,7 @@ FROM AnimeEpisode AE
 INNER JOIN AniDB_Episode ADBE ON AE.AniDB_EpisodeID = ADBE.EpisodeID
 WHERE AE.IsHidden = 0
   AND ADBE.EpisodeType = 1
-  AND ADBE.AirDate != 0
-  AND ADBE.AirDate < :currentTime
+  AND (ADBE.AirDate = 0 OR ADBE.AirDate < :currentTime)
   AND ADBE.AnimeID = :animeID
   AND NOT EXISTS (SELECT 1 FROM CrossRef_File_Episode CFE WHERE CFE.EpisodeID = ADBE.EpisodeID)
   AND (
@@ -264,8 +263,7 @@ FROM AnimeEpisode AE
 INNER JOIN AniDB_Episode ADBE ON AE.AniDB_EpisodeID = ADBE.EpisodeID
 WHERE AE.IsHidden = 0
   AND ADBE.EpisodeType = 1
-  AND ADBE.AirDate != 0
-  AND ADBE.AirDate < :currentTime
+  AND (ADBE.AirDate = 0 OR ADBE.AirDate < :currentTime)
   AND NOT EXISTS (SELECT 1 FROM CrossRef_File_Episode CFE WHERE CFE.EpisodeID = ADBE.EpisodeID)
   AND EXISTS (
       SELECT 1 FROM AniDB_GroupStatus GS
@@ -290,8 +288,7 @@ FROM AnimeEpisode AE
 INNER JOIN AniDB_Episode ADBE ON AE.AniDB_EpisodeID = ADBE.EpisodeID
 WHERE AE.IsHidden = 0
   AND ADBE.EpisodeType = 1
-  AND ADBE.AirDate != 0
-  AND ADBE.AirDate < :currentTime
+  AND (ADBE.AirDate = 0 OR ADBE.AirDate < :currentTime)
   AND ADBE.AnimeID = :animeID
   AND NOT EXISTS (SELECT 1 FROM CrossRef_File_Episode CFE WHERE CFE.EpisodeID = ADBE.EpisodeID)
   AND EXISTS (
@@ -345,6 +342,7 @@ WHERE AE.IsHidden = 0
         return ids
             .Select(GetByID)
             .WhereNotNull()
+            .Where(e => e.AniDB_Episode is { HasAired: true })
             .OrderBy(e => e.AniDB_Episode?.AnimeID)
             .ThenBy(e => e.AniDB_Episode?.EpisodeType)
             .ThenBy(e => e.AniDB_Episode?.EpisodeNumber);

--- a/Shoko.Server/Services/VideoReleaseService.cs
+++ b/Shoko.Server/Services/VideoReleaseService.cs
@@ -29,6 +29,7 @@ using Shoko.Server.Providers.AniDB.Release;
 using Shoko.Server.Providers.AniDB.UDP.Info;
 using Shoko.Server.Repositories.Cached;
 using Shoko.Server.Repositories.Cached.AniDB;
+using Shoko.Server.Scheduling.Jobs.Actions;
 using Shoko.Server.Scheduling.Jobs.AniDB;
 using Shoko.Server.Scheduling.Jobs.Shoko;
 using Shoko.Server.Settings;
@@ -864,6 +865,10 @@ public class VideoReleaseService(
         {
             logger.LogError(ex, "Got an error scheduling metadata after release saved.");
         }
+
+        // Refresh missing-episode/watched stats for the affected anime now that a file is linked.
+        foreach (var animeId in legacyXrefs.Select(x => x.AnimeID).Distinct())
+            await schedulerFactory.RunAfterCurrent<RefreshAnimeStatsJob>(c => c.AnimeID = animeId);
 
         SetWatchedStateIfNeeded(video, releaseInfo);
 


### PR DESCRIPTION
## Summary

Reported symptom: the dashboard's "Missing Episodes (Total)" tile shows a count greater than zero, but clicking it opens the Missing Episodes page (`/webui/utilities/missing-episodes`) and it says **"No series with missing episodes!"** — completely empty, not just a lower count.

Root cause: `VideoReleaseService.SaveReleaseForVideo` never triggers a stats recalculation for the anime a file was just linked to. `AnimeSeries.MissingEpisodeCount` — the field the dashboard sums — only gets refreshed via AniDB MyList sync, group-status refresh, or a manual API call, never via the normal file-import pipeline. So as soon as a file is imported for a previously-missing episode, the cached count goes stale and stays wrong until something unrelated happens to touch that series. Meanwhile `MissingEpisodes/Series` recomputes live on every request, so it correctly shows nothing — hence the disconnect between the two.

Along the way I also found and fixed a related but separate issue: `GetMissing()`'s raw SQL required `AirDate != 0`, which silently drops episodes with an unknown air date even when the anime itself has already finished airing. `AniDB_Episode.HasAired` (used by the cached stat) correctly treats those as aired. This didn't cause the reported symptom, but it's the same category of bug (live query and cached stat disagreeing) and was straightforward to align while in this code.

## Changes

- `Shoko.Server/Services/VideoReleaseService.cs`: enqueue `RefreshAnimeStatsJob` for each affected anime after a release is saved — the same job `GetAniDBReleaseGroupStatusJob` already uses for this purpose.
- `Shoko.Server/Repositories/Cached/AnimeEpisodeRepository.cs`: loosen the `AirDate` filter in the missing-episodes SQL to a coarse pre-filter, and apply the exact `HasAired` check in C#, following this file's existing SQL-narrows/C#-filters pattern (see `GetWithMultipleReleases`/`GetWithDuplicateFiles` in the same file).

## Test plan

- [x] Reproduced on a local-dev build against a real library: dashboard showed `MissingEpisodes: 1` while `MissingEpisodes/Series` returned `Total: 0`.
- [x] Confirmed via direct DB query that the series in question had zero episodes actually matching "missing" criteria — the persisted count was simply stale.
- [x] Applied the fix, ran `/api/stats_update` once to clear existing stale data, confirmed dashboard and live query now agree (`0` / `0`).
- [x] `dotnet build Shoko.Server.sln` — clean, 0 warnings, 0 errors.