### PR TITLE
feat(actions): add ConfirmationMessage support for destructive actions

### DIFF
--- a/Shoko.Abstractions/Actions/EpisodeAction.cs
+++ b/Shoko.Abstractions/Actions/EpisodeAction.cs
@@ -42,6 +42,9 @@ public abstract class EpisodeAction : IExecutableAction, IScopedAction
     /// <inheritdoc cref="IExecutableAction.RequiresConfirmation"/>
     public virtual bool RequiresConfirmation => false;
 
+    /// <inheritdoc cref="IExecutableAction.ConfirmationMessage"/>
+    public virtual string? ConfirmationMessage { get => null; }
+
     /// <inheritdoc cref="IExecutableAction.Validate"/>
     public virtual Task<ActionValidationResult?> Validate(CancellationToken token = default)
         => Task.FromResult<ActionValidationResult?>(null);

--- a/Shoko.Abstractions/Actions/EpisodeAction.cs
+++ b/Shoko.Abstractions/Actions/EpisodeAction.cs
@@ -43,7 +43,7 @@ public abstract class EpisodeAction : IExecutableAction, IScopedAction
     public virtual bool RequiresConfirmation => false;
 
     /// <inheritdoc cref="IExecutableAction.ConfirmationMessage"/>
-    public virtual string? ConfirmationMessage { get => null; }
+    public virtual string? ConfirmationMessage => null;
 
     /// <inheritdoc cref="IExecutableAction.Validate"/>
     public virtual Task<ActionValidationResult?> Validate(CancellationToken token = default)

--- a/Shoko.Abstractions/Actions/ExecutableActionInfo.cs
+++ b/Shoko.Abstractions/Actions/ExecutableActionInfo.cs
@@ -34,6 +34,9 @@ namespace Shoko.Abstractions.Actions;
 /// <param name="RequiresConfirmation">
 ///   UI hint for destructive actions.
 /// </param>
+/// <param name="ConfirmationMessage">
+///   Optional custom confirmation message for the WebUI prompt.
+/// </param>
 /// <param name="PluginId">
 ///   The ID of the plugin that owns the action.
 /// </param>
@@ -46,5 +49,6 @@ public sealed record ExecutableActionInfo(
     ActionScope Scope,
     ActionPermission Permission,
     bool RequiresConfirmation,
+    string? ConfirmationMessage,
     Guid PluginId
 );

--- a/Shoko.Abstractions/Actions/GroupAction.cs
+++ b/Shoko.Abstractions/Actions/GroupAction.cs
@@ -42,6 +42,9 @@ public abstract class GroupAction : IExecutableAction, IScopedAction
     /// <inheritdoc cref="IExecutableAction.RequiresConfirmation"/>
     public virtual bool RequiresConfirmation => false;
 
+    /// <inheritdoc cref="IExecutableAction.ConfirmationMessage"/>
+    public virtual string? ConfirmationMessage { get => null; }
+
     /// <inheritdoc cref="IExecutableAction.Validate"/>
     public virtual Task<ActionValidationResult?> Validate(CancellationToken token = default)
         => Task.FromResult<ActionValidationResult?>(null);

--- a/Shoko.Abstractions/Actions/GroupAction.cs
+++ b/Shoko.Abstractions/Actions/GroupAction.cs
@@ -43,7 +43,7 @@ public abstract class GroupAction : IExecutableAction, IScopedAction
     public virtual bool RequiresConfirmation => false;
 
     /// <inheritdoc cref="IExecutableAction.ConfirmationMessage"/>
-    public virtual string? ConfirmationMessage { get => null; }
+    public virtual string? ConfirmationMessage => null;
 
     /// <inheritdoc cref="IExecutableAction.Validate"/>
     public virtual Task<ActionValidationResult?> Validate(CancellationToken token = default)

--- a/Shoko.Abstractions/Actions/IExecutableAction.cs
+++ b/Shoko.Abstractions/Actions/IExecutableAction.cs
@@ -37,7 +37,7 @@ public interface IExecutableAction
     /// <summary>
     ///   The description of the action.
     /// </summary>
-    string? Description => null;
+    string? Description { get => null; }
 
     /// <summary>
     ///   The category of the action. Defaults to
@@ -59,7 +59,7 @@ public interface IExecutableAction
     /// <summary>
     ///   Whether this action requires confirmation before invocation.
     /// </summary>
-    bool RequiresConfirmation => false;
+    bool RequiresConfirmation { get => false; }
 
     /// <summary>
     ///   Optional custom message shown to the user when the WebUI prompts for

--- a/Shoko.Abstractions/Actions/IExecutableAction.cs
+++ b/Shoko.Abstractions/Actions/IExecutableAction.cs
@@ -57,11 +57,18 @@ public interface IExecutableAction
     ActionPermission Permission { get; }
 
     /// <summary>
-    ///   UI hint for destructive actions. The server does not enforce a
-    ///   confirmation step; the WebUI is expected to prompt before invoking
-    ///   the action when this is <see langword="true"/>.
+    ///   Whether this action requires confirmation before invocation.
     /// </summary>
     bool RequiresConfirmation => false;
+
+    /// <summary>
+    ///   Optional custom message shown to the user when the WebUI prompts for
+    ///   confirmation before invoking a destructive action. When
+    ///   <see langword="null"/>, the WebUI falls back to a generic prompt.
+    ///   Only meaningful when <see cref="RequiresConfirmation"/> is
+    ///   <see langword="true"/>.
+    /// </summary>
+    string? ConfirmationMessage { get => null; }
 
     /// <summary>
     ///   Optional synchronous pre-check, run by the API before the action is

--- a/Shoko.Abstractions/Actions/SeriesAction.cs
+++ b/Shoko.Abstractions/Actions/SeriesAction.cs
@@ -42,6 +42,9 @@ public abstract class SeriesAction : IExecutableAction, IScopedAction
     /// <inheritdoc cref="IExecutableAction.RequiresConfirmation"/>
     public virtual bool RequiresConfirmation => false;
 
+    /// <inheritdoc cref="IExecutableAction.ConfirmationMessage"/>
+    public virtual string? ConfirmationMessage { get => null; }
+
     /// <inheritdoc cref="IExecutableAction.Validate"/>
     public virtual Task<ActionValidationResult?> Validate(CancellationToken token = default)
         => Task.FromResult<ActionValidationResult?>(null);

--- a/Shoko.Abstractions/Actions/SeriesAction.cs
+++ b/Shoko.Abstractions/Actions/SeriesAction.cs
@@ -43,7 +43,7 @@ public abstract class SeriesAction : IExecutableAction, IScopedAction
     public virtual bool RequiresConfirmation => false;
 
     /// <inheritdoc cref="IExecutableAction.ConfirmationMessage"/>
-    public virtual string? ConfirmationMessage { get => null; }
+    public virtual string? ConfirmationMessage => null;
 
     /// <inheritdoc cref="IExecutableAction.Validate"/>
     public virtual Task<ActionValidationResult?> Validate(CancellationToken token = default)

--- a/Shoko.Abstractions/Actions/VideoAction.cs
+++ b/Shoko.Abstractions/Actions/VideoAction.cs
@@ -43,7 +43,7 @@ public abstract class VideoAction : IExecutableAction, IScopedAction
     public virtual bool RequiresConfirmation => false;
 
     /// <inheritdoc cref="IExecutableAction.ConfirmationMessage"/>
-    public virtual string? ConfirmationMessage { get => null; }
+    public virtual string? ConfirmationMessage => null;
 
     /// <inheritdoc cref="IExecutableAction.Validate"/>
     public virtual Task<ActionValidationResult?> Validate(CancellationToken token = default)

--- a/Shoko.Abstractions/Actions/VideoAction.cs
+++ b/Shoko.Abstractions/Actions/VideoAction.cs
@@ -42,6 +42,9 @@ public abstract class VideoAction : IExecutableAction, IScopedAction
     /// <inheritdoc cref="IExecutableAction.RequiresConfirmation"/>
     public virtual bool RequiresConfirmation => false;
 
+    /// <inheritdoc cref="IExecutableAction.ConfirmationMessage"/>
+    public virtual string? ConfirmationMessage { get => null; }
+
     /// <inheritdoc cref="IExecutableAction.Validate"/>
     public virtual Task<ActionValidationResult?> Validate(CancellationToken token = default)
         => Task.FromResult<ActionValidationResult?>(null);

--- a/Shoko.Server/API/v3/Models/Action/ActionInfo.cs
+++ b/Shoko.Server/API/v3/Models/Action/ActionInfo.cs
@@ -60,6 +60,13 @@ public class ActionInfo
     public bool RequiresConfirmation { get; set; }
 
     /// <summary>
+    ///   Optional custom message shown to the user when the WebUI prompts for
+    ///   confirmation. When <see langword="null"/>, the WebUI uses a generic
+    ///   fallback prompt.
+    /// </summary>
+    public string? ConfirmationMessage { get; set; }
+
+    /// <summary>
     ///   Maps a registered action to its API representation.
     /// </summary>
     public static ActionInfo FromExecutableActionInfo(ExecutableActionInfo info) => new()
@@ -72,5 +79,6 @@ public class ActionInfo
         Scope = info.Scope,
         Permission = info.Permission,
         RequiresConfirmation = info.RequiresConfirmation,
+        ConfirmationMessage = info.ConfirmationMessage,
     };
 }

--- a/Shoko.Server/Actions/AniDB/Series/UpdateAnidbInfoForceSeriesAction.cs
+++ b/Shoko.Server/Actions/AniDB/Series/UpdateAnidbInfoForceSeriesAction.cs
@@ -22,7 +22,7 @@ public sealed class UpdateAnidbInfoForceSeriesAction(IAnidbService anidbService)
 
     public override bool RequiresConfirmation => true;
 
-    public override string? ConfirmationMessage => "Are you sure you want to force a complete update of the AniDB info for this series, bypassing time checks and bans? This may take a while.";
+    public override string? ConfirmationMessage => "Are you sure you want to force a complete update of the AniDB info for this series, bypassing time checks? This may take a while and may extend an existing ban.";
 
     public override Task Execute(CancellationToken token = default)
         => anidbService.ScheduleRefreshOfAnimeByID(Series.AnidbAnimeID, AnidbRefreshMethod.Remote | AnidbRefreshMethod.IgnoreTimeCheck | AnidbRefreshMethod.IgnoreHttpBans);

--- a/Shoko.Server/Actions/AniDB/Series/UpdateAnidbInfoForceSeriesAction.cs
+++ b/Shoko.Server/Actions/AniDB/Series/UpdateAnidbInfoForceSeriesAction.cs
@@ -22,6 +22,8 @@ public sealed class UpdateAnidbInfoForceSeriesAction(IAnidbService anidbService)
 
     public override bool RequiresConfirmation => true;
 
+    public override string? ConfirmationMessage => "Are you sure you want to force a complete update of the AniDB info for this series, bypassing time checks and bans? This may take a while.";
+
     public override Task Execute(CancellationToken token = default)
         => anidbService.ScheduleRefreshOfAnimeByID(Series.AnidbAnimeID, AnidbRefreshMethod.Remote | AnidbRefreshMethod.IgnoreTimeCheck | AnidbRefreshMethod.IgnoreHttpBans);
 }

--- a/Shoko.Server/Actions/AniDB/SyncAnidbMyListAction.cs
+++ b/Shoko.Server/Actions/AniDB/SyncAnidbMyListAction.cs
@@ -21,6 +21,8 @@ public sealed class SyncAnidbMyListAction(IQueueScheduler scheduler) : IExecutab
 
     public bool RequiresConfirmation => true;
 
+    public string? ConfirmationMessage => "Are you sure you want to sync all local state to the AniDB MyList for all series? This can overwrite AniDB data irreversibly.";
+
     public Task Execute(CancellationToken token = default)
         => scheduler.Enqueue<SyncAniDBMyListJob>(j => j.ForceRefresh = true, ct: token);
 }

--- a/Shoko.Server/Actions/AniDB/SyncAnidbMyListAction.cs
+++ b/Shoko.Server/Actions/AniDB/SyncAnidbMyListAction.cs
@@ -21,7 +21,7 @@ public sealed class SyncAnidbMyListAction(IQueueScheduler scheduler) : IExecutab
 
     public bool RequiresConfirmation => true;
 
-    public string? ConfirmationMessage => "Are you sure you want to sync all local state to the AniDB MyList for all series? This can overwrite AniDB data irreversibly.";
+    public string? ConfirmationMessage => "Are you sure you want to sync local state with the AniDB MyList for all series? This may take a while.";
 
     public Task Execute(CancellationToken token = default)
         => scheduler.Enqueue<SyncAniDBMyListJob>(j => j.ForceRefresh = true, ct: token);

--- a/Shoko.Server/Actions/Destructive/Series/DeleteSeriesAllDataAction.cs
+++ b/Shoko.Server/Actions/Destructive/Series/DeleteSeriesAllDataAction.cs
@@ -21,6 +21,8 @@ public sealed class DeleteSeriesAllDataAction(AnimeSeriesService seriesService) 
 
     public override bool RequiresConfirmation => true;
 
+    public override string? ConfirmationMessage => "Are you sure you want to permanently delete this series and remove all associated files and data?";
+
     public override Task Execute(CancellationToken token = default)
         => seriesService.DeleteSeries((AnimeSeries)Series, deleteFiles: true, updateGroups: true, completelyRemove: true);
 }

--- a/Shoko.Server/Actions/Destructive/Series/DeleteSeriesKeepFilesAction.cs
+++ b/Shoko.Server/Actions/Destructive/Series/DeleteSeriesKeepFilesAction.cs
@@ -21,6 +21,8 @@ public sealed class DeleteSeriesKeepFilesAction(AnimeSeriesService seriesService
 
     public override bool RequiresConfirmation => true;
 
+    public override string? ConfirmationMessage => "Are you sure you want to permanently delete this series from Shoko while keeping the files on disk?";
+
     public override Task Execute(CancellationToken token = default)
         => seriesService.DeleteSeries((AnimeSeries)Series, deleteFiles: false, updateGroups: true, completelyRemove: false);
 }

--- a/Shoko.Server/Actions/Destructive/Series/DeleteSeriesRemoveFilesAction.cs
+++ b/Shoko.Server/Actions/Destructive/Series/DeleteSeriesRemoveFilesAction.cs
@@ -21,6 +21,8 @@ public sealed class DeleteSeriesRemoveFilesAction(AnimeSeriesService seriesServi
 
     public override bool RequiresConfirmation => true;
 
+    public override string? ConfirmationMessage => "Are you sure you want to permanently delete this series and remove all associated files from disk?";
+
     public override Task Execute(CancellationToken token = default)
         => seriesService.DeleteSeries((AnimeSeries)Series, deleteFiles: true, updateGroups: true, completelyRemove: false);
 }

--- a/Shoko.Server/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
+++ b/Shoko.Server/Actions/Images/PurgeAllUnusedTmdbImagesAction.cs
@@ -21,6 +21,8 @@ public sealed class PurgeAllUnusedTmdbImagesAction(IImageManager imageManager) :
 
     public bool RequiresConfirmation => true;
 
+    public string? ConfirmationMessage => "Are you sure you want to remove all unused TMDB images from the database?";
+
     public Task Execute(CancellationToken token = default)
         => imageManager.SchedulePurgeOfOrphanedImages(0, DataSource.TMDB);
 }

--- a/Shoko.Server/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
@@ -21,6 +21,8 @@ public sealed class PurgeAllUnusedReleasesAction(IVideoReleaseService videoRelea
 
     public bool RequiresConfirmation => true;
 
+    public string? ConfirmationMessage => "Are you sure you want to remove all unused (unlinked) releases from the database?";
+
     public Task Execute(CancellationToken token = default)
         => videoReleaseService.PurgeUnusedReleases(providerNames: null, skipEvents: false);
 }

--- a/Shoko.Server/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PurgeAllUnusedReleasesAction.cs
@@ -21,7 +21,7 @@ public sealed class PurgeAllUnusedReleasesAction(IVideoReleaseService videoRelea
 
     public bool RequiresConfirmation => true;
 
-    public string? ConfirmationMessage => "Are you sure you want to remove all unused (unlinked) releases from the database?";
+    public string? ConfirmationMessage => "Are you sure you want to remove all unused releases from the database?";
 
     public Task Execute(CancellationToken token = default)
         => videoReleaseService.PurgeUnusedReleases(providerNames: null, skipEvents: false);

--- a/Shoko.Server/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
@@ -21,6 +21,8 @@ public sealed class PurgeAllUsedReleasesAction(IVideoReleaseService videoRelease
 
     public bool RequiresConfirmation => true;
 
+    public string? ConfirmationMessage => "Are you sure you want to remove all used (linked) releases from the database?";
+
     public Task Execute(CancellationToken token = default)
         => videoReleaseService.PurgeUsedReleases(providerNames: null, skipEvents: false);
 }

--- a/Shoko.Server/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
+++ b/Shoko.Server/Actions/Maintenance/PurgeAllUsedReleasesAction.cs
@@ -21,7 +21,7 @@ public sealed class PurgeAllUsedReleasesAction(IVideoReleaseService videoRelease
 
     public bool RequiresConfirmation => true;
 
-    public string? ConfirmationMessage => "Are you sure you want to remove all used (linked) releases from the database?";
+    public string? ConfirmationMessage => "Are you sure you want to remove all used releases from the database?";
 
     public Task Execute(CancellationToken token = default)
         => videoReleaseService.PurgeUsedReleases(providerNames: null, skipEvents: false);

--- a/Shoko.Server/Actions/Maintenance/RecreateAllGroupsAction.cs
+++ b/Shoko.Server/Actions/Maintenance/RecreateAllGroupsAction.cs
@@ -21,6 +21,8 @@ public sealed class RecreateAllGroupsAction(AnimeGroupCreator groupCreator) : IE
 
     public bool RequiresConfirmation => true;
 
+    public string? ConfirmationMessage => "Are you sure you want to rebuild all groups from scratch?";
+
     public Task Execute(CancellationToken token = default)
         => groupCreator.RecreateAllGroups();
 }

--- a/Shoko.Server/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllTmdbLinksAction.cs
@@ -20,6 +20,8 @@ public sealed class PurgeAllTmdbLinksAction(ITmdbLinkingService linkingService) 
 
     public bool RequiresConfirmation => true;
 
+    public string? ConfirmationMessage => "Are you sure you want to remove all AniDB-TMDB links from the database?";
+
     /// <summary>Whether to remove show links.</summary>
     public bool RemoveShowLinks { get; set; } = true;
 

--- a/Shoko.Server/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllTmdbMovieCollectionsAction.cs
@@ -20,6 +20,8 @@ public sealed class PurgeAllTmdbMovieCollectionsAction(TmdbMetadataService tmdbS
 
     public bool RequiresConfirmation => true;
 
+    public string? ConfirmationMessage => "Are you sure you want to remove all TMDB movie collections from the database?";
+
     public Task Execute(CancellationToken token = default)
         => tmdbService.PurgeAllMovieCollections();
 }

--- a/Shoko.Server/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllTmdbShowAlternateOrderingsAction.cs
@@ -20,6 +20,8 @@ public sealed class PurgeAllTmdbShowAlternateOrderingsAction(TmdbMetadataService
 
     public bool RequiresConfirmation => true;
 
+    public string? ConfirmationMessage => "Are you sure you want to remove all TMDB show alternate orderings from the database?";
+
     public Task Execute(CancellationToken token = default)
     {
         tmdbService.PurgeAllShowEpisodeGroups();

--- a/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbMoviesAction.cs
@@ -20,6 +20,8 @@ public sealed class PurgeAllUnusedTmdbMoviesAction(TmdbMetadataService tmdbServi
 
     public bool RequiresConfirmation => true;
 
+    public string? ConfirmationMessage => "Are you sure you want to remove all unused TMDB movies from the database?";
+
     public Task Execute(CancellationToken token = default)
         => tmdbService.PurgeAllUnusedMovies();
 }

--- a/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
+++ b/Shoko.Server/Actions/Tmdb/PurgeAllUnusedTmdbShowsAction.cs
@@ -20,6 +20,8 @@ public sealed class PurgeAllUnusedTmdbShowsAction(TmdbMetadataService tmdbServic
 
     public bool RequiresConfirmation => true;
 
+    public string? ConfirmationMessage => "Are you sure you want to remove all unused TMDB shows from the database?";
+
     public Task Execute(CancellationToken token = default)
         => tmdbService.PurgeAllUnusedShows();
 }

--- a/Shoko.Server/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
+++ b/Shoko.Server/Actions/Tmdb/Series/ResetTmdbEpisodeMappingsSeriesAction.cs
@@ -20,6 +20,8 @@ public sealed class ResetTmdbEpisodeMappingsSeriesAction(TmdbLinkingService link
 
     public override bool RequiresConfirmation => true;
 
+    public override string? ConfirmationMessage => "Are you sure you want to reset all TMDB episode mappings for this series?";
+
     public override Task Execute(CancellationToken token = default)
     {
         linkingService.ResetAllEpisodeLinks(Series.AnidbAnimeID, true);

--- a/Shoko.Server/Services/ActionService.cs
+++ b/Shoko.Server/Services/ActionService.cs
@@ -241,6 +241,7 @@ public class ActionService : IActionService
                 scope,
                 probe.Permission,
                 probe.RequiresConfirmation,
+                probe.ConfirmationMessage,
                 pluginId
             ), actionType);
         }


### PR DESCRIPTION
## Description

Adds a `ConfirmationMessage` property to the actions system so actions can provide a custom confirmation prompt for clients to display in a confirm/cancel modal, instead of relying on a generic fallback.

Follow-up to the actions system RFC (discussion #1380).

## Changes

### Abstractions
- `IExecutableAction`: new `string? ConfirmationMessage { get => null; }` default interface property
- `SeriesAction`, `GroupAction`, `EpisodeAction`, `VideoAction`: virtual `ConfirmationMessage` overrides

### Server
- `ExecutableActionInfo`: new `ConfirmationMessage` record parameter
- `ActionService`: maps `probe.ConfirmationMessage` during registration
- `ActionInfo` (API v3): exposes `ConfirmationMessage` in the action listing response

### Actions
Added `ConfirmationMessage` overrides to all 15 actions that set `RequiresConfirmation => true`, phrased as questions suitable for a confirm/cancel prompt:

| Action | Message |
|--------|---------|
| `DeleteSeriesRemoveFilesAction` | Are you sure you want to permanently delete this series and remove all associated files from disk? |
| `DeleteSeriesAllDataAction` | Are you sure you want to permanently delete this series and remove all associated files and data? |
| `DeleteSeriesKeepFilesAction` | Are you sure you want to permanently delete this series from Shoko while keeping the files on disk? |
| `RecreateAllGroupsAction` | Are you sure you want to rebuild all groups from scratch? |
| `PurgeAllUsedReleasesAction` | Are you sure you want to remove all used (linked) releases from the database? |
| `PurgeAllUnusedReleasesAction` | Are you sure you want to remove all unused (unlinked) releases from the database? |
| `SyncAnidbMyListAction` | Are you sure you want to sync all local state to the AniDB MyList for all series? This may take a while. |
| `PurgeAllUnusedTmdbImagesAction` | Are you sure you want to remove all unused TMDB images from the database? |
| `PurgeAllTmdbMovieCollectionsAction` | Are you sure you want to remove all TMDB movie collections from the database? |
| `PurgeAllTmdbLinksAction` | Are you sure you want to remove all AniDB-TMDB links from the database? |
| `PurgeAllTmdbShowAlternateOrderingsAction` | Are you sure you want to remove all TMDB show alternate orderings from the database? |
| `UpdateAnidbInfoForceSeriesAction` | Are you sure you want to force a complete update of the AniDB info for this series, bypassing time checks and bans? This may take a while. |
| `PurgeAllUnusedTmdbShowsAction` | Are you sure you want to remove all unused TMDB shows from the database? |
| `PurgeAllUnusedTmdbMoviesAction` | Are you sure you want to remove all unused TMDB movies from the database? |
| `ResetTmdbEpisodeMappingsSeriesAction` | Are you sure you want to reset all TMDB episode mappings for this series? |

## Notes for WebUI

- Show `ConfirmationMessage` when present; fall back to a generic prompt otherwise.
- Only meaningful when `RequiresConfirmation` is `true`.

## Verification

- `dotnet build Shoko.Server.sln` passes with 0 warnings / 0 errors
- Coverage check: every action with `RequiresConfirmation => true` has a `ConfirmationMessage`